### PR TITLE
Issue #1962 Fine Volume Control -- added CSS border for easier textbox identification

### DIFF
--- a/menu/satus.css
+++ b/menu/satus.css
@@ -1319,7 +1319,8 @@ As our Syntax markup isnt read for <textarea>, is it?
 .satus-slider__input[type='text'] {
     appearance: none;
     background: transparent;
-    border: none;
+    border: 1px solid;
+    border-radius: 4px;
     color: inherit;
     font: inherit;
     padding: 0;


### PR DESCRIPTION
A black border around slider textboxes was added to help users identify the component as a textbox rather than just an item showing the current slider level. 