### PR TITLE
Fix issue 2044

### DIFF
--- a/menu/index.html
+++ b/menu/index.html
@@ -18,6 +18,7 @@
 <script src="skeleton-parts/themes.js"></script>
 <script src="skeleton-parts/blocklist.js"></script>
 <script src="skeleton-parts/analyzer.js"></script>
+<script src="skeleton-parts/dark-light-switch.js"></script>
 <link rel="stylesheet" href="satus.css">
 <link rel="stylesheet" href="styles/home.css">
 <link rel="stylesheet" href="styles/appearance.css">

--- a/menu/skeleton-parts/dark-light-switch.js
+++ b/menu/skeleton-parts/dark-light-switch.js
@@ -1,0 +1,57 @@
+const isDark = () => {
+    const themeElement = satus.storage.get('theme')
+    const lightThemes = ['desert', 'dawn', 'plain', 'default']
+    const darkThemes = ['sunset', 'night', 'dark', 'black']
+    return darkThemes.includes(themeElement)
+}
+
+extension.skeleton.header.sectionEnd.darkLightSwitch.svgSun.on = {
+    render: function () {
+        console.log(satus.storage.get('lastLightTheme') + " " + satus.storage.get('lastDarkTheme'))
+        if(isDark()) {
+            this.style.display = 'none'
+        }
+    }
+}
+
+extension.skeleton.header.sectionEnd.darkLightSwitch.svgMoon.on = {
+    render: function () {
+        if(!isDark()) {
+            this.style.display = 'none'
+        }
+    }
+}
+
+extension.skeleton.header.sectionEnd.darkLightSwitch.on = {
+    click: function () {
+        if(isDark()) {
+            if (satus.storage.get('lastLightTheme')) {
+                satus.storage.set('theme', satus.storage.get("lastLightTheme"))
+            } else {
+                satus.storage.set('theme', 'default')
+            }
+            document.getElementById('dark-light-switch-icon-sun').style.display = ''
+            document.getElementById('dark-light-switch-icon-moon').style.display = 'none'
+        } else {
+            if (satus.storage.get('lastDarkTheme')) {
+                satus.storage.set('theme', satus.storage.get("lastDarkTheme"))
+            } else {
+                satus.storage.set('theme', 'black')
+            }
+            document.getElementById('dark-light-switch-icon-sun').style.display = 'none'
+            document.getElementById('dark-light-switch-icon-moon').style.display = ''
+        }
+    }
+}
+
+satus.storage.onchanged(() => {
+    if(isDark()) {
+        document.getElementById('dark-light-switch-icon-sun').style.display = 'none'
+        document.getElementById('dark-light-switch-icon-moon').style.display = ''
+        satus.storage.set('lastDarkTheme', satus.storage.get('theme'))
+    } else {
+        document.getElementById('dark-light-switch-icon-sun').style.display = ''
+        document.getElementById('dark-light-switch-icon-moon').style.display = 'none'
+        satus.storage.set('lastLightTheme', satus.storage.get('theme'))
+    }
+}) 

--- a/menu/skeleton.js
+++ b/menu/skeleton.js
@@ -65,11 +65,63 @@ extension.skeleton.header = {
 		component: 'section',
 		variant: 'align-end',
 
+		darkLightSwitch: {
+			component: 'button',
+			variant: 'icon',
+
+			svgSun: {
+				component: "svg",
+				attr: {
+					'viewBox': '0 0 24 24',
+					'stroke': 'currentcolor',
+					'stroke-linecap': 'round',
+					'stroke-linejoin': 'round',
+					'stroke-width': '1.25',
+					'fill': 'none'
+				},
+				id: 'dark-light-switch-icon-sun',
+				
+				circle: {
+					component: 'circle',
+					attr: {
+						'cx': '12',
+						'cy': '12',
+						'r': '5'
+					}
+				},
+				path0: { component: 'path', attr: { d: 'M12.00 17.00 L12.00 21.00' } },
+				path1: { component: 'path', attr: { d: 'M8.46 15.54 L5.64 18.36' } },
+				path2: { component: 'path', attr: { d: 'M7.00 12.00 L3.00 12.00' } },
+				path3: { component: 'path', attr: { d: 'M8.46 8.46 L5.64 5.64' } },
+				path4: { component: 'path', attr: { d: 'M12.00 7.00 L12.00 3.00' } },
+				path5: { component: 'path', attr: { d: 'M15.54 8.46 L18.36 5.64' } },
+				path6: { component: 'path', attr: { d: 'M17.00 12.00 L21.00 12.00' } },
+				path7: { component: 'path', attr: { d: 'M15.54 15.54 L18.36 18.36' } }
+			},
+			svgMoon: {
+				component: "svg",
+				attr: {
+					'viewBox': '0 0 24 24',
+					'stroke': 'currentcolor',
+					'stroke-linecap': 'round',
+					'stroke-linejoin': 'round',
+					'stroke-width': '1.25',
+					'fill': 'none'
+				},
+				id: 'dark-light-switch-icon-moon',
+
+				path0: {component: 'path', attr: {d: 'M23,15 A11,11 0 0,1 9,1'}},
+				path1: {component: 'path', attr: {d: 'M9,1 A11,11 0 1,0 23,15'}}
+
+			}
+		},
 		search: {
 			component: 'button',
 			variant: 'icon',
-			on: {render: function () {
-				 this.click(); }				
+			on: {
+				render: function () {
+					this.click();
+				}
 			},
 
 			svg: {
@@ -190,7 +242,7 @@ extension.skeleton.main = {
 				}
 
 				return 'home';
-			} 
-		}, "frame"  : { component: 'iframe', class: 'frame',   attr: { 'src': 'https://improvedtube.com/wishes', 'style':'border: none;  bottom: 0px; overflow: hidden; width:326px; position:absolute; height:212px; left:-6px !important' } 	}		
+			}
+		}, "frame": { component: 'iframe', class: 'frame', attr: { 'src': 'https://improvedtube.com/wishes', 'style': 'border: none;  bottom: 0px; overflow: hidden; width:326px; position:absolute; height:212px; left:-6px !important' } }
 	}
 };


### PR DESCRIPTION
Add a light/dark mode icon on the left side of the search icon. 
When click on the icon, it switches between the light theme and the dark theme. 
The icon also changes to sun or moon, depends on the current theme color.
Four of the existing themes are categorized as light themes and the other four as dark themes. 
The custom theme is none of them and is not affected by any of them. It also remembers which theme color was used previously. 
When switching back to the light/dark mode, it switches to the previously used light/dark theme. 
https://github.com/code-charity/youtube/assets/37882796/4fe8a187-02f0-4439-b522-b8c574de7c36