### PR TITLE
resolved: toggle cards shortcut working

### DIFF
--- a/js&css/web-accessible/www.youtube.com/shortcuts.js
+++ b/js&css/web-accessible/www.youtube.com/shortcuts.js
@@ -706,7 +706,19 @@ ImprovedTube.shortcutStatsForNerds = function () {
 ------------------------------------------------------------------------------*/
 
 ImprovedTube.shortcutToggleCards = function () {
-	document.documentElement.toggleAttribute('it-player-hide-cards');
+    // console.log('Shortcut pressed'); // Check if the shortcut is triggered
+    
+    // Get the end screen div
+    var endScreenDiv = document.querySelector('.html5-endscreen');
+    
+    // Check if the end screen div exists
+    if (endScreenDiv) {
+        // Toggle the visibility of the end screen div
+        endScreenDiv.style.display = (endScreenDiv.style.display !== 'none') ? 'none' : 'block';
+        // console.log('Toggled'); // Check if the end screen is toggled
+    } else {
+        console.log('End screen div not found');
+    }
 };
 
 


### PR DESCRIPTION
Resolving Issue: #1845 
Hello, @ImprovedTube  , this PR is created to resolve the issue of toggling cards coming up at the end of youtube video.

Here is a detailed video as a result of changes done:
[Toggle Cards.webm](https://github.com/code-charity/youtube/assets/47809197/c2b584a3-8433-4ee4-81ac-851ac3e255f4)


**How it works:**
- Go to Shortcuts
- Create a shortcut for Toggle cards
- Now play any youtube video
- When toggling cards show, press shortcut it will hide, press again they will show (Toggling functionality perfectly working now)

Have a look, and please merge this PR, feel free to share suggestions if any.