### PR TITLE
feat: put player buttons under one button

### DIFF
--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -305,6 +305,7 @@ ImprovedTube.videoPageUpdate = function () {
 		ImprovedTube.playerRotateButton();
 		ImprovedTube.playerPopupButton();
 		ImprovedTube.playerFitToWinButton();
+		ImprovedTube.playerHamburgerButton();
 		ImprovedTube.playerControls();
 	}
 };
@@ -360,6 +361,7 @@ ImprovedTube.initPlayer = function () {
 		ImprovedTube.playerRotateButton();
 		ImprovedTube.playerPopupButton();
 		ImprovedTube.playerFitToWinButton();
+		ImprovedTube.playerHamburgerButton();
 		ImprovedTube.playerControls();
 
 		setTimeout(function () {

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -710,6 +710,70 @@ ImprovedTube.playerFitToWinButton = function () {
 		document.querySelector("html").setAttribute("it-player-size", ImprovedTube.storage.player_size ?? "do_not_change");
 	}
 };
+
+/*------------------------------------------------------------------------------
+HAMBURGER MENU
+------------------------------------------------------------------------------*/
+ImprovedTube.playerHamburgerButton = function () {
+    const videoPlayer = document.querySelector('.html5-video-player');
+
+    if (!videoPlayer) {
+        return;
+    }
+
+    const controlsContainer = videoPlayer.querySelector('.ytp-right-controls');
+
+    if (!controlsContainer) {
+        return;
+    }
+
+	let hamburgerMenu = document.querySelector('.custom-hamburger-menu');
+
+	if(this.storage.player_hamburger_button === true){
+		if (!hamburgerMenu) {
+			hamburgerMenu = document.createElement('div');
+			hamburgerMenu.className = 'custom-hamburger-menu';
+			hamburgerMenu.style.position = 'absolute';
+			hamburgerMenu.style.right = '0';
+			hamburgerMenu.style.marginTop = '8px';
+			hamburgerMenu.style.cursor = 'pointer';
+
+			const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+			svg.setAttributeNS(null, 'viewBox', '0 0 24 24');
+			svg.setAttribute('style', 'width: 32px; height: 32px;');
+
+			const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+			path.setAttributeNS(null, 'd', 'M3 18h18v-2H3v2zM3 13h18v-2H3v2zM3 6v2h18V6H3z');
+			path.setAttributeNS(null, 'fill', 'white');
+
+			svg.appendChild(path);
+			hamburgerMenu.appendChild(svg);
+
+			controlsContainer.style.paddingRight = '40px';
+			controlsContainer.parentNode.appendChild(hamburgerMenu);
+
+			let controlsVisible = true;
+			controlsContainer.style.display = controlsVisible ? 'none' : 'flex';
+			controlsVisible = false;
+			
+			hamburgerMenu.addEventListener('click', function () {
+				controlsContainer.style.display = controlsVisible ? 'none' : 'flex';
+				controlsVisible = !controlsVisible;
+
+				// Change the opacity of hamburgerMenu based on controls visibility
+				hamburgerMenu.style.opacity = controlsVisible ? '0.65' : '1';
+			});
+		} 
+	}else if (!this.storage.player_hamburger_button) {
+        // Remove the hamburger menu and restore the original padding of .ytp-right-controls
+        if(hamburgerMenu)
+			hamburgerMenu.remove();
+        controlsContainer.style.paddingRight = '0';
+    }
+};
+
+
+
 /*------------------------------------------------------------------------------
 POPUP PLAYER
 ------------------------------------------------------------------------------*/

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -1031,6 +1031,10 @@ extension.skeleton.main.layers.section.player.on.click = {
 			component: 'switch',
 			text: 'Fit to Window'
 		},
+		player_hamburger_button: {
+			component: 'switch',
+			text: 'Hamburger Menu'
+		},
 		player_popup_button: {
 			component: 'switch',
 			text: 'popupPlayer'


### PR DESCRIPTION
Resolving Issue: #1837 
Hello, @ImprovedTube , this PR is created to resolve the issue of putting up the player buttons under one button.

Here is a detailed video as a result of changes done:
[bindingbutton.webm](https://github.com/code-charity/youtube/assets/47809197/c269c91d-a405-442e-91fc-41dd07a094a4)

**_How it works:_**

- Go to Player
- There is a button **Hamburger Menu** below the fit to window button, turn it on
- Now all the right controls will be packed in one
- When you click on Hamburger Menu the options will be show, and opacity of Hamburger Icon will reduce indicating it is clicked
- When pressed again the options will collapse in a bar.

Have a look, and please merge this PR, feel free to share suggestions if any.