### PR TITLE
Content inside shortcut boxes is now visible !

### DIFF
--- a/js&css/satus.css
+++ b/js&css/satus.css
@@ -150,6 +150,7 @@
 	--satus-input-text-background: #e8e8e3;
 	--satus-input-text-border: #d6d6cd;
 	--satus-input-text-text: #848471;
+	--satus-shortcut-key-text: #000;
 }
 
 .satus-base[theme=dark] {
@@ -1646,7 +1647,7 @@ As our Syntax markup isnt read for <textarea>, is it?
 
 .satus-shortcut__value>.satus-shortcut__key {
 	font-size: 12px;
-
+	color: var(--satus-shortcut-key-text);
 	min-width: 24px;
 	height: 24px;
 }

--- a/menu/styles/themes.css
+++ b/menu/styles/themes.css
@@ -35,6 +35,7 @@
 	--satus-tabs-foreground: #33343d;
 	--satus-text-field-background: #1e1e1e;
 	--satus-text-field-foreground: #e0e0e0;
+	--satus-shortcut-key-text: #131316;
 }
 
 .satus-base[theme='night'] {
@@ -61,6 +62,8 @@
 	--satus-text-field-background: #3a48b4;
 	--satus-text-field-foreground: #f5f5f5;
 	--satus-text-field-border: #5d6acb;
+	--satus-shortcut-key-text: #191f4d;
+
 }
 
 .satus-base[theme='dawn'] {
@@ -87,6 +90,7 @@
 	--satus-text-field-background: #ed74a9;
 	--satus-text-field-foreground: #f5f5f5;
 	--satus-text-field-border: #e53883;
+	--satus-shortcut-key-text: #de357c;
 }
 
 .satus-base[theme='sunset'] {
@@ -113,6 +117,7 @@
 	--satus-text-field-background: #313668;
 	--satus-text-field-foreground: #f5f5f5;
 	--satus-text-field-border: #313668;
+	--satus-shortcut-key-text: #2f3364;
 }
 
 .satus-base[theme='desert'] {
@@ -140,6 +145,7 @@
 	--satus-text-field-background: #73a1fc;
 	--satus-text-field-foreground: #f5f5f5;
 	--satus-text-field-border: #73a1fc;
+	--satus-shortcut-key-text: #73a1fc;
 }
 
 .satus-base[theme='plain'] {
@@ -167,6 +173,7 @@
 	--satus-text-field-background: ##57a87a;
 	--satus-text-field-foreground: #f5f5f5;
 	--satus-text-field-border: #4c946b;
+	--satus-shortcut-key-text: #57a87a;
 }
 
 .satus-base[theme='black'] {
@@ -190,6 +197,7 @@
 	--satus-text-field-background: #1e1e1e;
 	--satus-text-field-border: #333;
 	--satus-text-field-foreground: #e0e0e0;
+	--satus-shortcut-key-text: #000;
 }
 
 


### PR DESCRIPTION
Closes #1788 

- Created a new variable for the text color inside the shortcut keys boxes for each theme applied.
- There is a text color matching with the selected theme which is easily visible inside the boxes. 

**Screenshots**
![Screenshot (29)](https://github.com/code-charity/youtube/assets/132138302/f00f82cb-6ef6-453a-bf18-155366659d90)
![Screenshot (30)](https://github.com/code-charity/youtube/assets/132138302/50171647-ff3f-4c16-8b1e-4a987260cba1)
![Screenshot (31)](https://github.com/code-charity/youtube/assets/132138302/da804f8c-9337-4c2e-bf6f-e085e5ad3098)
![Screenshot (32)](https://github.com/code-charity/youtube/assets/132138302/badbc9dc-9e9d-4ec7-8f81-f9bd8dc10f2f)
![Screenshot (33)](https://github.com/code-charity/youtube/assets/132138302/0c720ce7-898d-4c16-b929-b95969c0eecf)
![Screenshot (34)](https://github.com/code-charity/youtube/assets/132138302/ae039303-0fe7-4b11-8788-8fbcca5f5a32)
![Screenshot (35)](https://github.com/code-charity/youtube/assets/132138302/71333792-5c6c-4f6d-892f-8d39542db813)
![Screenshot (36)](https://github.com/code-charity/youtube/assets/132138302/4702ed50-993f-47dd-bf04-d629c44e164c)


 - Also, I believe bug-2 mentioned in the issue is already resolved, the scroll bar is fine as checked by me.

 - Kindly review and let me know for any changes required.
 - You can add hacktoberfest tag while merging this PR.