### PR TITLE
Fix Live Chat collapsing once storage loaded

### DIFF
--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -145,9 +145,9 @@ ImprovedTube.ytElementsHandler = function (node) {
 		}
 
 		ImprovedTube.elements.subscribe_button = node;
-	} else if (id === 'show-hide-button') {
-		this.elements.livechat.button = document.querySelector('[aria-label="Hide chat"]');
-		// console.log(document.querySelector('[aria-label="Hide chat"]'))
+	} else if (id === 'chat-messages') {
+		this.elements.livechat.button = document.querySelector('[aria-label="Close"]');
+		// console.log(document.querySelector('[aria-label="Close"]'))
 		this.livechat();
 	} else if (name === 'YTD-MASTHEAD') {
 		if (!this.elements.masthead) {

--- a/js&css/web-accessible/init.js
+++ b/js&css/web-accessible/init.js
@@ -101,6 +101,7 @@ ImprovedTube.init = function () {
 	this.youtubeLanguage();
 	this.myColors();
 	this.channelCompactTheme();
+	this.livechat();
 	
 	if (ImprovedTube.elements.player && ImprovedTube.elements.player.setPlaybackRate) {
 		ImprovedTube.videoPageUpdate();

--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -303,12 +303,12 @@ el.querySelector('*[target-id*=chapters]')?.removeAttribute('visibility');} }
 ------------------------------------------------------------------------------*/
 ImprovedTube.livechat = function () {
     if (this.storage.livechat === "collapsed") {
-		if (typeof isCollapsed === 'undefined') { var isCollapsed = false;   }
+        if (typeof isCollapsed === 'undefined') { var isCollapsed = false;   }
         if(ImprovedTube.elements.livechat && !isCollapsed){
             ImprovedTube.elements.livechat.button.click();
             isCollapsed = true 
         }
-  }  /* else{
+    }  /* else{
         if(isCollapsed){
             ImprovedTube.elements.livechat.button.click();
             isCollapsed = false


### PR DESCRIPTION
Handles #1910.

Fixes:
- addressing of the correct live-chat closing button element
- recalling of `livechat()` once storage got loaded (otherwise `storage.livechat` is `undefined` at this point in time)
- code indentation at one place

**One thing to note:** Terminology is now "closing" instead of "hiding". Not sure if this is important but wanted to hint on it. A "Show chat" button is still visible though, so it can be reopened again.