### PR TITLE
Remove shorts from homepage and search result

### DIFF
--- a/_locales/am/messages.json
+++ b/_locales/am/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "የታጠቡት የመጀመሪያ ጭምርን አርምያ"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/am/messages.json
+++ b/_locales/am/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },
+    "removeShortsReelSearchResults": {
+        "message": "የፈረሰኞች ዝግጅት ከስልክ ፍርቂ አውርድ"
+    },
     "repeat": {
         "message": "Repeat"
     },

--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -818,6 +818,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "إزالة الشورت من الصفحة الرئيسية"
+    },
     "removeRelatedSearchResults": {
         "message": "إزالة عمليات بحث مرتبطة بـ"
     },

--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -824,6 +824,9 @@
     "removeRelatedSearchResults": {
         "message": "إزالة عمليات بحث مرتبطة بـ"
     },
+    "removeShortsReelSearchResults": {
+        "message": "إزالة لفة Shorts من نتائج البحث"
+    },
     "repeat": {
         "message": "تكرار"
     },

--- a/_locales/bg/messages.json
+++ b/_locales/bg/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "Премахни Shorts от началната страница"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/bg/messages.json
+++ b/_locales/bg/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Премахнете ролката Shorts от резултатите от търсенето"
+    },
     "repeat": {
         "message": "Repeat"
     },

--- a/_locales/bn/messages.json
+++ b/_locales/bn/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "মুখপৃষ্ঠের শর্ট মুছে দিন"
+    },
     "removeRelatedSearchResults": {
         "message": "সম্পর্কিত অনুসন্ধান ফলাফল সরান"
     },

--- a/_locales/bn/messages.json
+++ b/_locales/bn/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "সম্পর্কিত অনুসন্ধান ফলাফল সরান"
     },
+    "removeShortsReelSearchResults": {
+        "message": "অনুসন্ধানের ফলাফল থেকে শর্টস রিল সরান"
+    },
     "repeat": {
         "message": "পুনরাবৃত্তি"
     },

--- a/_locales/ca/messages.json
+++ b/_locales/ca/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "Elimina els Shorts de la pàgina d'inici"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/ca/messages.json
+++ b/_locales/ca/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Elimineu el carrossel de Shorts dels resultats de cerca"
+    },
     "repeat": {
         "message": "Repeat"
     },

--- a/_locales/cs/messages.json
+++ b/_locales/cs/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "Odebrat Shorts z úvodní stránky"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/cs/messages.json
+++ b/_locales/cs/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Odstraňte karuselu Shorts z výsledků vyhledávání"
+    },
     "repeat": {
         "message": "Repeat"
     },

--- a/_locales/da/messages.json
+++ b/_locales/da/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "Fjern Shorts fra hjemmesiden"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/da/messages.json
+++ b/_locales/da/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Fjern Shorts-rulle fra søgeresultaterne"
+    },
     "repeat": {
         "message": "Repeat"
     },

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Auf TV abspielen"
     },
+    "removeHomePageShorts": {
+        "message": "Startseite Shorts entfernen"
+    },
     "removeRelatedSearchResults": {
         "message": "Ähnliche Suchergebnisse entfernen"
     },

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Ähnliche Suchergebnisse entfernen"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Shorts-Reel aus den Suchergebnissen entfernen"
+    },
     "repeat": {
         "message": "Repeat (Wiederholen)"
     },

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Αφαίρεσε σχετικά αποτελέσματα αναζήτησης"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Αφαιρέστε τη λίστα Shorts από τα αποτελέσματα αναζήτησης"
+    },
     "repeat": {
         "message": "Επανάληψη"
     },

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "Κατάργηση Shorts από την αρχική σελίδα"
+    },
     "removeRelatedSearchResults": {
         "message": "Αφαίρεσε σχετικά αποτελέσματα αναζήτησης"
     },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -830,6 +830,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "Remove home page's Shorts"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -836,6 +836,9 @@
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Remove Shorts reel from search results"
+    },
     "repeat": {
         "message": "Repeat"
     },

--- a/_locales/en_GB/messages.json
+++ b/_locales/en_GB/messages.json
@@ -788,6 +788,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "Remove home page's Shorts"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/en_US/messages.json
+++ b/_locales/en_US/messages.json
@@ -788,6 +788,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "Remove home page's Shorts"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Reproducir en el televisor"
     },
+    "removeHomePageShorts": {
+        "message": "Eliminar Shorts de la página de inicio"
+    },
     "removeRelatedSearchResults": {
         "message": "Quitar resultados relacionados"
     },

--- a/_locales/es_419/messages.json
+++ b/_locales/es_419/messages.json
@@ -794,6 +794,9 @@
     "removeRelatedSearchResults": {
         "message": "Quitar resultados relacionados"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Eliminar el carrusel de Shorts de los resultados de búsqueda"
+    },
     "repeat": {
         "message": "Repetir"
     },

--- a/_locales/es_419/messages.json
+++ b/_locales/es_419/messages.json
@@ -788,6 +788,9 @@
     "remote": {
         "message": "Reproducir en el televisor"
     },
+    "removeHomePageShorts": {
+        "message": "Eliminar Shorts de la página de inicio"
+    },
     "removeRelatedSearchResults": {
         "message": "Quitar resultados relacionados"
     },

--- a/_locales/et/messages.json
+++ b/_locales/et/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Eemaldage Shorts-rull otsingutulemustest"
+    },
     "repeat": {
         "message": "Repeat"
     },

--- a/_locales/et/messages.json
+++ b/_locales/et/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "Eemalda kodulehe Shortsid"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/fa/messages.json
+++ b/_locales/fa/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },
+    "removeShortsReelSearchResults": {
+        "message": "حذف کردن ریل Shorts از نتایج جستجو"
+    },
     "repeat": {
         "message": "Repeat"
     },

--- a/_locales/fa/messages.json
+++ b/_locales/fa/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "حذف کردن شورت‌های صفحه اصلی"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/fi/messages.json
+++ b/_locales/fi/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Poista Shorts-reel hakutuloksista"
+    },
     "repeat": {
         "message": "Repeat"
     },

--- a/_locales/fi/messages.json
+++ b/_locales/fi/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "Poista etusivun Shorts"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/fil/messages.json
+++ b/_locales/fil/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "Alisin ang Shorts mula sa homepage"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/fil/messages.json
+++ b/_locales/fil/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Alisin ang Shorts reel mula sa mga resulta ng paghahanap"
+    },
     "repeat": {
         "message": "Repeat"
     },

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "Supprimer les Shorts de la page d'accueil"
+    },
     "removeRelatedSearchResults": {
         "message": "Supprimer les résultats de recherche associés"
     },

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Supprimer les résultats de recherche associés"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Supprimer la liste de Shorts des résultats de recherche"
+    },
     "repeat": {
         "message": "Lire en boucle"
     },

--- a/_locales/gu/messages.json
+++ b/_locales/gu/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },
+    "removeShortsReelSearchResults": {
+        "message": "શોધના પરિણામોમાંથી શોર્ટસ રીલ કાઢી નાખો"
+    },
     "repeat": {
         "message": "Repeat"
     },

--- a/_locales/gu/messages.json
+++ b/_locales/gu/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "મુખ્ય પેજના શોર્ટ્સ કાઢો"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/he/messages.json
+++ b/_locales/he/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "הסר Shorts מהדף הראשי"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -806,6 +806,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "मुखपृष्ठ के शॉर्ट्स हटाएं"
+    },
     "removeRelatedSearchResults": {
         "message": "संबंधित खोज परिणाम निकालें"
     },

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -812,6 +812,9 @@
     "removeRelatedSearchResults": {
         "message": "संबंधित खोज परिणाम निकालें"
     },
+    "removeShortsReelSearchResults": {
+        "message": "खोज परिणामों से शॉर्ट्स रील को हटाएं"
+    },
     "repeat": {
         "message": "दोहराना"
     },

--- a/_locales/hr/messages.json
+++ b/_locales/hr/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Uklonite slične rezultate pretraživanja"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Uklonite Shorts kolut iz rezultata pretrage"
+    },
     "repeat": {
         "message": "Ponovi"
     },

--- a/_locales/hr/messages.json
+++ b/_locales/hr/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "Uklonite Shorts s početne stranice"
+    },
     "removeRelatedSearchResults": {
         "message": "Uklonite slične rezultate pretraživanja"
     },

--- a/_locales/hu/messages.json
+++ b/_locales/hu/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "Shorts eltávolítása a főoldalról"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/hu/messages.json
+++ b/_locales/hu/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Távolítsa el a Shorts karusellt a keresési találatokból"
+    },
     "repeat": {
         "message": "Repeat"
     },

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "Hapus Shorts dari halaman beranda"
+    },
     "removeRelatedSearchResults": {
         "message": "Hapus hasil pencarian terkait"
     },

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Hapus hasil pencarian terkait"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Hapus gulungan Shorts dari hasil pencarian"
+    },
     "repeat": {
         "message": "Putar ulang"
     },

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Riproduci su tv"
     },
+    "removeHomePageShorts": {
+        "message": "Rimuovi Shorts dalla pagina iniziale"
+    },
     "removeRelatedSearchResults": {
         "message": "Rimuovi risultati di ricerca correlati"
     },

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Rimuovi risultati di ricerca correlati"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Rimuovi il carosello di Shorts dai risultati di ricerca"
+    },
     "repeat": {
         "message": "Ripeti"
     },

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "関連動画を検索結果から削除する"
     },
+    "removeShortsReelSearchResults": {
+        "message": "検索結果からショートリールを削除"
+    },
     "repeat": {
         "message": "リピート"
     },

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "ホームページのショートを削除"
+    },
     "removeRelatedSearchResults": {
         "message": "関連動画を検索結果から削除する"
     },

--- a/_locales/kn/messages.json
+++ b/_locales/kn/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },
+    "removeShortsReelSearchResults": {
+        "message": "ಹುಡುಕಾಟದ ಫಲಿತಾಂಶಗಳಿಂದ ಷಾರ್ಟ್ಸ್ ರೀಲ್ ಅನ್ನು ತೆಗೆದುಹಾಕಿ"
+    },
     "repeat": {
         "message": "Repeat"
     },

--- a/_locales/kn/messages.json
+++ b/_locales/kn/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "ಮುಖ್ಯ ಪೇಜಿನ ಶಾರ್ಟ್ಸ್ ಅನ್ನು ತೆಗೆದುಹಾಕಿ"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -815,6 +815,9 @@
     "remote": {
         "message": "TV에서 재생"
     },
+    "removeHomePageShorts": {
+        "message": "홈 페이지의 쇼츠 제거"
+    },
     "removeRelatedSearchResults": {
         "message": "관련 검색 결과 제거"
     },

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -821,6 +821,9 @@
     "removeRelatedSearchResults": {
         "message": "관련 검색 결과 제거"
     },
+    "removeShortsReelSearchResults": {
+        "message": "검색 결과에서 Shorts 리얼 제거"
+    },
     "repeat": {
         "message": "반복"
     },

--- a/_locales/lt/messages.json
+++ b/_locales/lt/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "Pašalinkite Shorts iš pagrindinio puslapio"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/lt/messages.json
+++ b/_locales/lt/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Pašalinkite Shorts ritinį iš paieškos rezultatų"
+    },
     "repeat": {
         "message": "Repeat"
     },

--- a/_locales/lv/messages.json
+++ b/_locales/lv/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Noņemiet Shorts rullīti no meklēšanas rezultātiem"
+    },
     "repeat": {
         "message": "Repeat"
     },

--- a/_locales/lv/messages.json
+++ b/_locales/lv/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "Noņem Shorts no sākumlapas"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/ml/messages.json
+++ b/_locales/ml/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },
+    "removeShortsReelSearchResults": {
+        "message": "തിരച്ചില്‍ ഫലങ്ങളില്‍നിന്ന് ഷോര്‍ട്സ് റീല്‍ നീക്കം"
+    },
     "repeat": {
         "message": "Repeat"
     },

--- a/_locales/ml/messages.json
+++ b/_locales/ml/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "ഹോം പേജിന്റെ ഷോർട്ട് നീക്കം"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/mr/messages.json
+++ b/_locales/mr/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },
+    "removeShortsReelSearchResults": {
+        "message": "शोध निकाला लावा परिणामातील शॉर्ट्स रील"
+    },
     "repeat": {
         "message": "Repeat"
     },

--- a/_locales/mr/messages.json
+++ b/_locales/mr/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "मुख्य पृष्ठाच्या शॉर्ट्स काढा"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/ms/messages.json
+++ b/_locales/ms/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Alihkan gulungan Shorts dari hasil carian"
+    },
     "repeat": {
         "message": "Repeat"
     },

--- a/_locales/ms/messages.json
+++ b/_locales/ms/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "Alihkan Shorts dari laman utama"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/nb_NO/messages.json
+++ b/_locales/nb_NO/messages.json
@@ -806,6 +806,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "Fjern Shorts fra hjemmesiden"
+    },
     "removeRelatedSearchResults": {
         "message": "Fjern relaterte søkeresultater"
     },

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Speel af op TV"
     },
+    "removeHomePageShorts": {
+        "message": "Verwijder Shorts van de startpagina"
+    },
     "removeRelatedSearchResults": {
         "message": "Verwijder resultaten van gerelateerde videos"
     },

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Verwijder resultaten van gerelateerde videos"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Verwijder Shorts-reel uit de zoekresultaten"
+    },
     "repeat": {
         "message": "Herhalen"
     },

--- a/_locales/no/messages.json
+++ b/_locales/no/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "Fjern Shorts fra hjemmesiden"
+    },
     "removeRelatedSearchResults": {
         "message": "Fjern relaterte søkeresultater"
     },

--- a/_locales/no/messages.json
+++ b/_locales/no/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Fjern relaterte søkeresultater"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Fjern Shorts-rullen fra søkeresultatene"
+    },
     "repeat": {
         "message": "Gjenta"
     },

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Odtwarzaj na telewizorze"
     },
+    "removeHomePageShorts": {
+        "message": "Usuń Shorts z głównej strony"
+    },
     "removeRelatedSearchResults": {
         "message": "Usuń powiązane wyniki wyszukiwania"
     },

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Usuń powiązane wyniki wyszukiwania"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Usuń karuzelę Shorts z wyników wyszukiwania"
+    },
     "repeat": {
         "message": "Powtarzaj"
     },

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Assistir na TV"
     },
+    "removeHomePageShorts": {
+        "message": "Remover Shorts da página inicial"
+    },
     "removeRelatedSearchResults": {
         "message": "Remover os respectivos resultados de pesquisa"
     },

--- a/_locales/pt_PT/messages.json
+++ b/_locales/pt_PT/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "Remover Shorts da página inicial"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove resultados relacionado com a pesquisa"
     },

--- a/_locales/pt_PT/messages.json
+++ b/_locales/pt_PT/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Remove resultados relacionado com a pesquisa"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Remover o carrossel de Shorts dos resultados de pesquisa"
+    },
     "repeat": {
         "message": "Repetir"
     },

--- a/_locales/ro/messages.json
+++ b/_locales/ro/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Elimină rezultatele asemănătoare a căutării"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Eliminați roata de Shorts din rezultatele căutării"
+    },
     "repeat": {
         "message": "Repetă"
     },

--- a/_locales/ro/messages.json
+++ b/_locales/ro/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "Eliminați Shorts de pe pagina de start"
+    },
     "removeRelatedSearchResults": {
         "message": "Elimină rezultatele asemănătoare a căutării"
     },

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -818,6 +818,9 @@
     "remote": {
         "message": "Удаленное воспроизведение"
     },
+    "removeHomePageShorts": {
+        "message": "Удалить Shorts с главной страницы"
+    },
     "removeRelatedSearchResults": {
         "message": "Удалять связанные результаты поиска"
     },

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -824,6 +824,9 @@
     "removeRelatedSearchResults": {
         "message": "Удалять связанные результаты поиска"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Удалить карусель Shorts из результатов поиска"
+    },
     "repeat": {
         "message": "Повтор"
     },

--- a/_locales/si/messages.json
+++ b/_locales/si/messages.json
@@ -812,6 +812,9 @@
     "removeRelatedSearchResults": {
         "message": "Related search results කොටස ඉවත් කරන්න"
     },
+    "removeShortsReelSearchResults": {
+        "message": "සෙවා ප්‍රතිඵල සෙයානක් ඉවත් කරන්න"
+    },
     "repeat": {
         "message": "Repeat කරන්න"
     },

--- a/_locales/si/messages.json
+++ b/_locales/si/messages.json
@@ -806,6 +806,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "මුල් පිටුවේ ෂෝට් ඉවත් කරනවා"
+    },
     "removeRelatedSearchResults": {
         "message": "Related search results කොටස ඉවත් කරන්න"
     },

--- a/_locales/sk/messages.json
+++ b/_locales/sk/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Odstránte príbuzné výsledky vyhľadávania"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Odstráňte karusel Shorts z výsledkov vyhľadávania"
+    },
     "repeat": {
         "message": "Opakovať"
     },

--- a/_locales/sk/messages.json
+++ b/_locales/sk/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "Odstrániť Shorts zo začiatočnej stránky"
+    },
     "removeRelatedSearchResults": {
         "message": "Odstránte príbuzné výsledky vyhľadávania"
     },

--- a/_locales/sl/messages.json
+++ b/_locales/sl/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "Odstrani Shorts s prve strani"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/sl/messages.json
+++ b/_locales/sl/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Odstrani Shorts kolut iz rezultatov iskanja"
+    },
     "repeat": {
         "message": "Repeat"
     },

--- a/_locales/sr/messages.json
+++ b/_locales/sr/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "Уклоните Shorts са почетне стране"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/sr/messages.json
+++ b/_locales/sr/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Уклоните каруселу Shorts из резултата претраге"
+    },
     "repeat": {
         "message": "Repeat"
     },

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Spela på TV"
     },
+    "removeHomePageShorts": {
+        "message": "Ta bort Shorts från startsidan"
+    },
     "removeRelatedSearchResults": {
         "message": "Ta bort relaterade sökresultat"
     },

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Ta bort relaterade sökresultat"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Ta bort Shorts-reel från sökresultaten"
+    },
     "repeat": {
         "message": "Repetera"
     },

--- a/_locales/sw/messages.json
+++ b/_locales/sw/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Ondoa gurudumu la Shorts kutoka kwenye matokeo ya utafutaji"
+    },
     "repeat": {
         "message": "Repeat"
     },

--- a/_locales/sw/messages.json
+++ b/_locales/sw/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "Ondoa Shorts kutoka ukurasa wa nyumbani"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/ta/messages.json
+++ b/_locales/ta/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },
+    "removeShortsReelSearchResults": {
+        "message": "தேடல் முடிவுகளிலிருந்து ஷார்ட்ஸ் ரீலை அகற்று"
+    },
     "repeat": {
         "message": "Repeat"
     },

--- a/_locales/ta/messages.json
+++ b/_locales/ta/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "முகப்பு பக்கத்தின் ஷார்ட்ஸ் அகற்று"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/te/messages.json
+++ b/_locales/te/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "ముఖ్య పేజీని షార్ట్స్ తొలగించండి"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/te/messages.json
+++ b/_locales/te/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },
+    "removeShortsReelSearchResults": {
+        "message": "శోర్ట్స్ రీల్‌ను సెర్చ్ ఫలితాల నుండి తీసుకోండి"
+    },
     "repeat": {
         "message": "Repeat"
     },

--- a/_locales/th/messages.json
+++ b/_locales/th/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },
+    "removeShortsReelSearchResults": {
+        "message": "ลบ Shorts reel ออกจากผลการค้นหา"
+    },
     "repeat": {
         "message": "Repeat"
     },

--- a/_locales/th/messages.json
+++ b/_locales/th/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "ลบ Shorts ออกจากหน้าแรก"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "TV'de oynat"
     },
+    "removeHomePageShorts": {
+        "message": "Ana sayfa Shorts'ları kaldır"
+    },
     "removeRelatedSearchResults": {
         "message": "İlgili arama sonuçlarını kaldır"
     },

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "İlgili arama sonuçlarını kaldır"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Arama sonuçlarından Shorts reelini kaldır"
+    },
     "repeat": {
         "message": "Tekrarla"
     },

--- a/_locales/uk/messages.json
+++ b/_locales/uk/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Видаліть карусель Shorts з результатів пошуку"
+    },
     "repeat": {
         "message": "Repeat"
     },

--- a/_locales/uk/messages.json
+++ b/_locales/uk/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "Видалити Shorts з головної сторінки"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Phát trên TV"
     },
+    "removeHomePageShorts": {
+        "message": "Xóa Shorts trên trang chủ"
+    },
     "removeRelatedSearchResults": {
         "message": "Xóa kết quả tìm kiếm có liên quan"
     },

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "Xóa kết quả tìm kiếm có liên quan"
     },
+    "removeShortsReelSearchResults": {
+        "message": "Xóa vòng lặp Shorts khỏi kết quả tìm kiếm"
+    },
     "repeat": {
         "message": "Lặp lại"
     },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "隐藏搜索相关结果"
     },
+    "removeShortsReelSearchResults": {
+        "message": "删除搜索结果中的 Shorts 轮播"
+    },
     "repeat": {
         "message": "循环"
     },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "Play on TV"
     },
+    "removeHomePageShorts": {
+        "message": "移除主页的 Shorts"
+    },
     "removeRelatedSearchResults": {
         "message": "隐藏搜索相关结果"
     },

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -812,6 +812,9 @@
     "remote": {
         "message": "於電視上播放"
     },
+    "removeHomePageShorts": {
+        "message": "移除主頁的 Shorts"
+    },
     "removeRelatedSearchResults": {
         "message": "移除搜尋相關結果"
     },

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -818,6 +818,9 @@
     "removeRelatedSearchResults": {
         "message": "移除搜尋相關結果"
     },
+    "removeShortsReelSearchResults": {
+        "message": "刪除搜尋結果中的 Shorts 輪播"
+    },
     "repeat": {
         "message": "重複播放"
     },

--- a/js&css/extension/www.youtube.com/general/general.css
+++ b/js&css/extension/www.youtube.com/general/general.css
@@ -123,6 +123,14 @@ html[it-pathname='/results'][it-remove-related-search-results='true'] ytd-shelf-
 
 
 /*--------------------------------------------------------------
+# REMOVE SHOTS RELATED SEARCH RESULTS
+--------------------------------------------------------------*/
+
+html[it-pathname='/results'][it-remove-shorts-reel-search-results="true"] ytd-reel-shelf-renderer {
+	display: none !important
+}
+
+/*--------------------------------------------------------------
 # SCROLL BAR
 --------------------------------------------------------------*/
 

--- a/js&css/extension/www.youtube.com/general/general.css
+++ b/js&css/extension/www.youtube.com/general/general.css
@@ -61,6 +61,15 @@ html[it-pathname='/'][it-youtube-home-page='search'] ytm-searchbox>form {
 
 
 /*--------------------------------------------------------------
+# REMOVE HOMEPAGE SHORTS
+--------------------------------------------------------------*/
+
+html[it-pathname='/'][it-remove-home-page-shorts="true"] ytd-rich-section-renderer:has(ytd-rich-grid-slim-media[is-short]) {
+	display: none !important
+}
+
+
+/*--------------------------------------------------------------
 # COLLAPSE OF SUBSCRIPTION SECTIONS
 --------------------------------------------------------------*/
 

--- a/menu/skeleton-parts/general.js
+++ b/menu/skeleton-parts/general.js
@@ -1090,6 +1090,10 @@ extension.skeleton.main.layers.section.general = {
 					component: 'switch',
 					text: 'collapseOfSubscriptionSections'
 				},
+				remove_home_page_shorts: {
+					component: 'switch',
+					text: 'removeHomePageShorts'
+				},
 				remove_related_search_results: {
 					component: 'switch',
 					text: 'removeRelatedSearchResults'

--- a/menu/skeleton-parts/general.js
+++ b/menu/skeleton-parts/general.js
@@ -1097,6 +1097,10 @@ extension.skeleton.main.layers.section.general = {
 				remove_related_search_results: {
 					component: 'switch',
 					text: 'removeRelatedSearchResults'
+				},
+				remove_shorts_reel_search_results: {
+					component: 'switch',
+					text: 'removeShortsReelSearchResults'
 				}
 			},
 			embed: {


### PR DESCRIPTION
Implement these feature:
- remove shorts from home page:   
<img width="400" src="https://github.com/code-charity/youtube/assets/43416399/9d125696-6f63-4cc4-a5cb-81ad3bfedd11"/>
- remove shorts reel from search results:  
<img width="400" src="https://github.com/code-charity/youtube/assets/43416399/623d06f9-05e8-408e-952c-977b2c1acc3f"/>



related issue: 
- #1383 like part of it, but only work for homepage and search result.
- #1698, This issue is lack of discussion, but it looks alike. It worth noting that the implementation is not entirely remove the Shorts from search result actually, only the Shorts reel like the picture below.

<img src="https://github.com/code-charity/youtube/assets/43416399/74b2cfaa-7f90-4081-b95f-fa19e3f01804" width="300"/>


As the film's filters grow, another new category may be necessary. But for now, let's put it in other

Something deserves some discussion is where the setting should be placed. As the settings of search get grow, another new category may be necessary, but for now place at the top of `General` first (welcome for any idea!). 

The second is the locales. I was tried to do the translation as well as I can with ChatGPT. I can't guarantee the accuracy though but is better than none. 


