### PR TITLE
Disable Video Preview On Hover Option

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -131,7 +131,7 @@
 "device":{"message":"Device"},
 "dim":{"message":"Dim"},
 "disabled":{"message":"Disabled"},
-"disableHoverVideo":{"message":"Disable video playback on hover"},
+"disableThumbnailPlayback":{"message":"Disable video playback on hover"},
 "dislike":{"message":"Dislike"},
 "displayDayOfTheWeak":{"message":"Display day of the week"},
 "doNotChange":{"message":"Don't change"},

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -131,6 +131,7 @@
 "device":{"message":"Device"},
 "dim":{"message":"Dim"},
 "disabled":{"message":"Disabled"},
+"disableHoverVideo":{"message":"Disable video playback on hover"},
 "dislike":{"message":"Dislike"},
 "displayDayOfTheWeak":{"message":"Display day of the week"},
 "doNotChange":{"message":"Don't change"},

--- a/js&css/extension/init.js
+++ b/js&css/extension/init.js
@@ -39,7 +39,7 @@ extension.events.on('init', function () {
 	extension.features.confirmationBeforeClosing();
 	extension.features.defaultContentCountry();
 	extension.features.popupWindowButtons();
-	extension.features.disableHoverVideo();
+	extension.features.disableThumbnailPlayback();
 	extension.features.markWatchedVideos();
 	extension.features.relatedVideos();
 	extension.features.comments();

--- a/js&css/extension/init.js
+++ b/js&css/extension/init.js
@@ -39,6 +39,7 @@ extension.events.on('init', function () {
 	extension.features.confirmationBeforeClosing();
 	extension.features.defaultContentCountry();
 	extension.features.popupWindowButtons();
+	extension.features.disableHoverVideo();
 	extension.features.markWatchedVideos();
 	extension.features.relatedVideos();
 	extension.features.comments();

--- a/js&css/extension/www.youtube.com/general/general.js
+++ b/js&css/extension/www.youtube.com/general/general.js
@@ -515,18 +515,17 @@ extension.features.thumbnailsQuality = function (anything) {
 /*--------------------------------------------------------------
 # DISABLE VIDEO PLAYBACK ON HOVER
 --------------------------------------------------------------*/
-extension.features.disableHoverVideo = function (event) {
+extension.features.disableThumbnailPlayback = function (event) {
     if (event instanceof Event) {
-        if (extension.storage.get('disable_thumbnail_playback') === true && 
-            event.composedPath().some(elem => (elem.matches != null ? elem.matches("#content ytd-rich-item-renderer") : false)
+        if (event.composedPath().some(elem => (elem.matches != null ? elem.matches("#content ytd-rich-item-renderer") : false)
         )) {
             event.stopImmediatePropagation();
         }
     } else {
         if (extension.storage.get('disable_thumbnail_playback') === true) {
-            window.addEventListener('mouseenter', this.disableHoverVideo, true);
+            window.addEventListener('mouseenter', this.disableThumbnailPlayback, true);
         } else {
-            window.removeEventListener('mouseenter', this.disableHoverVideo, true);
+            window.removeEventListener('mouseenter', this.disableThumbnailPlayback, true);
         }
     }
 };

--- a/js&css/extension/www.youtube.com/general/general.js
+++ b/js&css/extension/www.youtube.com/general/general.js
@@ -512,6 +512,24 @@ extension.features.thumbnailsQuality = function (anything) {
 	}
 };
 
+/*--------------------------------------------------------------
+# DISABLE VIDEO PLAYBACK ON HOVER
+--------------------------------------------------------------*/
+extension.features.disableHoverVideo = function (event) {
+    if (event instanceof Event) {
+        if (extension.storage.get('disable_thumbnail_playback') === true && 
+            event.composedPath().some(elem => (elem.matches != null ? elem.matches("#content ytd-rich-item-renderer") : false)
+        )) {
+            event.stopImmediatePropagation();
+        }
+    } else {
+        if (extension.storage.get('disable_thumbnail_playback') === true) {
+            window.addEventListener('mouseenter', this.disableHoverVideo, true);
+        } else {
+            window.removeEventListener('mouseenter', this.disableHoverVideo, true);
+        }
+    }
+};
 
 /*--------------------------------------------------------------
 # OPEN VIDEOS IN A NEW TAB

--- a/menu/skeleton-parts/general.js
+++ b/menu/skeleton-parts/general.js
@@ -176,6 +176,10 @@ extension.skeleton.main.layers.section.general = {
 					text: 'hideAnimatedThumbnails',
 					tags: 'preview'
 				},
+                disable_thumbnail_playback: {
+					component: 'switch',
+					text: 'disableHoverVideo',
+				},
 				popup_window_buttons: {
 					component: 'switch',
 					text: 'popupWindowButtons',

--- a/menu/skeleton-parts/general.js
+++ b/menu/skeleton-parts/general.js
@@ -178,7 +178,7 @@ extension.skeleton.main.layers.section.general = {
 				},
                 disable_thumbnail_playback: {
 					component: 'switch',
-					text: 'disableHoverVideo',
+					text: 'disableThumbnailPlayback',
 				},
 				popup_window_buttons: {
 					component: 'switch',


### PR DESCRIPTION
Adds an option to disable video playback when hovering over thumbnails on the home page.

(Fixes #1785)

**How it works**:
Instead of using D-Rekk's solutions of `getEventListeners(node)` or `elem.remove()`, this solution adds an event listener to the global window object, listening for global `mouseenter` events.

Then, if the event's `composedPath` property contains an element matching "#content dtd-rich-item-renderer" (which selects the thumbnail elements that listen for the mouseenter event), the event is immediately stopped with `event.stopImmediatePropagation();`.

The event also runs before YouTube's native events by telling the event listener to trigger during the capturing phase instead of the bubbling phase.

**Notes**:
The second part of the issue (for recommended video previews in the sidebar) should already be covered by the "Hide animated thumbnails" option.

This is my first commit to the codebase, so please let me know if there are any changes that need to be made to integrate it!