### PR TITLE
Update satus.js  include categories in search

### DIFF
--- a/menu/satus.js
+++ b/menu/satus.js
@@ -3131,7 +3131,7 @@ satus.user.device.connection = function() {
 --------------------------------------------------------------*/
 
 satus.search = function(query, object, callback) {
-	var elements = ['switch', 'select', 'slider', 'shortcut', 'radio', 'color-picker', 'label'],
+	var elements = ['switch', 'select', 'slider', 'shortcut', 'radio', 'color-picker', 'label', 'button'],
 		threads = 0,
 		results = {},
 		excluded = [


### PR DESCRIPTION
Has side effects. While buttons are returned now, clicking them does nothing at first glance - thats because they are doing their thing under the Search results.

This is bad and shouldnt be merged :)