### PR TITLE
Add option to automatically disable captions in lyrics/karaoke videos #1235

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1148,6 +1148,9 @@
     "subtitles": {
         "message": "Subtitles"
     },
+    "RemoveSubtitlesForLyrics": {
+        "message": "Remove subtitles for lyrics"
+    },
     "sunset": {
         "message": "Sunset"
     },

--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -366,6 +366,7 @@ ImprovedTube.initPlayer = function () {
 		ImprovedTube.subtitlesCharacterEdgeStyle();
 		ImprovedTube.subtitlesFontOpacity();
 		ImprovedTube.subtitlesBackgroundOpacity();
+		ImprovedTube.subtitlesDisableLyrics();
 		ImprovedTube.playerQuality();
 		ImprovedTube.playerVolume();
 		if (this.storage.player_always_repeat === true) { ImprovedTube.playerRepeat(); }

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -416,6 +416,24 @@ ImprovedTube.subtitlesFontOpacity = function () {
 	}
 };
 /*------------------------------------------------------------------------------
+SUBTITLES DISABLE SUBTILES FOR LYRICS
+------------------------------------------------------------------------------*/
+ImprovedTube.subtitlesDisableLyrics = function () {
+	if (this.storage.subtitles_disable_lyrics === true) {
+		var player = this.elements.player,
+			button = this.elements.player_subtitles_button;
+
+		if (player && player.toggleSubtitles && button && button.getAttribute('aria-pressed') === 'true') {
+			// Music detection only uses 3 identifiers for Lyrics: lyrics, sing-along, karaoke.
+			// Easier to simply use those here. Can replace with music detection later.
+			const terms = ["sing?along", "karaoke", "lyric"];
+			if (terms.some(term => ImprovedTube.videoTitle().toLowerCase().includes(term))) {			
+				player.toggleSubtitles();
+			}									
+		}
+	}
+};
+/*------------------------------------------------------------------------------
 UP NEXT AUTOPLAY
 ------------------------------------------------------------------------------*/
 ImprovedTube.upNextAutoplay = function () {

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -680,6 +680,10 @@ extension.skeleton.main.layers.section.player.on.click = {
 						min: 0,
 						max: 100,
 						step: 1
+					},
+					subtitles_disable_lyrics: {
+						component: 'switch',
+						text: 'RemoveSubtitlesForLyrics'
 					}
 				}
 			}


### PR DESCRIPTION
I've added an option that toggles captions when a Lyrics/karaoke video is detected. This fixes #1235 . Should note, that with most music videos, the captions get automatically disabled anyways, but this is extra for whenever it has not been configured.