### PR TITLE
themes.js never ending optimizations

### DIFF
--- a/js&css/web-accessible/init.js
+++ b/js&css/web-accessible/init.js
@@ -94,7 +94,9 @@ ImprovedTube.init = function () {
 
 	window.addEventListener('yt-player-updated', yt_player_updated);
 	this.channelCompactTheme();
-	this.setTheme();
+	if (this.storage.theme) {
+		this.setTheme();
+	}
 	this.playerOnPlay();
 	this.playerSDR();
 	this.shortcuts();
@@ -136,7 +138,6 @@ document.addEventListener('yt-page-data-updated', function (event) {
 		ImprovedTube.playlistReverse();
 	}
 	ImprovedTube.playlistPopupUpdate();
-
 });
 
 window.addEventListener('load', function () {

--- a/js&css/web-accessible/www.youtube.com/themes.js
+++ b/js&css/web-accessible/www.youtube.com/themes.js
@@ -67,22 +67,19 @@ ImprovedTube.setTheme = function () {
 					'--yt-spec-base-background:' + primary_color + '!important;' +
 					'--yt-spec-raised-background:' + primary_color + '!important;' +
 					'--yt-spec-menu-background:' + primary_color + '!important;' +
-					'ytd-masthead { background-color:' + primary_color + '!important;}' +
 					'--yt-spec-inverted-background: #fff;' +
 					'}';
 
 				this.elements.my_colors = style;
 				document.documentElement.appendChild(style);
 				document.documentElement.removeAttribute('dark');
+				document.querySelector('ytd-masthead')?.removeAttribute('dark');
 				if (document.getElementById("cinematics")) {
 					document.getElementById("cinematics").style.visibility = 'hidden';
 					document.getElementById("cinematics").style.display = 'none !important';
 				}
-				if (document.querySelector('ytd-masthead')) {
-					document.querySelector('ytd-masthead').style.backgroundColor = ''+primary_color+'';
-				}
-			} else if (this.elements.my_colors) {
-				this.elements.my_colors.remove();
+			} else { //theoretically this will never be called
+				this.elements.my_colors?.remove();
 			}
 			break
 
@@ -91,14 +88,11 @@ ImprovedTube.setTheme = function () {
 			darkCookie = true;
 			document.documentElement.setAttribute('dark', '');
 			document.querySelector('ytd-masthead')?.setAttribute('dark', '');
-			document.querySelector('ytd-masthead')?.removeAttribute('style');
 			if (document.getElementById("cinematics")) {
 				document.getElementById('cinematics').style.visibility = 'visible';
 				document.getElementById('cinematics').style.display = 'none !important';
 			}
-			if (this.elements.my_colors) {
-				this.elements.my_colors.remove();
-			}
+			this.elements.my_colors?.remove();
 			break
 
 		case 'default':
@@ -109,7 +103,6 @@ ImprovedTube.setTheme = function () {
 		case 'desert':
 			document.documentElement.removeAttribute('dark');
 			document.querySelector('ytd-masthead')?.removeAttribute('dark');
-			document.querySelector('ytd-masthead')?.removeAttribute('style');
 			document.getElementById('cinematics')?.removeAttribute('style');
 			this.elements.my_colors?.remove();
 			break


### PR DESCRIPTION
get rid of setting hard style on ytd-masthead,
get rid of "ytd-masthead { background-color:' + primary_color + '!important;}", its already taken care of by defining --yt-spec-base-background
nicer removal of my_colors style
custom theme wasnt removing 'dark' Attribute from 'ytd-masthead'
cinematics style changes should also be converted into CSS