### PR TITLE
Raszpl patch 1

### DIFF
--- a/js&css/satus.js
+++ b/js&css/satus.js
@@ -57,8 +57,10 @@ locale.import = function(code, callback, path)
 	//satus.locale.import(url, onload, onsuccess);
 
 text(element, value)
-	// We always try to run values as functions?
-	// isFunction(value)	appears 6 times in satus.js
+
+// We always try to run values as functions to allow for dynamic content
+// for example menu/skeleton-parts/analyzer.js datasets: is being generated
+// from stored staticstics on the spot.
 ----------------------------------------------------------------
 
 >>> 2. COMPONENTS
@@ -1103,15 +1105,8 @@ satus.components.modal = function(component, skeleton) {
 	component.scrim = component.createChildElement('div', 'scrim');
 	component.surface = component.createChildElement('div', 'surface');
 
-	component.close = function(outside) {
+	component.close = function() {
 		var component = this;
-
-		//try calling cancel when clicked outside of modal dialog
-		if (outside) {
-			//not sure if bug free so better trap this for now
-			try { if (skeleton.actions.cancel.on.click) skeleton.actions.cancel.on.click(); }
-			catch(err){console.log(err);}
-		}
 
 		this.classList.add('satus-modal--closing');
 
@@ -1123,8 +1118,11 @@ satus.components.modal = function(component, skeleton) {
 	};
 
 	component.scrim.addEventListener('click', function() {
-		//this is someone clicking outside of modal dialog
-		this.parentNode.close(true);
+		// this is someone clicking outside of modal dialog, try cancel() first if default modal.confirm
+		if (skeleton.cancel && satus.isFunction(skeleton.cancel)) {
+			skeleton.cancel();
+		}
+		this.parentNode.close();
 	});
 
 	if (satus.isset(skeleton.content)) {

--- a/js&css/satus.js
+++ b/js&css/satus.js
@@ -2332,7 +2332,7 @@ satus.components.shortcut = function(component, skeleton) {
 
 							component.render(component.valueElement);
 
-							satus.storage.remove(component.storage);
+							satus.storage.remove(component.storage.key);
 
 							this.parentNode.parentNode.parentNode.close();
 
@@ -2346,7 +2346,7 @@ satus.components.shortcut = function(component, skeleton) {
 					text: 'cancel',
 					on: {
 						click: function() {
-							component.data = satus.storage.get(component.storage) || component.skeleton.value || {};
+							component.data = satus.storage.get(component.storage.key) || component.skeleton.value || {};
 
 							component.render(component.valueElement);
 

--- a/menu/skeleton-parts/analyzer.js
+++ b/menu/skeleton-parts/analyzer.js
@@ -5,6 +5,7 @@
 extension.skeleton.main.layers.section.analyzer = {
 	component: 'button',
 	variant: 'analyzer',
+	category: true,
 	on: {
 		click: {
 			analyzer_activation: {

--- a/menu/styles/analyzer.css
+++ b/menu/styles/analyzer.css
@@ -4,13 +4,9 @@
 
 .analyzer-watch-time {
 	font-size: 13px;
-
 	display: flex;
-
 	margin: 16px 6px 0;
-
 	opacity: .72;
-
 	justify-content: space-between;
 }
 
@@ -19,12 +15,9 @@
 }
 
 .satus-switch--activation {
-	margin: 12px;
 	padding: 12px;
-
 	border-radius: 3px;
 	background: rgba(var(--satus-light), .08);
-
 	--satus-switch-track: rgba(var(--satus-light), .1);
 }
 


### PR DESCRIPTION
Better handling for clicking outside modal.confirm, try cancel() first.
Explanation comment for reason behind "values as functions isFunction(value)"
https://github.com/code-charity/SATUS/issues/7 passing key instead of object