### PR TITLE
Update search.js polish, bugs fixed, remember/restore last search query and position.

### DIFF
--- a/menu/satus.js
+++ b/menu/satus.js
@@ -1182,9 +1182,10 @@ satus.components.modal.confirm = function(component, skeleton) {
 				},
 				on: {
 					click: function() {
-						// no listeners for this Event currently exist in the codebase
-						this.modalProvider.dispatchEvent(new CustomEvent('cancel'));
-						this.modalProvider.skeleton.cancel();
+						// cancel() is optional in modal.confirm simplified variant
+						if (this.modalProvider.skeleton.cancel && satus.isFunction(this.modalProvider.skeleton.cancel)) {
+							this.modalProvider.skeleton.cancel();
+						}
 						this.modalProvider.close();
 					}
 				}
@@ -1197,9 +1198,10 @@ satus.components.modal.confirm = function(component, skeleton) {
 				},
 				on: {
 					click: function() {
-						// no listeners for this Event currently exist in the codebase
-						this.modalProvider.dispatchEvent(new CustomEvent('confirm'));
-						this.modalProvider.skeleton.ok();
+						// ok() is optional in modal.confirm simplified variant
+						if (this.modalProvider.skeleton.ok && satus.isFunction(this.modalProvider.skeleton.ok)) {
+							this.modalProvider.skeleton.ok();
+						}
 						this.modalProvider.close();
 					}
 				}

--- a/menu/satus.js
+++ b/menu/satus.js
@@ -1947,7 +1947,7 @@ satus.components.colorPicker = function(component, skeleton) {
 					}
 				}
 			}
-		}, this.baseProvider.layers[0]);
+		}, this.baseProvider);
 	});
 };
 /*--------------------------------------------------------------

--- a/menu/satus.js
+++ b/menu/satus.js
@@ -1310,6 +1310,10 @@ satus.components.textField = function(component, skeleton) {
 		component.syntax.set(skeleton.syntax);
 	}
 
+	if (component.skeleton.storage) {
+		component.value = component.storage.value;
+	}
+
 	selection.setAttribute('disabled', '');
 
 	line_numbers.update = function() {
@@ -1418,7 +1422,9 @@ satus.components.textField = function(component, skeleton) {
 	input.addEventListener('input', function() {
 		var component = this.parentNode.parentNode;
 
-		component.storage.value = this.value;
+		if (component.skeleton.storage) {
+			component.storage.value = this.value;
+		}
 
 		component.lineNumbers.update();
 		component.pre.update();
@@ -1441,8 +1447,6 @@ satus.components.textField = function(component, skeleton) {
 		this.pre.update();
 		this.cursor.update();
 	});
-
-	component.value = component.storage.value || '';
 
 	component.addEventListener('render', function() {
 		component.lineNumbers.update();

--- a/menu/satus.js
+++ b/menu/satus.js
@@ -1895,7 +1895,7 @@ satus.components.colorPicker = function(component, skeleton) {
 							var modal = this.skeleton.parentSkeleton.parentSkeleton,
 								hsl = modal.value;
 
-							hsl[0] = this.storage.value;
+							hsl[0] = this.value;
 
 							this.previousSibling.style.backgroundColor = 'hsl(' + hsl[0] + 'deg,' + hsl[1] + '%, ' + hsl[2] + '%)';
 							this.parentNode.previousSibling.style.backgroundColor = 'hsl(' + hsl[0] + 'deg, 100%, 50%)';
@@ -2010,13 +2010,12 @@ satus.components.slider = function(component, skeleton) {
 	input.min = skeleton.min || 0;
 	input.max = skeleton.max || 1;
 	input.step = skeleton.step || 1;
-	input.value = component.storage.value || skeleton.value || 0;
+	input.value = component.storage?.value || skeleton.value || 0;
 
 	text_input.addEventListener('blur', function() {
 		var component = this.parentNode.parentNode;
 
 		component.input.value = Number(this.value.replace(/[^0-9.]/g, ''));
-		component.storage.value = Number(component.input.value);
 
 		component.update();
 	});
@@ -2026,7 +2025,6 @@ satus.components.slider = function(component, skeleton) {
 			var component = this.parentNode.parentNode;
 
 			component.input.value = Number(this.value.replace(/[^0-9.]/g, ''));
-			component.storage.value = Number(component.input.value);
 
 			component.update();
 		}
@@ -2035,7 +2033,7 @@ satus.components.slider = function(component, skeleton) {
 	input.addEventListener('input', function() {
 		var component = this.parentNode.parentNode;
 
-		component.storage.value = Number(this.value);
+		component.value = Number(this.value);
 
 		component.update();
 	});

--- a/menu/satus.js
+++ b/menu/satus.js
@@ -562,6 +562,10 @@ satus.toIndex = function(index, child, parent) {
 satus.on = function(element, listeners) {
 	if (listeners) {
 		for (var type in listeners) {
+			if (type == 'parentObject') {
+				continue;
+			}
+
 			var listener = listeners[type];
 
 			if (type === 'selectionchange') {

--- a/menu/satus.js
+++ b/menu/satus.js
@@ -1303,6 +1303,8 @@ satus.components.textField = function(component, skeleton) {
 		},
 		set: function(value) {
 			this.input.value = value;
+
+			this.dispatchEvent(new CustomEvent('change'));
 		}
 	});
 

--- a/menu/satus.js
+++ b/menu/satus.js
@@ -742,52 +742,53 @@ satus.render = function(skeleton, container, property, childrenOnly, prepend, sk
 		this.properties(element, skeleton.properties);
 		this.on(element, skeleton.on);
 
-		element.storage = (function() {
-			var parent = element,
-				key = skeleton.storage || property || false,
-				value;
-
-			if (satus.isFunction(key)) {
-				key = key();
-			}
-
-			if (skeleton.storage !== false) {
-				if (key) {
-					value = satus.storage.get(key);
-				}
-
-				if (skeleton.hasOwnProperty('value') && value === undefined) {
-					value = skeleton.value;
-				}
-			}
-
-			return Object.defineProperties({}, {
-				key: {
-					get: function() {
-						return key;
-					},
-					set: function(string) {
-						key = string;
-					}
-				},
-				value: {
-					get: function() {
-						return value;
-					},
-					set: function(val) {
-						value = val;
-
-						if (satus.storage.get(key) != val) {
-							if (skeleton.storage !== false) {
-								satus.storage.set(key, val);
-							}
+		// dont add storage component to storage: false elements
+		if (skeleton.storage != false) {
+			element.storage = (function() {
+				var parent = element,
+					key = skeleton.storage || property || false,
+					value;
 	
-							parent.dispatchEvent(new CustomEvent('change'));
+				if (satus.isFunction(key)) {
+					key = key();
+				}
+	
+				if (skeleton.storage !== false) {
+					if (key) {
+						value = satus.storage.get(key);
+					}
+	
+					if (skeleton.hasOwnProperty('value') && value === undefined) {
+						value = skeleton.value;
+					}
+				}
+	
+				return Object.defineProperties({}, {
+					key: {
+						get: function() {
+							return key;
+						},
+						set: function(string) {
+							key = string;
+						}
+					},
+					value: {
+						get: function() {
+							return value;
+						},
+						set: function(val) {
+							value = val;
+	
+							if (satus.storage.get(key) != val) {
+								satus.storage.set(key, val);
+		
+								parent.dispatchEvent(new CustomEvent('change'));
+							}
 						}
 					}
-				}
-			});
-		}());
+				});
+			}());
+		}
 
 		if (this.components[camelizedTagName]) {
 			this.components[camelizedTagName](element, skeleton);

--- a/menu/satus.js
+++ b/menu/satus.js
@@ -2267,6 +2267,7 @@ satus.components.shortcut = function(component, skeleton) {
 	component.addEventListener('click', function() {
 		satus.render({
 			component: 'modal',
+			variant: 'shortcut',
 			properties: {
 				parent: this
 			},

--- a/menu/satus.js
+++ b/menu/satus.js
@@ -3167,7 +3167,7 @@ satus.user.device.connection = function() {
 --------------------------------------------------------------*/
 
 satus.search = function(query, object, callback) {
-	var elements = ['switch', 'select', 'slider', 'shortcut', 'radio', 'color-picker', 'label'],
+	var elements = ['switch', 'select', 'slider', 'shortcut', 'radio', 'color-picker', 'label', 'button'],
 		threads = 0,
 		results = {},
 		excluded = [
@@ -3186,12 +3186,18 @@ satus.search = function(query, object, callback) {
 	function parse(items, parent) {
 		threads++;
 
-		for (var key in items) {
-			if (excluded.indexOf(key) === -1) {
+		for (const key in items) {
+			if (!excluded.includes(key)) {
 				var item = items[key];
 
-				if (item.component && item.text && elements.indexOf(item.component) !== -1
-					&& (satus.locale.data[item.text] ? satus.locale.data[item.text] : item.text).toLowerCase().indexOf(query) !== -1) {
+				if (item.component && item.text
+					// list of elements we allow search on
+					&& elements.includes(item.component)
+					// only pass buttons whose parents are variant: 'card' or special case 'appearance' (this one abuses variant tag for CSS)
+					&& (item.component != 'button' || item.parentObject?.variant == "card" || item.parentObject?.variant == "appearance")
+					// try to match query against localized description, fallback on component name
+					&& (satus.locale.data[item.text] ? satus.locale.data[item.text] : item.text).toLowerCase().includes(query)) {
+					// plop matching results in array - this means we cant have two elements with same name in results
 					results[key] = Object.assign({}, item);
 				}
 

--- a/menu/satus.js
+++ b/menu/satus.js
@@ -1119,11 +1119,23 @@ satus.components.modal = function(component, skeleton) {
 	};
 
 	component.scrim.addEventListener('click', function() {
-		// this is someone clicking outside of modal dialog, try cancel() first if default modal.confirm
-		if (skeleton.cancel && satus.isFunction(skeleton.cancel)) {
-			skeleton.cancel();
+		// this is someone clicking outside of modal dialog
+		if (skeleton.variant == 'confirm') {
+			if (skeleton.buttons?.cancel) {
+				// modal.confirm.buttons variant, we click cancel, those have own closing mechanism
+				if (skeleton.buttons.cancel.rendered?.click && satus.isFunction(skeleton.buttons.cancel.rendered.click)) {
+					skeleton.buttons.cancel.rendered.click();
+				}
+			} else {
+				// modal.confirm simplified variant, try optional cancel() then close()
+				if (skeleton.cancel && satus.isFunction(skeleton.cancel)) {
+					skeleton.cancel();
+				}
+				this.parentNode.close();
+			}
+		} else if (skeleton.variant == 'vertical-menu') {
+			this.parentNode.close();
 		}
-		this.parentNode.close();
 	});
 
 	if (satus.isset(skeleton.content)) {

--- a/menu/satus.js
+++ b/menu/satus.js
@@ -1129,7 +1129,7 @@ satus.components.modal = function(component, skeleton) {
 			case 'confirm':
 				if (skeleton.buttons?.cancel) {
 					// modal.confirm.buttons variant have own closing mechanism, lets try to click cancel button
-					if (skeleton.buttons.cancel1?.rendered?.click && satus.isFunction(skeleton.buttons.cancel.rendered.click)) {
+					if (skeleton.buttons.cancel?.rendered?.click && satus.isFunction(skeleton.buttons.cancel.rendered.click)) {
 						skeleton.buttons.cancel.rendered.click();
 					} else {
 						// cant find cancel button, just force close it

--- a/menu/satus.js
+++ b/menu/satus.js
@@ -1449,14 +1449,6 @@ satus.components.textField = function(component, skeleton) {
 		component.pre.update();
 		component.cursor.update();
 	});
-
-	if (skeleton.on) {
-		for (var type in skeleton.on) {
-			input.addEventListener(type, function(event) {
-				this.parentNode.parentNode.dispatchEvent(new Event(event.type));
-			});
-		}
-	}
 };
 /*--------------------------------------------------------------
 >>> CHART

--- a/menu/satus.js
+++ b/menu/satus.js
@@ -1430,7 +1430,7 @@ satus.components.textField = function(component, skeleton) {
 		component.hiddenValue.textContent = '';
 	};
 
-	document.addEventListener('selectionchange', function(event) {
+	input.addEventListener('selectionchange', function(event) {
 		component.lineNumbers.update();
 		component.pre.update();
 		component.cursor.update();

--- a/menu/satus.js
+++ b/menu/satus.js
@@ -1125,21 +1125,34 @@ satus.components.modal = function(component, skeleton) {
 
 	component.scrim.addEventListener('click', function() {
 		// this is someone clicking outside of modal dialog
-		if (skeleton.variant == 'confirm') {
-			if (skeleton.buttons?.cancel) {
-				// modal.confirm.buttons variant, we click cancel, those have own closing mechanism
-				if (skeleton.buttons.cancel.rendered?.click && satus.isFunction(skeleton.buttons.cancel.rendered.click)) {
-					skeleton.buttons.cancel.rendered.click();
+		switch (skeleton.variant) {
+			case 'confirm':
+				if (skeleton.buttons?.cancel) {
+					// modal.confirm.buttons variant have own closing mechanism, lets try to click cancel button
+					if (skeleton.buttons.cancel1?.rendered?.click && satus.isFunction(skeleton.buttons.cancel.rendered.click)) {
+						skeleton.buttons.cancel.rendered.click();
+					} else {
+						// cant find cancel button, just force close it
+						this.parentNode.close();
+					}
+				} else {
+					// modal.confirm simplified variant, try optional cancel() then close()
+					if (skeleton.cancel && satus.isFunction(skeleton.cancel)) {
+						skeleton.cancel();
+					}
+					this.parentNode.close();
 				}
-			} else {
-				// modal.confirm simplified variant, try optional cancel() then close()
-				if (skeleton.cancel && satus.isFunction(skeleton.cancel)) {
-					skeleton.cancel();
-				}
+				break;
+
+			case 'vertical-menu':
 				this.parentNode.close();
-			}
-		} else if (skeleton.variant == 'vertical-menu') {
-			this.parentNode.close();
+				break;
+				
+			case 'shortcut':
+			case 'color-picker':
+			// click cancel button
+				skeleton.actions.cancel.rendered.click();
+				break;
 		}
 	});
 

--- a/menu/satus.js
+++ b/menu/satus.js
@@ -1434,11 +1434,18 @@ satus.components.textField = function(component, skeleton) {
 		component.hiddenValue.textContent = '';
 	};
 
-	input.addEventListener('selectionchange', function(event) {
+	// global listener, make sure we remove when element no longer exists
+	function selectionchange(event) {
+		if (!document.body.contains(component)) {
+			document.removeEventListener('selectionchange', selectionchange);
+			return;
+		}
 		component.lineNumbers.update();
 		component.pre.update();
 		component.cursor.update();
-	});
+	};
+	
+	document.addEventListener('selectionchange', selectionchange);
 
 	input.addEventListener('input', function() {
 		var component = this.parentNode.parentNode;

--- a/menu/skeleton-parts/appearance.js
+++ b/menu/skeleton-parts/appearance.js
@@ -683,9 +683,10 @@ extension.skeleton.main.layers.section.appearance.on.click.comments = {
 			component: "section",
 			variant: "card",
 
-			comments: {
+			comments_show: {
 				component: "select",
 				text: "comments",
+				storage: 'comments',
 
 				options: [{
 					text: "normal",

--- a/menu/skeleton-parts/search.js
+++ b/menu/skeleton-parts/search.js
@@ -17,7 +17,7 @@ extension.skeleton.header.sectionEnd.search.on.click = {
 		},
 		blur: function () {
 			if (this.value.length === 0) {
-				var search_results = document.querySelector('.search-results');
+				let search_results = document.querySelector('.search-results');
 
 				if (search_results) {
 					search_results.close();
@@ -27,29 +27,28 @@ extension.skeleton.header.sectionEnd.search.on.click = {
 			}
 		},
 		input: function (event) {
-			var self = this,
+			let self = this,
 				value = this.value.trim();
 
 			if (value.length > 0) {
 				satus.search(value, extension.skeleton, function (results) {
-					var search_results = document.querySelector('.search-results'),
+					let search_results = document.querySelector('.search-results'),
 						skeleton = {
 							component: 'modal',
 							class: 'search-results'
 						};
 
-					for (var key in results) {
-						var result = results[key],
-							parent = result;
+					for (let key in results) {
+						let result = results[key],
+							parent = result,
+							category,
+							subcategory,
+							text;
 
-						while (
-							parent.parentObject &&
-							!parent.parentObject.category
-						) {
+						while (parent.parentObject && !parent.parentObject.category) {
+
 							parent = parent.parentObject;
 						}
-
-						var category = '';
 
 						if (parent.parentObject && parent.parentObject.label && parent.parentObject.label.text) {
 							category = parent.parentObject.label.text;
@@ -57,10 +56,7 @@ extension.skeleton.header.sectionEnd.search.on.click = {
 
 						parent = result;
 
-						while (
-							parent.parentObject &&
-							parent.parentObject.component !== 'button'
-						) {
+						while (parent.parentObject && parent.parentObject.component !== 'button') {
 							parent = parent.parentObject;
 						}
 
@@ -68,15 +64,15 @@ extension.skeleton.header.sectionEnd.search.on.click = {
 
 						if (parent) {
 							if (parent.label) {
-								var subcategory = parent.label.text;
+								subcategory = parent.label.text;
 							} else {
-								var subcategory = parent.text;
+								subcategory = parent.text;
 							}
 
 							if (category === subcategory) {
-								var text = satus.locale.get(category);
+								text = satus.locale.get(category);
 							} else {
-								var text = satus.locale.get(category) + ' > ' + satus.locale.get(subcategory);
+								text = satus.locale.get(category) + ' > ' + satus.locale.get(subcategory);
 							}
 
 							skeleton[category + subcategory + '_label'] = {
@@ -119,7 +115,7 @@ extension.skeleton.header.sectionEnd.search.on.click = {
 						}
 					} else {
 						if (search_results) {
-							var surface = document.querySelector('.search-results .satus-modal__surface');
+							let surface = document.querySelector('.search-results .satus-modal__surface');
 
 							satus.empty(surface);
 
@@ -130,7 +126,7 @@ extension.skeleton.header.sectionEnd.search.on.click = {
 							satus.render(skeleton, self.baseProvider);
 
 							document.querySelector('.search-results .satus-modal__scrim').addEventListener('click', function () {
-								var text_field = this.parentElement.baseProvider.skeleton.header.sectionEnd.textField.rendered,
+								let text_field = this.parentElement.baseProvider.skeleton.header.sectionEnd.textField.rendered,
 									search_results = document.querySelector('.search-results');
 
 								if (search_results) {
@@ -146,7 +142,7 @@ extension.skeleton.header.sectionEnd.search.on.click = {
 					}
 				}, true);
 			} else {
-				var search_results = document.querySelector('.search-results');
+				let search_results = document.querySelector('.search-results');
 
 				if (search_results) {
 					search_results.close();
@@ -162,7 +158,7 @@ extension.skeleton.header.sectionEnd.search.on.click = {
 		variant: 'icon',
 		on: {
 			click: function () {
-				var search_results = document.querySelector('.search-results');
+				let search_results = document.querySelector('.search-results');
 
 				if (search_results) {
 					search_results.close();

--- a/menu/skeleton-parts/search.js
+++ b/menu/skeleton-parts/search.js
@@ -14,6 +14,10 @@ extension.skeleton.header.sectionEnd.search.on.click = {
 	on: {
 		render: function () {
 			this.focus();
+			if (extension.search) {
+				this.value = extension.search;
+				this.dispatchEvent(new CustomEvent('input'));
+			}
 		},
 		blur: function () {
 			if (this.value.length === 0) {
@@ -29,6 +33,8 @@ extension.skeleton.header.sectionEnd.search.on.click = {
 		input: function (event) {
 			let self = this,
 				value = this.value.trim();
+
+			extension.search = value;
 
 			if (value.length > 0) {
 				satus.search(value, extension.skeleton, function (results) {
@@ -123,19 +129,23 @@ extension.skeleton.header.sectionEnd.search.on.click = {
 						} else {
 							self.setAttribute('results', '');
 
-							satus.render(skeleton, self.baseProvider);
+							search_results = satus.render(skeleton, self.baseProvider);
+							
+							if (extension.searchPosition) {
+								search_results.childNodes[1].scrollTop = extension.searchPosition;
+							}
 
 							document.querySelector('.search-results .satus-modal__scrim').addEventListener('click', function () {
+								// this is someone clicking outside of Search results window
 								let text_field = this.parentElement.baseProvider.skeleton.header.sectionEnd.search.on.click.rendered,
 									search_results = document.querySelector('.search-results');
 
 								if (search_results) {
+									extension.searchPosition = search_results.childNodes[1].scrollTop;
 									search_results.close();
 								}
 
-								text_field.value = '';
-
-								self.removeAttribute('results');
+								self.skeleton.close.rendered.click()
 							});
 						}
 					}
@@ -160,6 +170,7 @@ extension.skeleton.header.sectionEnd.search.on.click = {
 				let search_results = document.querySelector('.search-results');
 
 				if (search_results) {
+					extension.searchPosition = search_results.childNodes[1].scrollTop;
 					search_results.close();
 				}
 

--- a/menu/skeleton-parts/search.js
+++ b/menu/skeleton-parts/search.js
@@ -131,14 +131,36 @@ extension.skeleton.header.sectionEnd.search.on.click = {
 
 							search_results = satus.render(skeleton, self.baseProvider);
 							
+							// we need global listener here
+							function hidesearch(event) {
+								// make sure to clean it after closing search results
+								if (!document.body.contains(search_results)) {
+									document.removeEventListener('click', hidesearch);
+								}
+								// hide search results when clicking on result that is a 'button' inside search results
+								if (search_results.contains(event.target) && event.target.className.includes('satus-button')
+									// dont close on modal popups
+									&& !(event.target.skeleton?.on?.click?.component == "modal")
+									// shortcut are also modal popups
+									&& !(event.target.skeleton?.component == "shortcut")) {
+									search_results.close();
+									self.skeleton.close.rendered.click();
+								} else if (event.target.closest('.satus-modal.satus-modal--vertical-menu') && event.target.closest('.satus-button')) {
+									// hide search results when clicking on vertical-menu button
+									search_results.close();
+									self.skeleton.close.rendered.click();
+								}
+							}
+
+							document.addEventListener('click', hidesearch);
+							
 							if (extension.searchPosition) {
 								search_results.childNodes[1].scrollTop = extension.searchPosition;
 							}
 
 							document.querySelector('.search-results .satus-modal__scrim').addEventListener('click', function () {
 								// this is someone clicking outside of Search results window
-								let text_field = this.parentElement.baseProvider.skeleton.header.sectionEnd.search.on.click.rendered,
-									search_results = document.querySelector('.search-results');
+								let search_results = document.querySelector('.search-results');
 
 								if (search_results) {
 									extension.searchPosition = search_results.childNodes[1].scrollTop;

--- a/menu/skeleton-parts/search.js
+++ b/menu/skeleton-parts/search.js
@@ -126,7 +126,7 @@ extension.skeleton.header.sectionEnd.search.on.click = {
 							satus.render(skeleton, self.baseProvider);
 
 							document.querySelector('.search-results .satus-modal__scrim').addEventListener('click', function () {
-								let text_field = this.parentElement.baseProvider.skeleton.header.sectionEnd.textField.rendered,
+								let text_field = this.parentElement.baseProvider.skeleton.header.sectionEnd.search.on.click.rendered,
 									search_results = document.querySelector('.search-results');
 
 								if (search_results) {

--- a/menu/skeleton-parts/search.js
+++ b/menu/skeleton-parts/search.js
@@ -134,7 +134,6 @@ extension.skeleton.header.sectionEnd.search.on.click = {
 								}
 
 								text_field.value = '';
-								text_field.style.display = '';
 
 								self.removeAttribute('results');
 							});

--- a/menu/skeleton-parts/search.js
+++ b/menu/skeleton-parts/search.js
@@ -26,21 +26,6 @@ extension.skeleton.header.sectionEnd.search.on.click = {
 				this.remove();
 			}
 		},
-		keydown: function (event) {
-			var self = this;
-
-			setTimeout(function () {
-				if (self.storage.value.length === 0 && event.key === 'Backspace') {
-					var search_results = document.querySelector('.search-results');
-
-					if (search_results) {
-						search_results.close();
-					}
-
-					self.baseProvider.classList.remove('search-mode');
-				}
-			});
-		},
 		input: function (event) {
 			var self = this,
 				value = this.value.trim();
@@ -205,8 +190,3 @@ extension.skeleton.header.sectionEnd.search.on.click = {
 		}
 	}
 };
-
-
-
-
-

--- a/menu/skeleton.js
+++ b/menu/skeleton.js
@@ -11,7 +11,9 @@
 --------------------------------------------------------------*/
 
 extension.skeleton = {
-	component: 'base'
+	component: 'base',
+	search: false,
+	searchPosition: 0
 };
 
 


### PR DESCRIPTION
Update search.js keydown is redundant, input handles same case

Update search.js clean variable mess

Update search.js text_field was always broken 

Update satus.js removing redundant addEventListener 
All the listeners are already setup by satus.render. code here was doubling them down resulting in Search being performed twice every time.

Update satus.js respect storage: false on text-field elements 
Seatch text-field (Input) is of type component.skeleton.storage: false

Update satus.js propagate manual change 'text-field' value 
trigger 'change' event same way as in element.storage.set 
https://github.com/code-charity/youtube/blob/9c4e5f66e44bbe14cef4d59ce6f5cb1ae5e9d4fc/menu/satus.js#L785

Update satus.js more graceful handling of clicking outside of modal dialog
no more double .close()

Update search.js phantom style set 
we never set style on text-field to begin with, no reason to try and remove it either

Update satus.js stop adding storage component to storage: false elements

Update satus.js make ok() cancel() optional for modal.confirm simplified variant

Update search.js remember last search query and search_results scroll position, restore on search reopen

Update skeleton.js search restore variables