### PR TITLE
Fix #2067: Shorts not hiding in History tab

### DIFF
--- a/js&css/extension/www.youtube.com/general/general.css
+++ b/js&css/extension/www.youtube.com/general/general.css
@@ -53,6 +53,14 @@ html[it-pathname='/feed/trending'][it-remove-trending-shorts="true"] ytd-reel-sh
 		display: none !important;
 	}
 }
+
+html[it-pathname='/feed/trending'][it-remove-trending-shorts="true"] ytd-video-renderer:has(ytd-thumbnail-overlay-time-status-renderer[overlay-style="SHORTS"]) {
+	display: none !important;
+}
+html[it-pathname='/feed/history'][it-remove-history-shorts="true"] ytd-video-renderer:has(ytd-thumbnail-overlay-time-status-renderer[overlay-style="SHORTS"]) {
+	display: none !important;
+}
+
 /*
 html[it-pathname='/feed/trending'][it-remove-trending-shorts="true"] ytd-rich-section-renderer:has(ytd-rich-grid-slim-media[is-short]),
 html[it-pathname='/feed/history'][it-remove-history-shorts="true"] ytd-rich-section-renderer:has(ytd-rich-grid-slim-media[is-short]),


### PR DESCRIPTION
Previously, Shorts within the YouTube History and Trending pages were not hidden when they appeared outside of the Shorts section.

This fix addresses the issue by implementing the hiding logic uniformly across all sections within the History and Trending tabs. Now, Shorts are correctly hidden regardless of the section they appear in.

Changes Made:
- Inserted the hiding logic in History and Treding tabs to ensure Shorts are hidden consistently.

This resolves the issue reported in #2067.