### PR TITLE
(new option) playlist popup button

### DIFF
--- a/js&css/web-accessible/core.js
+++ b/js&css/web-accessible/core.js
@@ -35,6 +35,7 @@ var ImprovedTube = {
 		channel_home_page_postfix: new RegExp('\/(featured)?\/?$'),
 		thumbnail_quality: new RegExp('(default\.jpg|mqdefault\.jpg|hqdefault\.jpg|hq720\.jpg|sddefault\.jpg|maxresdefault\.jpg)+'),
 		video_id: new RegExp('[?&]v=([^&]+)'),
+		playlist_id: new RegExp('[?&]list=([^&]+)'),
 		channel_link: new RegExp('https:\/\/www.youtube.com\/@|((channel|user|c)\/)')
 	},
 	video_src: false,

--- a/js&css/web-accessible/core.js
+++ b/js&css/web-accessible/core.js
@@ -35,6 +35,7 @@ var ImprovedTube = {
 		channel_home_page_postfix: new RegExp('\/(featured)?\/?$'),
 		thumbnail_quality: new RegExp('(default\.jpg|mqdefault\.jpg|hqdefault\.jpg|hq720\.jpg|sddefault\.jpg|maxresdefault\.jpg)+'),
 		video_id: new RegExp('[?&]v=([^&]+)'),
+		video_time: new RegExp('[?&](?:t|start)=([^&]+)'),
 		playlist_id: new RegExp('[?&]list=([^&]+)'),
 		channel_link: new RegExp('https:\/\/www.youtube.com\/@|((channel|user|c)\/)')
 	},

--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -97,6 +97,7 @@ ImprovedTube.ytElementsHandler = function (node) {
 				this.playlistReverse();
 			}
 		}
+		this.playlistPopupUpdate();
 	} else if (name === 'YTD-GUIDE-SECTION-RENDERER') {
 		if (!this.elements.sidebar_section) {
 			this.elements.sidebar_section = node;
@@ -122,7 +123,9 @@ ImprovedTube.ytElementsHandler = function (node) {
 		if(document.documentElement.dataset.pageType === 'video'){
             this.hideDetailButton(node.$['flexible-item-buttons'].children);
         }
-	} else if (name === 'YTD-SUBSCRIBE-BUTTON-RENDERER') {
+	} else if (name === 'YTD-PLAYLIST-HEADER-RENDERER' || (name === 'YTD-MENU-RENDERER' && node.classList.contains('ytd-playlist-panel-renderer'))) {
+		this.playlistPopupUpdate();
+ 	} else if (name === 'YTD-SUBSCRIBE-BUTTON-RENDERER') {
 		if (node.className.indexOf('ytd-c4-tabbed-header-renderer') !== -1) {
 			ImprovedTube.blacklist('channel', node);
 		}
@@ -255,8 +258,6 @@ ImprovedTube.ytElementsHandler = function (node) {
 			ImprovedTube.chapters(node);}, 200);
 		}
 	}
-	// TODO move do different ifs ↑ to minimize calls (~ mini player, video player, and playlist page)
-	this.playlistPopup();
 
 };
 

--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -255,6 +255,8 @@ ImprovedTube.ytElementsHandler = function (node) {
 			ImprovedTube.chapters(node);}, 200);
 		}
 	}
+	// TODO move do different ifs ↑ to minimize calls (~ mini player, video player, and playlist page)
+	this.playlistPopup();
 
 };
 

--- a/js&css/web-accessible/init.js
+++ b/js&css/web-accessible/init.js
@@ -105,6 +105,8 @@ document.addEventListener('yt-page-data-updated', function (event) {
 		ImprovedTube.playlistShuffle();
 		ImprovedTube.playlistReverse();
 	}
+	// TODO when does this event fire ?
+	// ImprovedTube.playlistPopup();
 });
 
 window.addEventListener('load', function () {

--- a/js&css/web-accessible/init.js
+++ b/js&css/web-accessible/init.js
@@ -34,6 +34,9 @@ ImprovedTube.observer = new MutationObserver(function (mutationList) {
 			for (var j = 0, k = mutation.addedNodes.length; j < k; j++) {
 				ImprovedTube.childHandler(mutation.addedNodes[j]);
 			}
+			for (const node of mutation.removedNodes){
+				if(node.nodeName === 'BUTTON' && node.id === 'it-popup-playlist-button') ImprovedTube.playlistPopupUpdate();
+			}
 		}
 	}
 }).observe(document.documentElement, {
@@ -105,8 +108,7 @@ document.addEventListener('yt-page-data-updated', function (event) {
 		ImprovedTube.playlistShuffle();
 		ImprovedTube.playlistReverse();
 	}
-	// TODO when does this event fire ?
-	// ImprovedTube.playlistPopup();
+	ImprovedTube.playlistPopupUpdate();
 });
 
 window.addEventListener('load', function () {

--- a/js&css/web-accessible/www.youtube.com/playlist.js
+++ b/js&css/web-accessible/www.youtube.com/playlist.js
@@ -130,3 +130,48 @@ ImprovedTube.playlistShuffle = function () {
 		}, 5000);
 	}
 };
+
+/*------------------------------------------------------------------------------
+4.5.5 POPUP
+------------------------------------------------------------------------------*/
+ImprovedTube.playlistPopup = function () {
+	if (!(ImprovedTube.storage.playlist_popup ?? false)) return;
+	const shareButtonPlaylist = document.body.querySelector('ytd-app>div#content>ytd-page-manager>ytd-browse>ytd-playlist-header-renderer ytd-button-renderer.ytd-playlist-header-renderer:has(button[aria-label="Share"])'),
+		shuffleButtonMini = document.body.querySelector('ytd-app>ytd-miniplayer ytd-playlist-panel-renderer div#playlist-action-menu ytd-toggle-button-renderer.ytd-menu-renderer:has(button[aria-label="Shuffle playlist"])'),
+		shuffleButtonPanel = document.body.querySelector('ytd-app>div#content>ytd-page-manager>ytd-watch-flexy ytd-playlist-panel-renderer div#playlist-action-menu ytd-toggle-button-renderer.ytd-menu-renderer:has(button[aria-label="Shuffle playlist"])');
+	/* TODO
+		check siblings if there is a button (playlist popup button) → query select with id on parentElement (of the share/shuffle button)
+		→ if not, create one (data-list has the playlist id)
+		? class yt-spec-button-shape-next--tonal should be yt-spec-button-shape-next--text for the mini player and the playlist panel
+		? id must not be different for the 3 different button positions (when using querySelector ↑)
+		! refactor ~ one function to create a button and 3 checks for which variant to create
+	*/
+	if(shareButtonPlaylist != null && !document.getElementById('it-popup-playlist-button')){
+		var button = document.createElement('button'),
+			svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
+			path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+		
+		button.id = 'it-popup-playlist-button';
+		button.className = 'yt-spec-button-shape-next yt-spec-button-shape-next--tonal yt-spec-button-shape-next--overlay yt-spec-button-shape-next--size-m yt-spec-button-shape-next--icon-button style-scope ytd-playlist-header-renderer';
+		button.title = "Popup playlist";
+		button.style.opacity='0.8';
+		button.dataset.list = document.body.querySelector('ytd-app>div#content>ytd-page-manager>ytd-browse>ytd-playlist-header-renderer div.thumbnail-and-metadata-wrapper>a[href*="list="]').href.match(ImprovedTube.regex.playlist_id)[1];
+		button.addEventListener('click', function (event) {
+			window.open(`${location.protocol}//www.youtube.com/embed/videoseries?autoplay=${(ImprovedTube.storage.player_autoplay ?? true) ? '1' : '0'}&list=${this.dataset.list}`, '_blank', `directories=no,toolbar=no,location=no,menubar=no,status=no,titlebar=no,scrollbars=no,resizable=no,width=${innerWidth},height=${innerHeight}`);
+		}, true);
+
+		svg.style.width = '24px';
+		svg.style.height = '24px';
+		svg.style.pointerEvents = 'none';
+		svg.style.fill = 'currentColor';
+		svg.setAttribute('viewBox', '0 0 24 24');
+		path.setAttribute('d', 'M19 7h-8v6h8V7zm2-4H3C2 3 1 4 1 5v14c0 1 1 2 2 2h18c1 0 2-1 2-2V5c0-1-1-2-2-2zm0 16H3V5h18v14z');
+
+		svg.append(path);
+
+		button.append(svg);
+
+		shareButtonPlaylist.insertAdjacentElement('afterend', button);
+		// ImprovedTube.elements.playlist.actions.appendChild(button);
+	}
+};

--- a/menu/skeleton-parts/playlist.js
+++ b/menu/skeleton-parts/playlist.js
@@ -39,6 +39,15 @@ extension.skeleton.main.layers.section.playlist = {
 					component: 'switch',
 					text: 'shuffle'
 				}
+			},
+			section3: {
+				component: 'section',
+				variant: 'card',
+
+				playlist_popup: {
+					component: 'switch',
+					text: 'popup'
+				}
 			}
 		}
 	},

--- a/menu/skeleton-parts/playlist.js
+++ b/menu/skeleton-parts/playlist.js
@@ -38,15 +38,10 @@ extension.skeleton.main.layers.section.playlist = {
 				playlist_shuffle: {
 					component: 'switch',
 					text: 'shuffle'
-				}
-			},
-			section3: {
-				component: 'section',
-				variant: 'card',
-
+				},
 				playlist_popup: {
 					component: 'switch',
-					text: 'popup'
+					text: 'popupPlayer'
 				}
 			}
 		}


### PR DESCRIPTION
More info is in #1805 section [2].

The option is under the Playlist menu and is defaulted off.

Works with (tested):

- open a playlist page
- open a video page (with a playlist)
- change the video in the playlist panel (video page)
- change to the mini player (with playlist)
- change video in the playlist panel (in mini player)
- navigate to a different playlist page (within YouTube, without reloading the page)
- open another video page (with another playlist)

The button may reappear with some delay when it is removed by page updates.