### PR TITLE
Update satus.js limit writes to essential ones

### DIFF
--- a/menu/satus.js
+++ b/menu/satus.js
@@ -1765,8 +1765,6 @@ satus.components.colorPicker = function(component, skeleton) {
 			set: function(value) {
 				array = value;
 
-				this.parentNode.storage.value = array;
-
 				element.style.backgroundColor = 'rgb(' + value.join(',') + ')';
 			}
 		});
@@ -1894,6 +1892,7 @@ satus.components.colorPicker = function(component, skeleton) {
 								component = modal.parentElement;
 
 							component.color.value = component.skeleton.value || [0, 0, 0];
+							satus.storage.remove(component.storage.key);
 
 							modal.rendered.close();
 						}
@@ -1917,6 +1916,7 @@ satus.components.colorPicker = function(component, skeleton) {
 								component = modal.parentElement;
 
 							component.color.value = satus.color.hslToRgb(modal.value);
+							component.storage.value = component.color.value;
 
 							modal.rendered.close();
 						}

--- a/menu/satus.js
+++ b/menu/satus.js
@@ -777,11 +777,13 @@ satus.render = function(skeleton, container, property, childrenOnly, prepend, sk
 					set: function(val) {
 						value = val;
 
-						if (skeleton.storage !== false) {
-							satus.storage.set(key, val);
+						if (satus.storage.get(key) != val) {
+							if (skeleton.storage !== false) {
+								satus.storage.set(key, val);
+							}
+	
+							parent.dispatchEvent(new CustomEvent('change'));
 						}
-
-						parent.dispatchEvent(new CustomEvent('change'));
 					}
 				}
 			});

--- a/menu/satus.js
+++ b/menu/satus.js
@@ -1937,6 +1937,8 @@ satus.components.colorPicker = function(component, skeleton) {
 --------------------------------------------------------------*/
 
 satus.components.radio = function(component, skeleton) {
+	let value;
+
 	component.nativeControl = component.createChildElement('input', 'input');
 
 	component.createChildElement('i');
@@ -1954,10 +1956,10 @@ satus.components.radio = function(component, skeleton) {
 		component.nativeControl.value = skeleton.value;
 	}
 
-	component.storage.value = satus.storage.get(component.storage.key);
+	value = satus.storage.get(component.storage.key);
 
-	if (satus.isset(component.storage.value)) {
-		component.nativeControl.checked = component.storage.value === skeleton.value;
+	if (satus.isset(value)) {
+		component.nativeControl.checked = value === skeleton.value;
 	} else if (skeleton.checked) {
 		component.nativeControl.checked = true;
 	}

--- a/menu/satus.js
+++ b/menu/satus.js
@@ -983,13 +983,7 @@ satus.storage.set = function(key, value, callback) {
 		}
 	}
 
-	for (let key in this.data) {
-		if (typeof this.data[key] !== 'function') {
-			items[key] = this.data[key];
-		}
-	}
-
-	chrome.storage.local.set(items, function() {
+	chrome.storage.local.set({[key]: value}, function() {
 		satus.events.trigger('storage-set');
 
 		if (callback) {


### PR DESCRIPTION
Dont save storage if new value is same as old value. The way satus works the mere act of displaying for example themes performs useless redundant writes.
Stop radio from writing on every render
Actually save just the value saved, not everything
color picker no longer writes on every render