### PR TITLE
Update satus.js extend .on listener to redirecting to elements like w…

### DIFF
--- a/menu/satus.js
+++ b/menu/satus.js
@@ -592,19 +592,27 @@ satus.on = function(element, listeners) {
 				});
 			} else if (satus.isString(listener)) {
 				element.addEventListener(type, function() {
-					var match = this.skeleton.on[event.type].match(/(["'`].+["'`]|[^.()]+)/g),
+					let match = this.skeleton.on[event.type].match(/(["'`].+["'`]|[^.()]+)/g),
 						target = this.baseProvider;
 
-					for (var i = 0, l = match.length; i < l; i++) {
-						var key = match[i];
+					for (let i = 0, l = match.length; i < l; i++) {
+						let key = match[i];
 
-						if (target.skeleton[key]) {
+						if (target.skeleton && target.skeleton[key]) {
 							target = target.skeleton[key];
 						} else {
 							if (typeof target[key] === 'function') {
 								target[key]();
 							} else {
 								target = target[key];
+								// render last element if its not a function, lets us use redirects
+								if (i == match.length-1 && (typeof target != 'function')) {
+									let layers = this.layersProvider;
+									if (!layers && this.baseProvider.layers.length > 0) {
+										layers = this.baseProvider.layers[0];
+									}
+									layers.open(target);
+								}
 							}
 						}
 

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -1065,55 +1065,7 @@ extension.skeleton.main.layers.section.player.on.click = {
 							component: "button",
 							text: "hidePlayerControlsBarButtons",
 							on: {
-								click: {
-									component: "section",
-									variant: "card",
-			
-									player_play_button: {
-										component: "switch",
-										text: "playPause"
-									},
-									player_previous_button: {
-										component: "switch",
-										text: "previousVideo"
-									},
-									player_next_button: {
-										component: "switch",
-										text: "nextVideo"
-									},
-									player_volume_button: {
-										component: "switch",
-										text: "volume"
-									},
-									player_autoplay_button: {
-										component: "switch",
-										text: "autoplay"
-									},
-									player_settings_button: {
-										component: "switch",
-										text: "settings"
-									},
-									player_subtitles_button: {
-										component: "switch",
-										text: "subtitles"
-									},
-									player_miniplayer_button: {
-										component: "switch",
-										text: "nativeMiniPlayer"
-									},
-									player_view_button: {
-										component: "switch",
-										text: "viewMode"
-									},
-									player_screen_button: {
-										component: "switch",
-										text: "screen"
-									},
-									player_remote_button: {
-										component: "switch",
-										text: "remote"
-									}
-								}
+								click: 'main.layers.section.appearance.on.click.player.on.click.player_hide_controls_options.on.click'
 							}
 						},
 	}	


### PR DESCRIPTION
…e now allow calling functions

like 
https://github.com/code-charity/youtube/blob/98338c8305169195487b8cdc3e23749a6c781e85/menu/skeleton.js#L36

but instead of calling a function we can point to an element path, for example
`click: 'main.layers.section.appearance.on.click.player.on.click.player_hide_controls_options.on.click'`
 lets us define buttons that redirect to other elements