### PR TITLE
Feature #300: Reduce quality when window loses focus (from pull request #2162)

### DIFF
--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -578,6 +578,9 @@
     "quality": {
         "message": "الجودة"
     },
+    "qualityWithoutFocus": {
+        "message": "الجودة بدون تركيز"
+    },
     "ram": {
         "message": "الذاكرة العشوائية"
     },

--- a/_locales/bg/messages.json
+++ b/_locales/bg/messages.json
@@ -2,6 +2,9 @@
     "hideHomePageShorts": {
         "message": "Премахни Shorts от началната страница"
     },
+    "qualityWithoutFocus": {
+        "message": "Качество без фокус"
+    },
     "removeShortsReelSearchResults": {
         "message": "Премахнете ролката Shorts от резултатите от търсенето"
     }

--- a/_locales/ca/messages.json
+++ b/_locales/ca/messages.json
@@ -2,6 +2,9 @@
     "hideHomePageShorts": {
         "message": "Elimina els Shorts de la pàgina d'inici"
     },
+    "qualityWithoutFocus": {
+        "message": "Quality without focus"
+    },
     "removeShortsReelSearchResults": {
         "message": "Elimineu el carrossel de Shorts dels resultats de cerca"
     }

--- a/_locales/cs/messages.json
+++ b/_locales/cs/messages.json
@@ -2,6 +2,9 @@
     "hideHomePageShorts": {
         "message": "Odebrat Shorts z úvodní stránky"
     },
+    "qualityWithoutFocus": {
+        "message": "Quality without focus"
+    },
     "removeShortsReelSearchResults": {
         "message": "Odstraňte karuselu Shorts z výsledků vyhledávání"
     }

--- a/_locales/da/messages.json
+++ b/_locales/da/messages.json
@@ -2,6 +2,9 @@
     "hideHomePageShorts": {
         "message": "Fjern Shorts fra hjemmesiden"
     },
+    "qualityWithoutFocus": {
+        "message": "Quality without focus"
+    },
     "removeShortsReelSearchResults": {
         "message": "Fjern Shorts-rulle fra søgeresultaterne"
     }

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -566,6 +566,9 @@
     "quality": {
         "message": "Qualität"
     },
+    "qualityWithoutFocus": {
+        "message": "Qualität ohne Fokus"
+    },
     "raised": {
         "message": "Erhöht"
     },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -968,6 +968,9 @@
     "quality": {
         "message": "Quality"
     },
+    "qualityWithoutFocus": {
+        "message": "Quality without focus"
+    },
     "raised": {
         "message": "Raised"
     },

--- a/_locales/en_GB/messages.json
+++ b/_locales/en_GB/messages.json
@@ -41,6 +41,9 @@
     "primaryColor": {
         "message": "Primary colour"
     },
+    "qualityWithoutFocus": {
+        "message": "Quality without focus"
+    },
     "textColor": {
         "message": "Text colour"
     },

--- a/_locales/en_US/messages.json
+++ b/_locales/en_US/messages.json
@@ -4,5 +4,8 @@
     },
     "player_rotate_button": {
         "message": "player rotate button"
+    },
+    "qualityWithoutFocus": {
+        "message": "Quality without focus"
     }
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -806,6 +806,9 @@
     "quality": {
         "message": "Calidad"
     },
+    "qualityWithoutFocus": {
+        "message": "Calidad sin enfoque"
+    },
     "rateMe": {
         "message": "Califícame"
     },

--- a/_locales/es_419/messages.json
+++ b/_locales/es_419/messages.json
@@ -668,6 +668,9 @@
     "quality": {
         "message": "Calidad"
     },
+    "qualityWithoutFocus": {
+        "message": "Calidad sin enfoque"
+    },
     "rateMe": {
         "message": "Califícame"
     },

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -512,6 +512,9 @@
     "quality": {
         "message": "Qualité"
     },
+    "qualityWithoutFocus": {
+        "message": "Qualité sans concentration"
+    },
     "rateUs": {
         "message": "Nous évaluer"
     },

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -680,6 +680,9 @@
     "quality": {
         "message": "Qualità"
     },
+    "qualityWithoutFocus": {
+        "message": "Kualitas Tanpa Fokus"
+    },
     "raised": {
         "message": "Rialzato"
     },

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -704,6 +704,9 @@
     "quality": {
         "message": "Jakość"
     },
+    "qualityWithoutFocus": {
+        "message": "Jakość bez ostrości"
+    },
     "raised": {
         "message": "Podniesione"
     },

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -755,6 +755,9 @@
     "quality": {
         "message": "Качество"
     },
+    "qualityWithoutFocus": {
+        "message": "Качество при неактивном окне"
+    },
     "raised": {
         "message": "Поднятый"
     },

--- a/_locales/uk/messages.json
+++ b/_locales/uk/messages.json
@@ -8,6 +8,9 @@
     "hideHomePageShorts": {
         "message": "Видалити Shorts з головної сторінки"
     },
+    "qualityWithoutFocus": {
+        "message": "Якість при неактивному вікні"
+    },
     "removeShortsReelSearchResults": {
         "message": "Видаліть карусель Shorts з результатів пошуку"
     }

--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -290,6 +290,7 @@ ImprovedTube.pageType = function () {
 ImprovedTube.pageOnFocus = function () {
 	ImprovedTube.playerAutopauseWhenSwitchingTabs();
 	ImprovedTube.playerAutoPip();
+	ImprovedTube.playerQualityWithoutFocus();
 };
 
 ImprovedTube.videoPageUpdate = function () {

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -533,6 +533,62 @@ ImprovedTube.playerQuality = function () {
 	}
 };
 /*------------------------------------------------------------------------------
+QUALITY WITHOUT FOCUS
+------------------------------------------------------------------------------*/
+ImprovedTube.playerQualityWithoutFocus = function () {
+	function closest (num, arr) {
+		let curr = arr[0];
+		let diff = Math.abs (num - curr);
+		for (let val = 0; val < arr.length; val++) {
+			let newdiff = Math.abs (num - arr[val]);
+			if (newdiff < diff) {
+				diff = newdiff;
+				curr = arr[val];
+			}
+		}
+		return curr;
+	};
+    var player = this.elements.player,
+    qualityWithoutFocus = this.storage.player_quality_without_focus;
+	quality = this.storage.player_quality;
+	if(qualityWithoutFocus && qualityWithoutFocus != 'disabled' && player){
+		if(this.focus === false) {
+				var available_quality_levels = player.getAvailableQualityLevels();
+					if (available_quality_levels.includes(qualityWithoutFocus) === false) {
+						let label = ['tiny', 'small', 'medium', 'large', 'hd720', 'hd1080', 'hd1440', 'hd2160', 'hd2880', 'highres'];
+						let resolution = ['144', '240', '360', '480', '720', '1080', '1440', '2160', '2880', '4320'];
+						let availableresolutions = available_quality_levels.reduce(function (array, elem) {
+							array.push(resolution[label.indexOf(elem)]); return array;
+							}, []);
+		
+						qualityWithoutFocus = closest (resolution[label.indexOf(qualityWithoutFocus)], availableresolutions);
+						qualityWithoutFocus = label[resolution.indexOf(qualityWithoutFocus)];
+					}
+		
+					player.setPlaybackQualityRange(qualityWithoutFocus);
+					player.setPlaybackQuality(qualityWithoutFocus);
+				
+		}
+		if (this.focus === true){
+				var available_quality_levels = player.getAvailableQualityLevels();		
+					if (available_quality_levels.includes(quality) === false) {
+						let label = ['tiny', 'small', 'medium', 'large', 'hd720', 'hd1080', 'hd1440', 'hd2160', 'hd2880', 'highres'];
+						let resolution = ['144', '240', '360', '480', '720', '1080', '1440', '2160', '2880', '4320'];
+						let availableresolutions = available_quality_levels.reduce(function (array, elem) {
+							array.push(resolution[label.indexOf(elem)]); return array;
+							}, []);
+		
+						quality = closest (resolution[label.indexOf(quality)], availableresolutions);
+						quality = label[resolution.indexOf(quality)];
+					}
+		
+					player.setPlaybackQualityRange(quality);
+					player.setPlaybackQuality(quality);		
+		}
+	}
+
+};
+/*------------------------------------------------------------------------------
 FORCED VOLUME
 ------------------------------------------------------------------------------*/
 ImprovedTube.playerVolume = function () {

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -760,6 +760,70 @@ extension.skeleton.main.layers.section.player.on.click = {
 				}
 			}
 		},
+		player_quality_without_focus: {
+			component: 'select',
+			text: 'qualityWithoutFocus',
+			id: 'player_quality_without_focus',
+			options: [{
+				text: 'disabled',
+				value: 'disabled'
+			}, {
+				text: '144p',
+				value: 'tiny'
+			}, {
+				text: '240p',
+				value: 'small'
+			}, {
+				text: '360p',
+				value: 'medium'
+			}, {
+				text: '480p',
+				value: 'large'
+			}, {
+				text: '720p',
+				value: 'hd720'
+			}, {
+				text: '1080p',
+				value: 'hd1080'
+			}, {
+				text: '1440p',
+				value: 'hd1440'
+			}, {
+				text: '2160p',
+				value: 'hd2160'
+			}, {
+				text: '2880p',
+				value: 'hd2880'
+			}, {
+				text: '4320p',
+				value: 'highres'
+			}],
+			on: {
+				render: function () {
+					if (satus.storage.get('player_h264')) {
+						if (this.childNodes[2].selectedIndex >6) {
+							this.childNodes[1].style = 'color: red!important; font-weight: bold;';
+							this.childNodes[1].textContent = '1080p';
+						} else {
+							this.childNodes[1].style = '';
+							this.childNodes[1].textContent = this.childNodes[2].options[this.childNodes[2].selectedIndex].text;
+						}
+						for (let index =7; index <= 10; index++) {
+							this.childNodes[2].childNodes[index].style = 'color: red!important; font-weight: bold;';
+						}
+					} else if (satus.storage.get('block_vp9') && satus.storage.get('block_h264')) {
+						this.childNodes[1].style = 'color: red!important; font-weight: bold;';
+						this.childNodes[1].textContent = 'Video disabled';
+					} else {
+						this.childNodes[1].style = '';
+						this.childNodes[1].textContent = this.childNodes[2].options[this.childNodes[2].selectedIndex].text;
+						for (let index =7; index <= 10; index++) {
+							this.childNodes[2].childNodes[index].style = '';
+						}
+					}
+				}
+			}
+		},
 		player_codecs: {
 			component: 'button',
 			text: 'codecs',
@@ -895,6 +959,7 @@ extension.skeleton.main.layers.section.player.on.click = {
 						document.getElementById('player_quality').dispatchEvent(new CustomEvent('render'));
 						document.getElementById('player_codecs').dispatchEvent(new CustomEvent('render'));
 						document.getElementById('optimize_codec_for_hardware_acceleration').dispatchEvent(new CustomEvent('render'));
+						document.getElementById('player_quality_without_focus').dispatchEvent(new CustomEvent('render'));
 					}
 					if (this.dataset.value === 'false') {
 						let where = this;


### PR DESCRIPTION
This commit is adding a feature described in https://github.com/code-charity/youtube/issues/300. Users can choose the quality to which the player will lower when the window is unfocused. When the window is focused again, the quality is coming back to the desired one. 
By mistake I closed previous pull request
+ I made the changes regarding @raszpl and @ImprovedTube comments 