### PR TITLE
IT/1959 Loop/Repeat Parity

### DIFF
--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -347,14 +347,11 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
             var otherButton = document.querySelector('#it-repeat-button');
 
             function matchLoopState(opacity) {
-                var otherButton = document.querySelector('#it-repeat-button');
-                if (otherButton) {
+                if (ImprovedTube.storage.player_repeat_button === true) {
+                    var otherButton = document.querySelector('#it-repeat-button');
                     otherButton.children[0].style.opacity = opacity;
-                    svg.style.opacity = opacity;
                 }
-                else {
-                    svg.style.opacity = opacity;
-                }
+                svg.style.opacity = opacity;
             }
 
 			button.onclick = function () {
@@ -373,11 +370,13 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
 			svg.appendChild(path); 	button.appendChild(svg);
 			section.insertAdjacentElement('afterend', button)
 
-            if(otherButton && otherButton.children[0].style.opacity === '1') {
-                var video = ImprovedTube.elements.video;
-                matchLoopState('1');
-                if (!video.hasAttribute('loop')) {
-                    video.setAttribute('loop', '');
+            if(ImprovedTube.storage.player_repeat_button === true) {
+                if (document.querySelector('#it-repeat-button').style.opacity === '1') {
+                    matchLoopState('1');
+                    var video = ImprovedTube.elements.video;
+                    if (!video.hasAttribute('loop')) {
+                        video.setAttribute('loop', '');
+                    }
                 }
             }
 		}

--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -340,9 +340,21 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
 
 			button.className = 'improvedtube-player-button';
 			button.dataset.tooltip = 'Loop';
-			svg.style.opacity = '.5';
+            svg.style.opacity = '.5';
 			svg.setAttributeNS(null, 'viewBox', '0 0 24 24');
 			path.setAttributeNS(null, 'd', 'M7 7h10v3l4-4-4-4v3H5v6h2V7zm10 10H7v-3l-4 4 4 4v-3h12v-6h-2v4zm-4-2V9h-1l-2 1v1h1.5v4H13z');
+            var otherButton = document.querySelector('#it-repeat-button');
+
+            function matchLoopState(opacity) {
+                var otherButton = document.querySelector('#it-repeat-button');
+                if (otherButton) {
+                    otherButton.children[0].style.opacity = opacity;
+                    svg.style.opacity = opacity;
+                }
+                else {
+                    svg.style.opacity = opacity;
+                }
+            }
 
 			button.onclick = function () {
 				var video = ImprovedTube.elements.video,
@@ -350,17 +362,23 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
 
 				if (video.hasAttribute('loop')) {
 					video.removeAttribute('loop');
-
-					svg.style.opacity = '.5';
+                    matchLoopState('.5')
 				} else if (!/ad-showing/.test(ImprovedTube.elements.player.className)) {
 					video.setAttribute('loop', '');
-
-					svg.style.opacity = '1';
+                    matchLoopState('1')
 				}
 			};
-
+            
 			svg.appendChild(path); 	button.appendChild(svg);
 			section.insertAdjacentElement('afterend', button)
+
+            if(otherButton && otherButton.children[0].style.opacity === '1') {
+                var video = ImprovedTube.elements.video;
+                matchLoopState('1');
+                if (!video.hasAttribute('loop')) {
+                    video.setAttribute('loop', '');
+                }
+            }
 		}
 			if (this.storage.below_player_pip !== false) {
 			var button = document.createElement('button'),

--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -339,6 +339,7 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
 				path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
 
 			button.className = 'improvedtube-player-button';
+            button.id = 'it-below-player-loop';
 			button.dataset.tooltip = 'Loop';
             svg.style.opacity = '.5';
 			svg.setAttributeNS(null, 'viewBox', '0 0 24 24');

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -681,10 +681,10 @@ ImprovedTube.playerRepeatButton = function (node) {
 		svg.setAttributeNS(null, 'viewBox', '0 0 24 24');
 		path.setAttributeNS(null, 'd', 'M7 7h10v3l4-4-4-4v3H5v6h2V7zm10 10H7v-3l-4 4 4 4v-3h12v-6h-2v4zm-4-2V9h-1l-2 1v1h1.5v4H13z');
 		svg.appendChild(path);
-		var otherButton = document.querySelector('.improvedtube-player-button');
+		var otherButton = document.querySelector('#it-below-player-loop');
 
 		function matchLoopState(opacity) {
-			var otherButton = document.querySelector('.improvedtube-player-button');
+			var otherButton = document.querySelector('#it-below-player-loop');
 			if (otherButton) {
 				otherButton.children[0].style.opacity = opacity;
 				svg.style.opacity = opacity;

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -681,17 +681,13 @@ ImprovedTube.playerRepeatButton = function (node) {
 		svg.setAttributeNS(null, 'viewBox', '0 0 24 24');
 		path.setAttributeNS(null, 'd', 'M7 7h10v3l4-4-4-4v3H5v6h2V7zm10 10H7v-3l-4 4 4 4v-3h12v-6h-2v4zm-4-2V9h-1l-2 1v1h1.5v4H13z');
 		svg.appendChild(path);
-		var otherButton = document.querySelector('#it-below-player-loop');
 
 		function matchLoopState(opacity) {
-			var otherButton = document.querySelector('#it-below-player-loop');
-			if (otherButton) {
+			if (ImprovedTube.storage.below_player_loop !== false) {
+				var otherButton = document.querySelector('#it-below-player-loop');
 				otherButton.children[0].style.opacity = opacity;
-				svg.style.opacity = opacity;
 			}
-			else {
-				svg.style.opacity = opacity;
-			}
+			svg.style.opacity = opacity;
 		}
 		
 		this.createPlayerButton({
@@ -711,11 +707,13 @@ ImprovedTube.playerRepeatButton = function (node) {
 			},
 			title: 'Repeat',
 		});
-
-		if(otherButton && otherButton.children[0].style.opacity === '1') {
-			matchLoopState('1');
-			if (!video.hasAttribute('loop')) {
-				video.setAttribute('loop', '');
+		if(ImprovedTube.storage.below_player_loop !== false) {
+			var otherButton = document.querySelector('#it-below-player-loop');
+			if (document.querySelector('#it-below-player-loop').style.opacity === '1') {
+				matchLoopState('1');
+				if (!video.hasAttribute('loop')) {
+					video.setAttribute('loop', '');
+				}
 			}
 		}
 

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -680,32 +680,50 @@ ImprovedTube.playerRepeatButton = function (node) {
 
 		svg.setAttributeNS(null, 'viewBox', '0 0 24 24');
 		path.setAttributeNS(null, 'd', 'M7 7h10v3l4-4-4-4v3H5v6h2V7zm10 10H7v-3l-4 4 4 4v-3h12v-6h-2v4zm-4-2V9h-1l-2 1v1h1.5v4H13z');
-
 		svg.appendChild(path);
+		var otherButton = document.querySelector('.improvedtube-player-button');
 
+		function matchLoopState(opacity) {
+			var otherButton = document.querySelector('.improvedtube-player-button');
+			if (otherButton) {
+				otherButton.children[0].style.opacity = opacity;
+				svg.style.opacity = opacity;
+			}
+			else {
+				svg.style.opacity = opacity;
+			}
+		}
+		
 		this.createPlayerButton({
 			id: 'it-repeat-button',
 			child: svg,
+			opacity: 1,
 			onclick: function () {
 				var video = ImprovedTube.elements.video;
 
 				if (video.hasAttribute('loop')) {
 					video.removeAttribute('loop');
-
-					this.style.opacity = '.5';
+					matchLoopState('.5')
 				} else if (!/ad-showing/.test(ImprovedTube.elements.player.className)) {
 					video.setAttribute('loop', '');
-
-					this.style.opacity = '1';
+					matchLoopState('1')
 				}
 			},
-			title: 'Repeat'
+			title: 'Repeat',
 		});
+
+		if(otherButton && otherButton.children[0].style.opacity === '1') {
+			matchLoopState('1');
+			if (!video.hasAttribute('loop')) {
+				video.setAttribute('loop', '');
+			}
+		}
 
 		if (this.storage.player_always_repeat === true) {
 			setTimeout(function () {
 				ImprovedTube.elements.video.setAttribute('loop', '');
 				ImprovedTube.elements.buttons['it-repeat-styles'].style.opacity = '1';
+				matchLoopState('1');
 			}, 100);
 		}
 	}  


### PR DESCRIPTION
Improved the sync of the repeat and loop buttons to be visually and functionally linked when the user turns both buttons on. Before, I noticed that when one was set to on and the other was then added, the visual indicators of if the video would loop or not was indiscernable. I fixed this by detecting if the other button was active and then setting their opacities to be the same based on the current setting of the video (if looping or not). I did this through the onClick functions for each button respectfully, as well as adding an if statement check when the button is first added to ensure it is visually and functionally in sync.