### PR TITLE
Small fix & updated video and playlist URL-less popups

### DIFF
--- a/background.js
+++ b/background.js
@@ -261,29 +261,26 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
 			hostname: new URL(sender.url).hostname,
 			tabId: sender.tab.id
 		 });
-	} else  if (action === 'fixPopup') {
-		//no URL-bar
+	} else if (action === 'fixPopup') {
+		//~ get the current focused tab and convert it to a URL-less popup (with same state and size)
 		chrome.windows.getLastFocused(w => {
-		chrome.tabs.query({ windowId: w.id, active: true }, ts => {
-		const t = ts[0];
-		const data = { type: "popup"  };
-		if (t) { data.tabId = t.id;  }
-		chrome.windows.create(data, pw => { chrome.windows.update(pw.id, { state: w.state
-		, width: message.playerSize.width, 
-		  height: message.playerSize.height});
-				}); 
-	    //title
-		chrome.tabs.onUpdated.addListener(function listener(tabId, changeInfo) {
-          if (tabId === t.id && changeInfo.status === 'complete') {
-            chrome.tabs.executeScript(t.id, {
-              code: `document.title = "ImprovedTube Popup Player: ${message.title}";`
-            });
-            chrome.tabs.onUpdated.removeListener(listener);
-          }
-        });				
-			});		  
-		  });
-	};	  
+			chrome.tabs.query({
+				windowId: w.id,
+				active: true
+			}, ts => {
+				const tID = ts[0]?.id,
+					data = { type: 'popup' };
+				if (tID) data.tabId = tID;
+				chrome.windows.create(data, pw => {
+					chrome.windows.update(pw.id, {
+						state: w.state,
+						width: message.playerSize.width,
+						height: message.playerSize.height
+					});
+				});
+			});
+		});
+	};
 });
 
 // Create the frameless window with no URL

--- a/js&css/extension/init.js
+++ b/js&css/extension/init.js
@@ -148,13 +148,14 @@ document.addEventListener('it-message-from-youtube', function () {
 				name: 'only-one-player'
 			});
 		} else if (message.action === 'popup player') {
-			chrome.runtime.sendMessage({   
-			action: 'fixPopup',    
-			url: message.url, 
-			playerSize: { width: message.width, height: message.height   },
-			title: message.title
+			chrome.runtime.sendMessage({
+				action: 'fixPopup',
+				url: message.url,
+				playerSize: {
+					width: message.width,
+					height: message.height
+				}
 			});
-			
 		} else if (message.action === 'analyzer') {
 			if (extension.storage.data.analyzer_activation === true) {
 				var data = message.name,

--- a/js&css/web-accessible/core.js
+++ b/js&css/web-accessible/core.js
@@ -270,9 +270,10 @@ document.addEventListener('it-message-from-extension', function () {
 			ImprovedTube.elements.buttons['it-repeat-button'].remove();
 			ImprovedTube.elements.buttons['it-repeat-styles'].remove();}  		 }
 		} else if (camelized_key === 'playerHamburgerButton') { if(ImprovedTube.storage.player_hamburger_button == false) {
-			document.querySelector('.custom-hamburger-menu')?.remove(); 
+			document.querySelector('.custom-hamburger-menu')?.remove?.(); 
 			// Restoring the original padding:
-			document.querySelector('.html5-video-player')?.querySelector('.ytp-right-controls')?.style.paddingRight = '0';	}
+			const rightControls = document.querySelector('.html5-video-player')?.querySelector?.('.ytp-right-controls');
+			if (rightControls != null) rightControls.style.paddingRight = '0';	}
 		} /* else if (message.hasOwnProperty('mixer')) {
 			if (ImprovedTube.elements.player) {
 				  document.documentElement.setAttribute('it-response', JSON.stringify({

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -797,11 +797,11 @@ ImprovedTube.playerPopupButton = function () {
 						if (videoLink && videoLink.href.match(ImprovedTube.regex.video_id)[1] !== videoID) this.location.search = this.location.search.replace(/(\?)list=[^&]+&|&list=[^&]+/, '$1');
 					}, {passive: true, once: true});
 				}
+				//~ change focused tab to URL-less popup
 				ImprovedTube.messages.send({
 					action: 'popup player',
-					width: player.offsetWidth,
-					height: player.offsetHeight,
-					title: document.title
+					width: ytPlayer.offsetWidth,
+					height: ytPlayer.offsetHeight
 				});
 			},
 			title: 'Popup'

--- a/js&css/web-accessible/www.youtube.com/playlist.js
+++ b/js&css/web-accessible/www.youtube.com/playlist.js
@@ -165,13 +165,33 @@ ImprovedTube.playlistPopupCreateButton = function (playlistID, altButtonStyle, c
 			const videoURL = ImprovedTube.elements.player?.getVideoUrl();
 			if (videoURL != null && ImprovedTube.regex.video_id.test(videoURL)) {
 				ImprovedTube.elements.player.pauseVideo();
-				window.open(`${location.protocol}//www.youtube.com/embed/${videoURL.match(ImprovedTube.regex.video_id)[1]}?autoplay=${(ImprovedTube.storage.player_autoplay ?? true) ? '1' : '0'}&start=${videoURL.match(ImprovedTube.regex.video_time)?.[1] ?? '0'}&list=${this.dataset.list}`, '_blank', `directories=no,toolbar=no,location=no,menubar=no,status=no,titlebar=no,scrollbars=no,resizable=no,width=${ImprovedTube.elements.player.offsetWidth ?? innerWidth},height=${ImprovedTube.elements.player.offsetHeight ?? innerHeight}`);
+				const listID = this.dataset.list,
+					videoID = videoURL.match(ImprovedTube.regex.video_id)[1],
+					popup = window.open(`${location.protocol}//www.youtube.com/embed/${videoID}?autoplay=${(ImprovedTube.storage.player_autoplay ?? true) ? '1' : '0'}&start=${videoURL.match(ImprovedTube.regex.video_time)?.[1] ?? '0'}&list=${listID}`, '_blank', `directories=no,toolbar=no,location=no,menubar=no,status=no,titlebar=no,scrollbars=no,resizable=no,width=${ImprovedTube.elements.player.offsetWidth ?? innerWidth},height=${ImprovedTube.elements.player.offsetHeight ?? innerHeight}`);
 				//! If the video is not in the playlist or not within the first 200 entries, then it automatically selects the first video in the list.
 				//! But this is okay since this button is mainly for the playlist, not the video (see the video popup button in player.js).
+				popup.addEventListener('load', function () {
+					"use strict";
+					//~ check if the video ID in the link of the video title matches the original video ID in the URL and if not reload as a videoseries/playlist (without the videoID and start-time).
+					const videoLink = this.document.querySelector('div#player div.ytp-title-text>a[href]');
+					if (videoLink && videoLink.href.match(ImprovedTube.regex.video_id)[1] !== videoID) this.location.href = `${location.protocol}//www.youtube.com/embed/videoseries?autoplay=${(ImprovedTube.storage.player_autoplay ?? true) ? '1' : '0'}&list=${listID}`;
+				}, {passive: true, once: true});
 			} else window.open(`${location.protocol}//www.youtube.com/embed/videoseries?autoplay=${(ImprovedTube.storage.player_autoplay ?? true) ? '1' : '0'}&list=${this.dataset.list}`, '_blank', `directories=no,toolbar=no,location=no,menubar=no,status=no,titlebar=no,scrollbars=no,resizable=no,width=${innerWidth},height=${innerHeight}`);
+			//~ change focused tab to URL-less popup
+			ImprovedTube.messages.send({
+				action: 'popup player',
+				width: ImprovedTube.elements.player?.offsetWidth ?? innerWidth,
+				height: ImprovedTube.elements.player?.offsetHeight ?? innerHeight
+			});
 		} : function (event) {
 			"use strict";
 			window.open(`${location.protocol}//www.youtube.com/embed/videoseries?autoplay=${(ImprovedTube.storage.player_autoplay ?? true) ? '1' : '0'}&list=${this.dataset.list}`, '_blank', `directories=no,toolbar=no,location=no,menubar=no,status=no,titlebar=no,scrollbars=no,resizable=no,width=${innerWidth},height=${innerHeight}`);
+			//~ change focused tab to URL-less popup
+			ImprovedTube.messages.send({
+				action: 'popup player',
+				width: window.innerWidth,
+				height: window.innerHeight
+			});
 		},
 		true
 	);


### PR DESCRIPTION
## [1] A quick fix for a recent commit (e6a15c50e079ac58e82599757b21e381f755f38f) for #1842 

<https://github.com/code-charity/youtube/blob/ca19c6ee60c7ffdb5ff420bb7264ae35cfcfa03d/js%26css/web-accessible/core.js#L273-L275>

When the first query selector for `.custom-hamburger-menu` fails, there is an optional chaining (`?.`) with `remove`, but the `()` comes after that, so it could be that it's trying to call `null()` with yields an error and the rest of the extension does not load...

With the second selector, everything's fine until it could be `null.paddingRight`, which is a problem, but even with an `?.` there, it can be `null = '0'`, which is, of course, also an error, so you need a temporary variable to check for null before setting it to something:

```JavaScript
// [...]
document.querySelector('.custom-hamburger-menu')?.remove?.(); 
// Restoring the original padding:
const rightControls = document.querySelector('.html5-video-player')?.querySelector?.('.ytp-right-controls');
if (rightControls != null) rightControls.style.paddingRight = '0';      }
// [...]
```

## [2] Updated URL-less window popup from 7fbb43f03c77de06bc586fc49b0938a50ae6718a

Removed the title from the event calls since the window title automatically gets overwritten when the page loads.

Fixed: the variable named `player` in `player.js` to its correct name: `ytPlayer` (noticed this because the opened window had 0 width & height xD).

## [3] Added URL-less popup window to playlist popup button

## [4] Fixed video start-time of playlist popup

When the video opened is > 200th in the playlist, it uses the first video in the playlist (as expected), but it still has the same start-time as the initial video, so it could potentially skip to the end and immediately play the next, video for no _apparent_ reason.

 (now it removes the start time and video whenever that is detected).
