### PR TITLE
Raszpl patch 2

### DIFF
--- a/js&css/satus.js
+++ b/js&css/satus.js
@@ -1110,6 +1110,16 @@ satus.components.modal = function(component, skeleton) {
   component.close = function() {
     var component = this;
 
+  component.close = function(outside) {
+    var component = this;
+    
+    //try calling cancel when clicked outside of modal dialog
+    if (outside) {
+        //not sure if bug free so better trap this for now
+        try { if (skeleton.actions.cancel.on.click) skeleton.actions.cancel.on.click(); }
+        catch(err){console.log(err);}
+    }
+
     this.classList.add('satus-modal--closing');
 
     setTimeout(function() {
@@ -1120,7 +1130,8 @@ satus.components.modal = function(component, skeleton) {
   };
 
   component.scrim.addEventListener('click', function() {
-    this.parentNode.close();
+    //this is someone clicking outside of modal dialog
+    this.parentNode.close(true);
   });
 
   if (satus.isset(skeleton.content)) {

--- a/js&css/satus.js
+++ b/js&css/satus.js
@@ -1107,9 +1107,6 @@ satus.components.modal = function(component, skeleton) {
   component.scrim = component.createChildElement('div', 'scrim');
   component.surface = component.createChildElement('div', 'surface');
 
-  component.close = function() {
-    var component = this;
-
   component.close = function(outside) {
     var component = this;
     

--- a/js&css/web-accessible/core.js
+++ b/js&css/web-accessible/core.js
@@ -69,22 +69,22 @@ var ImprovedTube = {
 /*--------------------------------------------------------------
 CODEC || 30FPS
 ----------------------------------------------------------------
-    Do not move, needs to be on top of first injected content
-    file to patch HTMLMediaElement before YT player uses it.
+	Do not move, needs to be on top of first injected content
+	file to patch HTMLMediaElement before YT player uses it.
 --------------------------------------------------------------*/
 if (localStorage['it-codec'] || localStorage['it-player30fps']) {
 	function overwrite(self, callback, mime) {
-        if (localStorage['it-codec']) {
-            var re = new RegExp(localStorage['it-codec']);
-            // /webm|vp8|vp9/av01/
-            if (re.test(mime)) return '';
-        }
-        if (localStorage['it-player30fps']) {
-            var match = /framerate=(\d+)/.exec(mime);
-            if (match && match[1] > 30) return '';
-        }
+		if (localStorage['it-codec']) {
+			var re = new RegExp(localStorage['it-codec']);
+			// /webm|vp8|vp9|av01/
+			if (re.test(mime)) return '';
+		}
+		if (localStorage['it-player30fps']) {
+			var match = /framerate=(\d+)/.exec(mime);
+			if (match && match[1] > 30) return '';
+		}
 		return callback.call(self, mime);
-	}
+	};
 
 	if (window.MediaSource) {
 		var isTypeSupported = window.MediaSource.isTypeSupported;
@@ -151,38 +151,38 @@ document.addEventListener('it-message-from-extension', function () {
 
 		if (message.action === 'storage-loaded') {
 			ImprovedTube.storage = message.storage;
-            
-            if (ImprovedTube.storage.player_h264) {
-             localStorage['it-codec'] = "/webm|vp8|vp9|av01/";
-            } else {
-                localStorage.removeItem('it-codec');
-            }
-            if (!ImprovedTube.storage.player_60fps) {
-             localStorage['it-player30fps'] = true;
-            } else {
-                localStorage.removeItem('it-player30fps');
-            }
+			
+			if (ImprovedTube.storage.player_h264) {
+			 localStorage['it-codec'] = "/webm|vp8|vp9|av01/";
+			} else {
+				localStorage.removeItem('it-codec');
+			}
+			if (!ImprovedTube.storage.player_60fps) {
+			 localStorage['it-player30fps'] = true;
+			} else {
+				localStorage.removeItem('it-player30fps');
+			}
 
-//    FEEDBACK WHEN THE USER CHANGED A SETTING
+//	  FEEDBACK WHEN THE USER CHANGED A SETTING
 			ImprovedTube.init();
 		} else if (message.action === 'storage-changed') {
 			var camelized_key = message.camelizedKey;
 
 			ImprovedTube.storage[message.key] = message.value;
-            if(message.key==="player_h264"){
-                if (ImprovedTube.storage.player_h264) {
-                localStorage['it-codec'] = "/webm|vp8|vp9|av01/";
-                } else {
-                    localStorage.removeItem('it-codec');
-                }
-            }
-            if(message.key==="player_60fps"){
-                if (!ImprovedTube.storage.player_60fps) {
-                localStorage['it-player30fps'] = true;
-                } else {
-                    localStorage.removeItem('it-player30fps');
-                }
-            }
+			if(message.key==="player_h264"){
+				if (ImprovedTube.storage.player_h264) {
+				localStorage['it-codec'] = "/webm|vp8|vp9|av01/";
+				} else {
+					localStorage.removeItem('it-codec');
+				}
+			}
+			if(message.key==="player_60fps"){
+				if (!ImprovedTube.storage.player_60fps) {
+				localStorage['it-player30fps'] = true;
+				} else {
+					localStorage.removeItem('it-player30fps');
+				}
+			}
 			if(ImprovedTube.storage[message.key]==="when_paused"){
 				ImprovedTube.whenPaused();
 			};
@@ -195,20 +195,20 @@ document.addEventListener('it-message-from-extension', function () {
 				ImprovedTube.setTheme();
 			} else if (camelized_key === 'description') {
 				if (ImprovedTube.storage.description === "expanded" || ImprovedTube.storage.description === "classic_expanded" )
-			    {try{document.querySelector("#more").click() || document.querySelector("#expand").click() ;} catch{} }
+				{try{document.querySelector("#more").click() || document.querySelector("#expand").click() ;} catch{} }
 				if (ImprovedTube.storage.description === "normal" || ImprovedTube.storage.description === "classic" )
 				{try{document.querySelector("#less").click() || document.querySelector("#collapse").click();} catch{}}
 				ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer();
 			}
- 			  else if (camelized_key === 'transcript') {
-   				  if (ImprovedTube.storage.transcript === true) {try{document.querySelector('*[target-id*=transcript]').removeAttribute('visibility');}catch{}
+			  else if (camelized_key === 'transcript') {
+				  if (ImprovedTube.storage.transcript === true) {try{document.querySelector('*[target-id*=transcript]').removeAttribute('visibility');}catch{}
 				} if (ImprovedTube.storage.transcript === false){try{document.querySelector('*[target-id*=transcript] #visibility-button button').click();}catch{}}
 			  }
 			  else if (camelized_key === 'chapters') {
 					 if (ImprovedTube.storage.chapters === true){try{document.querySelector('*[target-id*=chapters]').removeAttribute('visibility');}catch{}
 				} if (ImprovedTube.storage.chapters === false){try{document.querySelector('*[target-id*=chapters] #visibility-button button').click();}catch{}}
 			  }
-			    else if (camelized_key === 'commentsSidebar') {
+				else if (camelized_key === 'commentsSidebar') {
 				 if(ImprovedTube.storage.comments_sidebar === false)
 				 {document.querySelector("#below").appendChild(document.querySelector("#comments"));
 				  document.querySelector("#secondary").appendChild(document.querySelector("#related"));	}

--- a/js&css/web-accessible/core.js
+++ b/js&css/web-accessible/core.js
@@ -152,13 +152,15 @@ document.addEventListener('it-message-from-extension', function () {
 		if (message.action === 'storage-loaded') {
 			ImprovedTube.storage = message.storage;
 			
-			if (ImprovedTube.storage.player_h264) {
-			 localStorage['it-codec'] = "/webm|vp8|vp9|av01/";
+			if (ImprovedTube.storage.block_vp9 || ImprovedTube.storage.block_av1 || ImprovedTube.storage.block_h264) {
+				let atlas = {block_vp9:'vp9|vp09', block_h264:'avc1', block_av1:'av01'}
+				localStorage['it-codec'] = Object.keys(atlas).reduce(function (all, key) {
+					return ImprovedTube.storage[key] ? ((all?all+'|':'') + atlas[key]) : all}, '');
 			} else {
 				localStorage.removeItem('it-codec');
 			}
 			if (!ImprovedTube.storage.player_60fps) {
-			 localStorage['it-player30fps'] = true;
+				localStorage['it-player30fps'] = true;
 			} else {
 				localStorage.removeItem('it-player30fps');
 			}
@@ -169,10 +171,11 @@ document.addEventListener('it-message-from-extension', function () {
 			var camelized_key = message.camelizedKey;
 
 			ImprovedTube.storage[message.key] = message.value;
-			if(message.key==="player_h264"){
-				if (ImprovedTube.storage.player_h264) {
-				localStorage['it-codec'] = "/webm|vp8|vp9|av01/";
-				} else {
+			if(['block_vp9', 'block_h264', 'block_av1'].includes(message.key)){
+				let atlas = {block_vp9:'vp9|vp09', block_h264:'avc1', block_av1:'av01'}
+				localStorage['it-codec'] = Object.keys(atlas).reduce(function (all, key) {
+					return ImprovedTube.storage[key] ? ((all?all+'|':'') + atlas[key]) : all}, '');
+				if (!localStorage['it-codec']) {
 					localStorage.removeItem('it-codec');
 				}
 			}

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -376,6 +376,19 @@ ImprovedTube.playerAutofullscreen = function () {
 QUALITY
 ------------------------------------------------------------------------------*/
 ImprovedTube.playerQuality = function () {
+	function closest (num, arr) {
+                let curr = arr[0];
+                let diff = Math.abs (num - curr);
+                for (let val = 0; val < arr.length; val++) {
+                    let newdiff = Math.abs (num - arr[val]);
+                    if (newdiff < diff) {
+                        diff = newdiff;
+                        curr = arr[val];
+                    }
+                }
+                return curr;
+            };
+
 	var player = this.elements.player,
 		quality = this.storage.player_quality;
 
@@ -384,7 +397,14 @@ ImprovedTube.playerQuality = function () {
 
 		if (quality && quality !== 'auto') {
 			if (available_quality_levels.includes(quality) === false) {
-				quality = available_quality_levels[0];
+				let label = ['tiny', 'small', 'medium', 'large', 'hd720', 'hd1080', 'hd1440', 'hd2160', 'hd2880', 'highres'];
+				let resolution = ['144', '240', '360', '480', '720', '1080', '1440', '2160', '2880', '4320'];
+				let availableresolutions = available_quality_levels.reduce(function (array, elem) {
+					array.push(resolution[label.indexOf(elem)]); return array;
+					}, []);
+
+				quality = closest (resolution[label.indexOf(quality)], availableresolutions);
+				quality = label[resolution.indexOf(quality)];
 			}
 
 			player.setPlaybackQualityRange(quality);

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -889,7 +889,6 @@ extension.skeleton.main.layers.section.player.on.click = {
 					if (this.dataset.value === 'true') {
 						var component = this;
 						ModalHelper(this, function(){
-							satus.storage.set('block_vp8', true);
 							satus.storage.set('block_vp9', true);
 							satus.storage.set('block_av1', true);
 							this.parentNode.parentNode.parentNode.close();
@@ -919,17 +918,6 @@ extension.skeleton.main.layers.section.player.on.click = {
 							on: {
 								click: function () {
 									if (this.dataset.value === 'true' && satus.storage.get('player_h264')) {
-										satus.storage.set('player_h264', false);
-									}
-								}
-							}
-						},
-						block_vp8: {
-							component: 'switch',
-							text: 'blockVp8',
-							on: {
-								click: function () {
-									if (this.dataset.value === 'false' && satus.storage.get('player_h264')) {
 										satus.storage.set('player_h264', false);
 									}
 								}

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -41,13 +41,13 @@ extension.skeleton.main.layers.section.player = {
 # ModalHelper
 --------------------------------------------------------------*/
 
-function ModalHelper(where, ok, cancel) {
+function ModalHelper(where, what, ok, cancel) {
 	satus.render({
 		component: 'modal',
 
 		message: {
 			component: 'text',
-			text: 'youtubeLimitsVideoQualityTo1080pForH264Codec'
+			text: what
 		},
 		actions: {
 			component: 'section',
@@ -57,14 +57,23 @@ function ModalHelper(where, ok, cancel) {
 				component: 'button',
 				text: 'OK',
 				on: {
-					click: ok
+					click: function () {
+						ok();
+						this.parentNode.parentNode.parentNode.close();
+						}
 				}
 			},
 			cancel: {
 				component: 'button',
 				text: 'cancel',
 				on: {
-					click: cancel
+					click:  function () {
+						where.click();
+						cancel();
+						if (this.componentName) {
+							this.parentNode.parentNode.parentNode.close();
+							}
+						}
 				}
 			}
 		}
@@ -887,18 +896,12 @@ extension.skeleton.main.layers.section.player.on.click = {
 			on: {
 				click: function () {
 					if (this.dataset.value === 'true') {
-						var component = this;
-						ModalHelper(this, function(){
+						ModalHelper(this, 'youtubeLimitsVideoQualityTo1080pForH264Codec', function(){
 							satus.storage.set('block_vp9', true);
 							satus.storage.set('block_av1', true);
-							this.parentNode.parentNode.parentNode.close();
 							satus.storage.set('block_h264', false);
 						},
 						function(){
-							component.click();
-							if (this.componentName) {
-								this.parentNode.parentNode.parentNode.close();
-							}
 						});
 					}
 				}
@@ -920,6 +923,12 @@ extension.skeleton.main.layers.section.player.on.click = {
 									if (this.dataset.value === 'true' && satus.storage.get('player_h264')) {
 										satus.storage.set('player_h264', false);
 									}
+									if (this.dataset.value === 'true' && satus.storage.get('block_vp9')) {
+										ModalHelper(this, 'You need either VP9 or H264 enabled for Youtube to work. Disabling both will break Video.', function(){
+										},
+										function(){
+										});
+									}
 								}
 							}
 						},
@@ -930,6 +939,12 @@ extension.skeleton.main.layers.section.player.on.click = {
 								click: function () {
 									if (this.dataset.value === 'false' && satus.storage.get('player_h264')) {
 										satus.storage.set('player_h264', false);
+									}
+									if (this.dataset.value === 'true' && satus.storage.get('block_h264')) {
+										ModalHelper(this, 'You need either VP9 or H264 enabled for Youtube to work. Disabling both will break Video.', function(){
+										},
+										function(){
+										});
 									}
 								}
 							}

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -57,42 +57,48 @@ extension.skeleton.main.layers.section.player.on.click = {
 			component: 'switch',
 			text: 'autopauseWhenSwitchingTabs',
 			storage: 'player_autopause_when_switching_tabs',
-				 on: {	 click: function () { setTimeout(() => {
-
-							if (satus.storage.get('player_autopause_when_switching_tabs')) {
-								if (satus.storage.get('only_one_player_instance_playing')) {
-									this.nextSibling.click();
-								}
+			on: {
+				click: function () {
+					setTimeout(() => {
+						if (satus.storage.get('player_autopause_when_switching_tabs')) {
+							if (satus.storage.get('only_one_player_instance_playing')) {
+								this.nextSibling.click();
 							}
-						  }, "250");  }
-					}
+						}
+					}, "250");
+				}
+			}
 		},
 		only_one_player_instance_playing: {
 			component: 'switch',
 			text: 'onlyOnePlayerInstancePlaying',
-			 on: {
-						click: function () { setTimeout(() => {
-							if (satus.storage.get('only_one_player_instance_playing')) {
-								if (satus.storage.get('player_autopause_when_switching_tabs')) {
-									this.previousSibling.click();
-								}
+			on: {
+				click: function () {
+					setTimeout(() => {
+						if (satus.storage.get('only_one_player_instance_playing')) {
+							if (satus.storage.get('player_autopause_when_switching_tabs')) {
+								this.previousSibling.click();
 							}
-						}, "250");	}
-					}
+						}
+					}, "250");
+				}
+			}
 		},
 		player_autoPip: {
 			component: 'switch',
 			text: 'autoPip',
 			value: false,
-			 on: {
-						click: function () { setTimeout(() => {
-							if (satus.storage.get('player_autoPip')) {
-								if (satus.storage.get('player_autopause_when_switching_tabs')) {
-									this.previousSibling.click();
-								}
+			on: {
+				click: function () {
+					setTimeout(() => {
+						if (satus.storage.get('player_autoPip')) {
+							if (satus.storage.get('player_autopause_when_switching_tabs')) {
+								this.previousSibling.click();
 							}
-						}, "250");	}
-					}
+						}
+					}, "250");
+				}
+			}
 		},
 		quality: {
 			component: 'select',

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -53,47 +53,47 @@ extension.skeleton.main.layers.section.player.on.click = {
 			value: true,
 			storage: 'player_autoplay'
 		},
-				autopause_when_switching_tabs: {
+		autopause_when_switching_tabs: {
 			component: 'switch',
 			text: 'autopauseWhenSwitchingTabs',
 			storage: 'player_autopause_when_switching_tabs',
-				 on: {	 click: function () { setTimeout(() => { 
- 
+				 on: {	 click: function () { setTimeout(() => {
+
 							if (satus.storage.get('player_autopause_when_switching_tabs')) {
 								if (satus.storage.get('only_one_player_instance_playing')) {
 									this.nextSibling.click();
 								}
 							}
 						  }, "250");  }
-					}	
+					}
 		},
-				only_one_player_instance_playing: {
+		only_one_player_instance_playing: {
 			component: 'switch',
 			text: 'onlyOnePlayerInstancePlaying',
 			 on: {
-						click: function () { setTimeout(() => { 
+						click: function () { setTimeout(() => {
 							if (satus.storage.get('only_one_player_instance_playing')) {
 								if (satus.storage.get('player_autopause_when_switching_tabs')) {
 									this.previousSibling.click();
 								}
 							}
-						}, "250");  }
-					}			
+						}, "250");	}
+					}
 		},
-				player_autoPip: {
+		player_autoPip: {
 			component: 'switch',
 			text: 'autoPip',
 			value: false,
 			 on: {
-						click: function () { setTimeout(() => { 
+						click: function () { setTimeout(() => {
 							if (satus.storage.get('player_autoPip')) {
 								if (satus.storage.get('player_autopause_when_switching_tabs')) {
 									this.previousSibling.click();
 								}
 							}
-						}, "250");  }
-					}		
-		},		
+						}, "250");	}
+					}
+		},
 		quality: {
 			component: 'select',
 			text: 'quality',
@@ -177,7 +177,7 @@ extension.skeleton.main.layers.section.player.on.click = {
 			component: 'switch',
 			text: 'autoFullscreen',
 			storage: 'player_autofullscreen'
-		},		
+		},
 		subtitles: {
 			component: 'button',
 			text: 'subtitles',
@@ -938,7 +938,7 @@ extension.skeleton.main.layers.section.player.on.click = {
 					value: 'av1-vp8-vp9'
 				}
 			]
-		
+
 		},
 		player_60fps: {
 			component: 'switch',

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -37,6 +37,39 @@ extension.skeleton.main.layers.section.player = {
 	}
 };
 
+/*--------------------------------------------------------------
+# ModalHelper
+--------------------------------------------------------------*/
+
+function ModalHelper(where, ok, cancel) {
+	satus.render({
+		component: 'modal',
+
+		message: {
+			component: 'text',
+			text: 'youtubeLimitsVideoQualityTo1080pForH264Codec'
+		},
+		actions: {
+			component: 'section',
+			variant: 'actions',
+
+			ok: {
+				component: 'button',
+				text: 'OK',
+				on: {
+					click: ok
+				}
+			},
+			cancel: {
+				component: 'button',
+				text: 'cancel',
+				on: {
+					click: cancel
+				}
+			}
+		}
+	}, where.parentNode.parentNode.parentNode);
+};
 
 /*--------------------------------------------------------------
 # SECTION
@@ -855,38 +888,19 @@ extension.skeleton.main.layers.section.player.on.click = {
 				click: function () {
 					if (this.dataset.value === 'true') {
 						var component = this;
-						satus.render({
-							component: 'modal',
-
-							message: {
-								component: 'text',
-								text: 'youtubeLimitsVideoQualityTo1080pForH264Codec'
-							},
-							actions: {
-								component: 'section',
-								variant: 'actions',
-
-								cancel: {
-									component: 'button',
-									text: 'cancel',
-									on: {
-										click: function () {
-											component.click();
-											this.parentNode.parentNode.parentNode.close()
-										}
-									}
-								},
-								ok: {
-									component: 'button',
-									text: 'OK',
-									on: {
-										click: function () {
-											this.parentNode.parentNode.parentNode.close()
-										}
-									}
-								}
+						ModalHelper(this, function(){
+							satus.storage.set('block_vp8', true);
+							satus.storage.set('block_vp9', true);
+							satus.storage.set('block_av1', true);
+							this.parentNode.parentNode.parentNode.close();
+							satus.storage.set('block_h264', false);
+						},
+						function(){
+							component.click();
+							if (this.componentName) {
+								this.parentNode.parentNode.parentNode.close();
 							}
-						},this.parentNode.parentNode.parentNode);
+						});
 					}
 				}
 			}
@@ -899,22 +913,49 @@ extension.skeleton.main.layers.section.player.on.click = {
 					section: {
 						component: 'section',
 						variant: 'card',
-
 						block_h264: {
 							component: 'switch',
-							text: 'blockH264'
+							text: 'blockH264',
+							on: {
+								click: function () {
+									if (this.dataset.value === 'true' && satus.storage.get('player_h264')) {
+										satus.storage.set('player_h264', false);
+									}
+								}
+							}
 						},
 						block_vp8: {
 							component: 'switch',
-							text: 'blockVp8'
+							text: 'blockVp8',
+							on: {
+								click: function () {
+									if (this.dataset.value === 'false' && satus.storage.get('player_h264')) {
+										satus.storage.set('player_h264', false);
+									}
+								}
+							}
 						},
 						block_vp9: {
 							component: 'switch',
-							text: 'blockVp9'
+							text: 'blockVp9',
+							on: {
+								click: function () {
+									if (this.dataset.value === 'false' && satus.storage.get('player_h264')) {
+										satus.storage.set('player_h264', false);
+									}
+								}
+							}
 						},
 						block_av1: {
 							component: 'switch',
-							text: 'blockAv1'
+							text: 'blockAv1',
+							on: {
+								click: function () {
+									if (this.dataset.value === 'false' && satus.storage.get('player_h264')) {
+										satus.storage.set('player_h264', false);
+									}
+								}
+							}
 						}
 					}
 				}

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -38,7 +38,8 @@ extension.skeleton.main.layers.section.player = {
 };
 
 /*--------------------------------------------------------------
-# ModalHelper
+# ModalHelper, like satus.components.modal.confirm but lets you
+  pass callback functions
 --------------------------------------------------------------*/
 
 function ModalHelper(where, what, ok, cancel) {
@@ -895,14 +896,30 @@ extension.skeleton.main.layers.section.player.on.click = {
 			storage: 'player_h264',
 			on: {
 				click: function () {
+					//always refresh player_codecs element when clicking here
+					let skeleton = this.parentNode.skeleton;
+					refresh = function () {
+						skeleton.player_codecs.list.rendered.dispatchEvent(new CustomEvent('refresh'));
+						skeleton.optimize_codec_for_hardware_acceleration.list.rendered.dispatchEvent(new CustomEvent('refresh'));
+					}
 					if (this.dataset.value === 'true') {
 						ModalHelper(this, 'youtubeLimitsVideoQualityTo1080pForH264Codec', function(){
 							satus.storage.set('block_vp9', true);
 							satus.storage.set('block_av1', true);
 							satus.storage.set('block_h264', false);
+							refresh();
 						},
 						function(){
+							satus.storage.set('block_vp9', false);
+							satus.storage.set('block_av1', false);
+							satus.storage.set('block_h264', false);
+							refresh();
 						});
+					} else {
+						satus.storage.set('block_vp9', false);
+						satus.storage.set('block_av1', false);
+						satus.storage.set('block_h264', false);
+						refresh();
 					}
 				}
 			}
@@ -910,6 +927,9 @@ extension.skeleton.main.layers.section.player.on.click = {
 		player_codecs: {
 			component: 'button',
 			text: 'codecs',
+			style: {
+				justifyContent: 'space-between'
+			},
 			on: {
 				click: {
 					section: {
@@ -962,33 +982,68 @@ extension.skeleton.main.layers.section.player.on.click = {
 						}
 					}
 				}
+			},
+			list: {
+				component: 'span',
+				style: {
+					opacity: .64
+				},
+				on: {
+					refresh: function () { this.skeleton.on.render() },
+					render: function () {
+						var codecs = (satus.storage.get('block_h264') ? '' : 'h.264 ') + (satus.storage.get('block_vp9') ? '' : 'vp9 ') + (satus.storage.get('block_av1') ? '' : 'av1');
+						var here = this.parentObject ? this.parentObject.rendered : this;
+
+						if (codecs) {
+							here.style = '';
+							here.textContent = codecs;
+						} else {
+							here.style = 'color: red!important; font-weight: bold;';
+							here.textContent = 'none';
+						}
+					}
+				}
 			}
 		},
-		avoid_cpu_rendering_when_possible: {
-			component: 'select',
-			text: 'avoidCpuRenderingWhenPossible',
-			options: [{
-					text: 'disabled',
-					value: 'disabled'
-				},
-				{
-					text: 'auto',
-					value: 'auto'
-				},
-				{
-					text: 'avoidAv1',
-					value: 'av1'
-				},
-				{
-					text: 'avoidAv1Vp9',
-					value: 'av1-vp9'
-				},
-				{
-					text: 'avoidAv1Vp8Vp9',
-					value: 'av1-vp8-vp9'
+		optimize_codec_for_hardware_acceleration: {
+			component: 'button',
+			text: 'Optimize Codec for hardware acceleration',
+			style: {
+				justifyContent: 'space-between'
+			},
+			on: {
+				click: function () {
+					//put some code here
 				}
-			]
+			},
+			list: {
+				component: 'span',
+				style: {
+					opacity: .64
+				},
+				on: {
+					refresh: function () { this.skeleton.on.render() },
+					render: function () {
+						// put some code here looking up GPU  capabilities and comparing to currrent codec selection
+						var codecs = (satus.storage.get('block_h264') ? '' : 'h.264 ') + (satus.storage.get('block_vp9') ? '' : 'vp9 ') + (satus.storage.get('block_av1') ? '' : 'av1');
+						var here = this.parentObject ? this.parentObject.rendered : this;
 
+						if (1) { // todo
+							here.style = '';
+							here.textContent = 'Feature not yet available';
+						} else if (2) { // todo
+							here.style = '';
+							here.textContent = 'unknown GPU';
+						} else if (codecs) {
+							here.style = 'color: greenimportant; font-weight: bold;';
+							here.textContent = 'Optimal';
+						} else {
+							here.style = 'color: red!important; font-weight: bold;';
+							here.textContent = 'Not optimal';
+						}
+					}
+				}
+			}
 		},
 		player_60fps: {
 			component: 'switch',

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -53,6 +53,11 @@ extension.skeleton.main.layers.section.player.on.click = {
 			value: true,
 			storage: 'player_autoplay'
 		},
+		up_next_autoplay: {
+			component: 'switch',
+			text: 'upNextAutoplay',
+			value: true
+		},
 		autopause_when_switching_tabs: {
 			component: 'switch',
 			text: 'autopauseWhenSwitchingTabs',
@@ -99,45 +104,6 @@ extension.skeleton.main.layers.section.player.on.click = {
 					}, "250");
 				}
 			}
-		},
-		quality: {
-			component: 'select',
-			text: 'quality',
-			options: [{
-				text: 'auto',
-				value: 'auto'
-			}, {
-				text: '144p',
-				value: 'tiny'
-			}, {
-				text: '240p',
-				value: 'small'
-			}, {
-				text: '360p',
-				value: 'medium'
-			}, {
-				text: '480p',
-				value: 'large'
-			}, {
-				text: '720p',
-				value: 'hd720'
-			}, {
-				text: '1080p',
-				value: 'hd1080'
-			}, {
-				text: '1440p',
-				value: 'hd1440'
-			}, {
-				text: '2160p',
-				value: 'hd2160'
-			}, {
-				text: '2880p',
-				value: 'hd2880'
-			}, {
-				text: '4320p',
-				value: 'highres'
-			}],
-			storage: 'player_quality'
 		},
 		player_forced_volume: {
 			component: 'switch',
@@ -838,14 +804,48 @@ extension.skeleton.main.layers.section.player.on.click = {
 			value: true,
 			storage: 'player_crop_chapter_titles'
 		},
-		up_next_autoplay: {
-			component: 'switch',
-			text: 'upNextAutoplay',
-			value: true
-		},
 		mini_player: {
 			component: 'switch',
 			text: 'customMiniPlayer'
+		},
+		quality: {
+			component: 'select',
+			text: 'quality',
+			options: [{
+				text: 'auto',
+				value: 'auto'
+			}, {
+				text: '144p',
+				value: 'tiny'
+			}, {
+				text: '240p',
+				value: 'small'
+			}, {
+				text: '360p',
+				value: 'medium'
+			}, {
+				text: '480p',
+				value: 'large'
+			}, {
+				text: '720p',
+				value: 'hd720'
+			}, {
+				text: '1080p',
+				value: 'hd1080'
+			}, {
+				text: '1440p',
+				value: 'hd1440'
+			}, {
+				text: '2160p',
+				value: 'hd2160'
+			}, {
+				text: '2880p',
+				value: 'hd2880'
+			}, {
+				text: '4320p',
+				value: 'highres'
+			}],
+			storage: 'player_quality'
 		},
 		h264: {
 			component: 'switch',


### PR DESCRIPTION
'up next autoplay' moved next to autoplay, quality moved next to codec options
added helper modal function, "Codec h.264" sets "Codecs", "Codecs" disable "Codec h.264"
Improved modal dialog handling, clicking outside tries to Cancel, previously clicking outside just force removed dialog.
removing "block_vp8", YT doesnt use it anymore. "Codecs" works now, can pick individual codecs to block.
more work on ModalHelper, popup warnings for disabling all video decoders.
more h264/codec interaction work, now switching one automatically updates another. Preliminary optimize_codec_for_hardware_acceleration implementation. Needs a list of GPUs with supported hardware codecs.