### PR TITLE
Correct full-screen text in all languages

### DIFF
--- a/_locales/am/messages.json
+++ b/_locales/am/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "ሙሉ ማያ"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -401,6 +401,9 @@
     "foundABug": {
         "message": "وجدت خطأ؟"
     },
+    "fullScreen": {
+        "message": "ملء الشاشة"
+    },
     "fullWindow": {
         "message": "نافذة كاملة"
     },

--- a/_locales/bg/messages.json
+++ b/_locales/bg/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "Цял екран"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/bn/messages.json
+++ b/_locales/bn/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "একটি বাগ খুঁজে পেয়েছি?"
     },
+    "fullScreen": {
+        "message": "পূর্ণ স্ক্রীণ"
+    },
     "fullWindow": {
         "message": "পুরো উইন্ডো"
     },

--- a/_locales/ca/messages.json
+++ b/_locales/ca/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "Pantalla completa"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/cs/messages.json
+++ b/_locales/cs/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "Celá obrazovka"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/da/messages.json
+++ b/_locales/da/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "Fuld skærm"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Fehler gefunden?"
     },
+    "fullScreen": {
+        "message": "Vollbild"
+    },
     "fullWindow": {
         "message": "Ganzes Fenster"
     },

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Εντοπίσατε κάποιο σφάλμα;"
     },
+    "fullScreen": {
+        "message": "Πλήρης οθόνη"
+    },
     "fullWindow": {
         "message": "Πλήρες παράθυρο"
     },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -413,6 +413,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "Full screen"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/en_GB/messages.json
+++ b/_locales/en_GB/messages.json
@@ -395,6 +395,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "Full screen"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/en_US/messages.json
+++ b/_locales/en_US/messages.json
@@ -395,6 +395,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "Full screen"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "¿Encontraste un error (bug)?"
     },
+    "fullScreen": {
+        "message": "Pantalla completa"
+    },
     "fullWindow": {
         "message": "Pantalla completa"
     },

--- a/_locales/es_419/messages.json
+++ b/_locales/es_419/messages.json
@@ -395,6 +395,9 @@
     "foundABug": {
         "message": "¿Encontraste un error (bug)?"
     },
+    "fullScreen": {
+        "message": "Pantalla completa"
+    },
     "fullWindow": {
         "message": "Pantalla completa"
     },

--- a/_locales/et/messages.json
+++ b/_locales/et/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "Täisekraan"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/fa/messages.json
+++ b/_locales/fa/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "تمام صفحه"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/fi/messages.json
+++ b/_locales/fi/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "Koko näyttö"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/fil/messages.json
+++ b/_locales/fil/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "Full screen"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Un bogue?"
     },
+    "fullScreen": {
+        "message": "Plein écran"
+    },
     "fullWindow": {
         "message": "Fenêtre pleine"
     },

--- a/_locales/gu/messages.json
+++ b/_locales/gu/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "પૂર્ણ સ્ક્રીન"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/he/messages.json
+++ b/_locales/he/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "מסך מלא"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -395,6 +395,9 @@
     "foundABug": {
         "message": "बग मिला?"
     },
+    "fullScreen": {
+        "message": "फ़ुल स्क्रीन"
+    },
     "fullWindow": {
         "message": "पूर्ण स्क्रीन"
     },

--- a/_locales/hr/messages.json
+++ b/_locales/hr/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Pronašli ste grešku?"
     },
+    "fullScreen": {
+        "message": "Cijeli zaslon"
+    },
     "fullWindow": {
         "message": "Puni prozor"
     },

--- a/_locales/hu/messages.json
+++ b/_locales/hu/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "Teljes képernyő"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Menemukan masalah?"
     },
+    "fullScreen": {
+        "message": "Layar penuh"
+    },
     "fullWindow": {
         "message": "Layar penuh"
     },

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Trovato un bug?"
     },
+    "fullScreen": {
+        "message": "Schermo intero"
+    },
     "fullWindow": {
         "message": "Finestra intera"
     },

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "バグ報告"
     },
+    "fullScreen": {
+        "message": "全画面"
+    },
     "fullWindow": {
         "message": "フルウィンドウ"
     },

--- a/_locales/kn/messages.json
+++ b/_locales/kn/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "ಪೂರ್ಣ ಪರದೆ"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "버그 신고"
     },
+    "fullScreen": {
+        "message": "전체 화면"
+    },
     "fullWindow": {
         "message": "전체 화면"
     },

--- a/_locales/lt/messages.json
+++ b/_locales/lt/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "Visas ekranas"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/lv/messages.json
+++ b/_locales/lv/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "Pilnekrāna režīms"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/ml/messages.json
+++ b/_locales/ml/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "പൂര്‍ണ്ണ സ്ക്രീന്‍"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/mr/messages.json
+++ b/_locales/mr/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "फुल स्क्रीन"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/ms/messages.json
+++ b/_locales/ms/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "Skrin penuh"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/nb_NO/messages.json
+++ b/_locales/nb_NO/messages.json
@@ -395,6 +395,9 @@
     "foundABug": {
         "message": "Fant du en feil?"
     },
+    "fullScreen": {
+        "message": "Fullskjerm"
+    },
     "fullWindow": {
         "message": "Fullt vindu"
     },

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Heb je een bug gevonden?"
     },
+    "fullScreen": {
+        "message": "Volledig scherm"
+    },
     "fullWindow": {
         "message": "Volledig scherm"
     },

--- a/_locales/no/messages.json
+++ b/_locales/no/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Fant du en feil?"
     },
+    "fullScreen": {
+        "message": "Fullskjerm"
+    },
     "fullWindow": {
         "message": "Fullt vindu"
     },

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Znalazłeś błąd?"
     },
+    "fullScreen": {
+        "message": "Pełny ekran"
+    },
     "fullWindow": {
         "message": "Pełne okno"
     },

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Encontrou um Bug?"
     },
+    "fullScreen": {
+        "message": "Tela inteira"
+    },
     "fullWindow": {
         "message": "Tela Cheia"
     },

--- a/_locales/pt_PT/messages.json
+++ b/_locales/pt_PT/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Encontrou um erro?"
     },
+    "fullScreen": {
+        "message": "Ecrã inteiro"
+    },
     "fullWindow": {
         "message": "Janela completa"
     },

--- a/_locales/ro/messages.json
+++ b/_locales/ro/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Ai găsit un bug?"
     },
+    "fullScreen": {
+        "message": "Ecran complet"
+    },
     "fullWindow": {
         "message": "Ecran complet"
     },

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -401,6 +401,9 @@
     "foundABug": {
         "message": "Нашли ошибку?"
     },
+    "fullScreen": {
+        "message": "Во весь экран"
+    },
     "fullWindow": {
         "message": "Растянуть на все окно"
     },

--- a/_locales/si/messages.json
+++ b/_locales/si/messages.json
@@ -395,6 +395,9 @@
     "foundABug": {
         "message": "දෝෂයක් හම්බුනාද ඔයාට?"
     },
+    "fullScreen": {
+        "message": "පූර්ණ තිරය"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/sk/messages.json
+++ b/_locales/sk/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Našli ste chybu?"
     },
+    "fullScreen": {
+        "message": "Celá obrazovka"
+    },
     "fullWindow": {
         "message": "Celé okno"
     },

--- a/_locales/sl/messages.json
+++ b/_locales/sl/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "Celoten zaslon"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/sr/messages.json
+++ b/_locales/sr/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "Режим целог екрана"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Hittade ett fel?"
     },
+    "fullScreen": {
+        "message": "Helskärm"
+    },
     "fullWindow": {
         "message": "Helt fönster"
     },

--- a/_locales/sw/messages.json
+++ b/_locales/sw/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "Skrini nzima"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/ta/messages.json
+++ b/_locales/ta/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "முழுத்திரை"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/te/messages.json
+++ b/_locales/te/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "ఫుల్-స్క్రీన్‌"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/th/messages.json
+++ b/_locales/th/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "เต็มหน้าจอ"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Hata mı buldun?"
     },
+    "fullScreen": {
+        "message": "Tam ekran"
+    },
     "fullWindow": {
         "message": "Tam pencere"
     },

--- a/_locales/uk/messages.json
+++ b/_locales/uk/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Found a bug?"
     },
+    "fullScreen": {
+        "message": "Повноекранний режим"
+    },
     "fullWindow": {
         "message": "Full height"
     },

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "Tìm thấy lỗi (bug)?"
     },
+    "fullScreen": {
+        "message": "Toàn màn hình"
+    },
     "fullWindow": {
         "message": "Toàn cửa sổ"
     },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "遇到了Bug?"
     },
+    "fullScreen": {
+        "message": "全屏"
+    },
     "fullWindow": {
         "message": "全屏"
     },

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -398,6 +398,9 @@
     "foundABug": {
         "message": "遇到問題了嗎?"
     },
+    "fullScreen": {
+        "message": "全螢幕"
+    },
     "fullWindow": {
         "message": "全螢幕"
     },

--- a/menu/skeleton-parts/appearance.js
+++ b/menu/skeleton-parts/appearance.js
@@ -250,7 +250,7 @@ extension.skeleton.main.layers.section.appearance.on.click.player = {
 						},
 						player_screen_button: {
 							component: "switch",
-							text: "screen"
+							text: "fullScreen"
 						},
 						player_remote_button: {
 							component: "switch",


### PR DESCRIPTION
<img src="https://github.com/code-charity/youtube/assets/43416399/903c443b-348a-4032-8311-71b01d2a439f" height="300">

At the `appearance > player > Hide player controls buttons >  screen`, I think the text right here has room for improvement. 
The toggle button here is intended for the "full-screen" , so it would be better to use 'Full screen' as the text.

The translation of locales are captured from youtube UI itself.

<img src="https://github.com/code-charity/youtube/assets/43416399/f19a766d-66fa-44d9-ab32-0a994dde056c" width="300">

If you have any questions, please feel free to discuss them below.

