### PR TITLE
fix blacklist feature

### DIFF
--- a/js&css/web-accessible/core.js
+++ b/js&css/web-accessible/core.js
@@ -30,7 +30,7 @@ var ImprovedTube = {
 		blacklist_buttons: []
 	},
 	regex: {
-		channel: new RegExp('\/@|((channel|user|c)\/)'),
+		channel: new RegExp('\/(@|c\/@?|channel\/|user\/)(?<name>[^/]+)'),
 		channel_home_page: new RegExp('\/@|((channel|user|c)\/)[^/]+(\/featured)?\/?$'),
 		channel_home_page_postfix: new RegExp('\/(featured)?\/?$'),
 		thumbnail_quality: new RegExp('(default\.jpg|mqdefault\.jpg|hqdefault\.jpg|hq720\.jpg|sddefault\.jpg|maxresdefault\.jpg)+'),

--- a/js&css/web-accessible/www.youtube.com/blacklist.js
+++ b/js&css/web-accessible/www.youtube.com/blacklist.js
@@ -142,6 +142,7 @@ ImprovedTube.blacklist = function (type, node) {
 				this.added = !this.added;
 
 				ImprovedTube.messages.send({
+					action: 'blacklist',
 					type: 'channel',
 					id,
 					title: data.title,

--- a/js&css/web-accessible/www.youtube.com/blacklist.js
+++ b/js&css/web-accessible/www.youtube.com/blacklist.js
@@ -108,7 +108,7 @@ ImprovedTube.blacklist = function (type, node) {
 	} else if (type === 'channel') {
 		if (node.nodeName === 'A') {
 			try {
-				var id = node.href.match(/@|c\/@?|channel\/|user\/([^/]+)/)[1]
+				var id = node.href.match(ImprovedTube.regex.channel).groups.name;
 
 				if (this.storage.blacklist.channels[id]) {
 					var parent = node.parentNode.__dataHost.__dataHost;
@@ -123,7 +123,7 @@ ImprovedTube.blacklist = function (type, node) {
 			} catch (err) {}
 		} else {
 			var button = this.elements.blacklistChannel || document.createElement('button'),
-				id = location.href.match(/@|c\/@?|channel\/|user\/([^/]+)/)[1];
+				id = location.href.match(ImprovedTube.regex.channel).groups.name;
 
 			button.className = 'it-add-channel-to-blacklist';
 
@@ -137,7 +137,7 @@ ImprovedTube.blacklist = function (type, node) {
 
 			button.addEventListener('click', function (event) {
 				var data = this.parentNode.__dataHost.__data.data,
-					id = location.href.match(/@|c\/@?|channel\/|user\/([^/]+)/)[1];
+					id = location.href.match(ImprovedTube.regex.channel).groups.name;
 
 				this.added = !this.added;
 

--- a/js&css/web-accessible/www.youtube.com/blacklist.js
+++ b/js&css/web-accessible/www.youtube.com/blacklist.js
@@ -103,7 +103,9 @@ ImprovedTube.blacklist = function (type, node) {
 		this.elements.blacklist_buttons.push(button);
 
 		if (id && id[1] && ImprovedTube.storage.blacklist.videos[id[1]]) {
-			node.parentNode.__dataHost.classList.add('it-blacklisted-video');
+			//node.__dataHost.classList.add('it-blacklisted-video'); // this only affects the thumbnail
+			node.parentNode.__dataHost.$.dismissible.classList.add('it-blacklisted-video'); // this affects the title and co. as well
+
 		}
 	} else if (type === 'channel') {
 		if (node.nodeName === 'A') {
@@ -114,10 +116,10 @@ ImprovedTube.blacklist = function (type, node) {
 					var parent = node.parentNode.__dataHost.__dataHost;
 
 					if (
-						parent.nodeName === 'YTD-GRID-VIDEO-RENDERER' &&
+						parent.nodeName === 'YTD-GRID-VIDEO-RENDERER' ||
 						parent.nodeName === 'YTD-VIDEO-META-BLOCK'
 					) {
-						parent.classList.add('it-blacklisted-video');
+						parent.__dataHost.$.dismissible.classList.add('it-blacklisted-video'); // this affects the title and co. as well
 					}
 				}
 			} catch (err) {}


### PR DESCRIPTION
I fixed the channel name regex again and refactored it into the `ImprovedTube.regex.channel` object, so that it doesn't need to be changed everywhere if something changes.

Furthermore I noticed a missing action in the `ImprovedTube.messages.send()` call, that prevented channels from actually getting added to the blacklist.

Finally I updated the selectors for the blacklist css targets, so that hopefully all blacklisted videos get the dark overlay, no matter the page (channel, trending, subscriptions, ... ).

As a possible improvement, we could maybe add a switch, whether the blacklisted videos should be hidden completely or just use the dark overlay, although this could probably also be achieved by editing the `.it-blacklisted-video` css class.