### PR TITLE
feat: hide video title on fullscreen

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1129,5 +1129,8 @@
     },
     "openNewTab": {
         "message": "Open in new tab"
+    },
+    "hideVideoTitleFullScreen": {
+        "message": "Hide video title in fullscreen"
     }
 }

--- a/js&css/extension/init.js
+++ b/js&css/extension/init.js
@@ -44,6 +44,7 @@ extension.events.on('init', function () {
 	extension.features.relatedVideos();
 	extension.features.comments();
 	extension.features.openNewTab();
+	extension.features.hideVideoTitleFullScreen();
 	bodyReady();
 });
 

--- a/js&css/extension/www.youtube.com/appearance/player/player.js
+++ b/js&css/extension/www.youtube.com/appearance/player/player.js
@@ -8,3 +8,23 @@
 #
 --------------------------------------------------------------*/
 
+
+/*--------------------------------------------------------------
+#  HIDE VIDEO TITLE IN FULLSCREEN
+--------------------------------------------------------------*/
+
+extension.features.hideVideoTitleFullScreen = function (){
+    document.addEventListener('fullscreenchange', function (){
+        if(document.fullscreenElement){
+            const youtubeTitle = document.querySelector(".ytp-title-text > a");
+    
+            if(youtubeTitle){
+                if (extension.storage.get("hide_video_title_fullScreen") === true) {
+                    youtubeTitle.style.display = "none";
+                }else{
+                    youtubeTitle.style.display = "block";
+                }
+            }
+        }
+    });
+}

--- a/menu/skeleton-parts/appearance.js
+++ b/menu/skeleton-parts/appearance.js
@@ -384,6 +384,10 @@ extension.skeleton.main.layers.section.appearance.on.click.player = {
 				component: "switch",
 				text: "hideScrollForDetails",
 				tags: "remove,hide"
+			},
+			hide_video_title_fullScreen: {
+				component: "switch",
+				text: "hideVideoTitleFullScreen",
 			}
 		}
 	}


### PR DESCRIPTION
Issue #1677

feature added in appearrance -> player -> hide video title in fullscreen

It will hide the video title when the video is fullscreen and the option is enabled. Currently, this feature works for all videos, not for a category of videos

![Capture](https://github.com/code-charity/youtube/assets/66458004/62be4aa9-9ab1-4fb4-8602-a00f28c1a299)
