### PR TITLE
Update player.css to get rid of top and bottom margins on 16:9 aspect ratio using max width

### DIFF
--- a/js&css/extension/www.youtube.com/appearance/player/player.css
+++ b/js&css/extension/www.youtube.com/appearance/player/player.css
@@ -388,7 +388,7 @@ html[data-page-type=video][it-player-size='max_width'] ytd-watch-flexy:not([full
     justify-content: center !important}
 	
 html[data-page-type=video][it-player-size='max_width'] {
-	--it-player-size: 100vh;}
+	--it-player-size: 86vh;}
 
 html[data-page-type=video][it-player-size='max_width'] .ytp-fit-cover-video .html5-main-video {
 	object-fit: contain !important;}


### PR DESCRIPTION
Shrinks the player's height when in Max. Width within the page mode so there aren't black bars that continue above and below the video. Only works properly when viewing a 16:9 video within a browser window with the same aspect ratio Will have small black bars if the browser is maximised with the task bar underneath it. Should NOT be a permanent solution. The player should resize according to the video, not the other way round.