### PR TITLE
Special 'satus_remove' value signaling default option, remove instead of storing

### DIFF
--- a/js&css/web-accessible/core.js
+++ b/js&css/web-accessible/core.js
@@ -358,6 +358,18 @@ document.addEventListener('it-message-from-extension', function () {
 				case 'blocklistActivate':
 					if (ImprovedTube.storage.blocklist_activate === true) {document.querySelectorAll('.it-add-to-blocklist').forEach(e => e.remove());}
 					break
+
+				case 'subtitlesFontFamily':
+				case 'subtitlesFontColor':
+				case 'subtitlesFontSize':
+				case 'subtitlesBackgroundColor':
+				case 'subtitlesWindowColor':
+				case 'subtitlesWindowOpacity':
+				case 'subtitlesCharacterEdgeStyle':
+				case 'subtitlesFontOpacity':
+				case 'subtitlesBackgroundOpacity':
+					ImprovedTube.subtitlesUserSettings();
+					break
 			}
 
 			if (ImprovedTube[camelized_key]) {

--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -361,15 +361,7 @@ ImprovedTube.initPlayer = function () {
 		ImprovedTube.playerPlaybackSpeed();
 		ImprovedTube.subtitles();
 		ImprovedTube.subtitlesLanguage();
-		ImprovedTube.subtitlesFontFamily();
-		ImprovedTube.subtitlesFontColor();
-		ImprovedTube.subtitlesFontSize();
-		ImprovedTube.subtitlesBackgroundColor();
-		ImprovedTube.subtitlesWindowColor();
-		ImprovedTube.subtitlesWindowOpacity();
-		ImprovedTube.subtitlesCharacterEdgeStyle();
-		ImprovedTube.subtitlesFontOpacity();
-		ImprovedTube.subtitlesBackgroundOpacity();
+		ImprovedTube.subtitlesUserSettings();
 		ImprovedTube.subtitlesDisableLyrics();
 		ImprovedTube.playerQuality();
 		ImprovedTube.playerVolume();

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -203,26 +203,16 @@ ImprovedTube.subtitles = function () {
 SUBTITLES LANGUAGE
 ------------------------------------------------------------------------------*/
 ImprovedTube.subtitlesLanguage = function () {
-	var option = this.storage.subtitles_language;
-	if (this.isset(option) && option !== 'default') {
-		var player = this.elements.player,
-			button = this.elements.player_subtitles_button;
+	const option = this.storage.subtitles_language,
+		player = this.elements.player,
+		button = this.elements.player_subtitles_button;
 
-		if (player && player.getOption && button && button.getAttribute('aria-pressed') === 'true') {
-			var tracklist = this.elements.player.getOption('captions', 'tracklist', {
-				includeAsr: true
-			});
+	if (option && player && player.getOption && button && button.getAttribute('aria-pressed') === 'true') {
+		const tracklists = player.getOption('captions', 'tracklist', {includeAsr: true}),
+			matchedTrack = tracklists.find(element => element.languageCode.includes(option) && (!element.vss_id.includes("a.") || this.storage.auto_generate));
 
-			var matchTrack = false;
-			for (var i =0, l = tracklist.length; i<l; i++){
-				if (tracklist[i].languageCode.includes(option)) {
-					if( false === tracklist[i].vss_id.includes("a.") || true === this.storage.auto_generate){
-						this.elements.player.setOption('captions', 'track', tracklist[i]);
-						matchTrack = true; break;
-					}
-				}
-			}
-		 //   if (!matchTrack){  player.toggleSubtitles();  }
+		if (matchedTrack) {
+			player.setOption('captions', 'track', matchedTrack);
 		}
 	}
 };

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -218,187 +218,61 @@ ImprovedTube.subtitlesLanguage = function () {
 };
 /*------------------------------------------------------------------------------
 SUBTITLES FONT FAMILY
+SUBTITLES FONT COLOR
+SUBTITLES FONT SIZE
+SUBTITLES BACKGROUND COLOR
+SUBTITLES BACKGROUND OPACITY
+SUBTITLES WINDOW COLOR
+SUBTITLES WINDOW OPACITY
+SUBTITLES CHARACTER EDGE STYLE
+SUBTITLES FONT OPACITY
+default = {
+    "fontFamily": 4,
+    "color": "#fff",
+    "fontSizeIncrement": 0,
+    "background": "#080808",
+    "backgroundOpacity": 0.75,
+    "windowColor": "#080808",
+    "windowOpacity": 0,
+    "charEdgeStyle": 0,
+    "textOpacity": 1,
+},
 ------------------------------------------------------------------------------*/
-ImprovedTube.subtitlesFontFamily = function () {
-	const option = this.storage.subtitles_font_family,
+ImprovedTube.subtitlesUserSettings = function () {
+	const ourSettings = [
+			['fontFamily', 'number', this.storage.subtitles_font_family],
+			['color', 'color', this.storage.subtitles_font_color],
+			['fontSizeIncrement', 'number', this.storage.subtitles_font_size],
+			['background', 'color', this.storage.subtitles_background_color],
+			['backgroundOpacity', 'fraction', this.storage.subtitles_background_opacity],
+			['windowColor', 'color', this.storage.subtitles_window_color],
+			['windowOpacity', 'fraction', this.storage.subtitles_window_opacity],
+			['charEdgeStyle', 'number', this.storage.subtitles_character_edge_style],
+			['textOpacity', 'fraction', this.storage.subtitles_font_opacity]
+		],
+		option = ourSettings.filter(element => element[2]),
 		player = this.elements.player,
 		button = this.elements.player_subtitles_button;
 
-	if (option && player && player.getSubtitlesUserSettings && button && button.getAttribute('aria-pressed') === 'true') {
+	if (option.length && player.getSubtitlesUserSettings && button && button.getAttribute('aria-pressed') === 'true') {
 		let settings = player.getSubtitlesUserSettings();
+		
+		for (const value of option) {
+			switch(value[1]) {
+				case 'number':
+					settings[value[0]] = Number(value[2]);
+					break;
 
-		if (settings) {
-			settings.fontFamily = Number(option);
-			player.updateSubtitlesUserSettings(settings);
-		}
-	}
-};
-/*------------------------------------------------------------------------------
-SUBTITLES FONT COLOR
-------------------------------------------------------------------------------*/
-ImprovedTube.subtitlesFontColor = function () {
-	var option = this.storage.subtitles_font_color;
+				case 'color':
+					settings[value[0]] = value[2];
+					break;
 
-	if (this.isset(option)) {
-		var player = this.elements.player,
-			button = this.elements.player_subtitles_button;
-
-		if (player && player.getSubtitlesUserSettings && button && button.getAttribute('aria-pressed') === 'true') {
-			var settings = player.getSubtitlesUserSettings();
-
-			if (settings) {
-				settings.color = option;
-
-				player.updateSubtitlesUserSettings(settings);
+				case 'fraction':
+					settings[value[0]] = Number(option) / 100;
+					break;
 			}
 		}
-	}
-};
-/*------------------------------------------------------------------------------
-SUBTITLES FONT SIZE
-------------------------------------------------------------------------------*/
-ImprovedTube.subtitlesFontSize = function () {
-	var option = this.storage.subtitles_font_size;
-
-	if (this.isset(option)) {
-		var player = this.elements.player,
-			button = this.elements.player_subtitles_button;
-
-		if (player && player.getSubtitlesUserSettings && button && button.getAttribute('aria-pressed') === 'true') {
-			var settings = player.getSubtitlesUserSettings();
-
-			if (settings) {
-				settings.fontSizeIncrement = Number(option);
-
-				player.updateSubtitlesUserSettings(settings);
-			}
-		}
-	}
-};
-/*------------------------------------------------------------------------------
-SUBTITLES BACKGROUND COLOR
-------------------------------------------------------------------------------*/
-ImprovedTube.subtitlesBackgroundColor = function () {
-	var option = this.storage.subtitles_background_color;
-
-	if (this.isset(option)) {
-		var player = this.elements.player,
-			button = this.elements.player_subtitles_button;
-
-		if (player && player.getSubtitlesUserSettings && button && button.getAttribute('aria-pressed') === 'true') {
-			var settings = player.getSubtitlesUserSettings();
-
-			if (settings) {
-				settings.background = option;
-
-				player.updateSubtitlesUserSettings(settings);
-			}
-		}
-	}
-};
-/*------------------------------------------------------------------------------
-SUBTITLES BACKGROUND OPACITY
-------------------------------------------------------------------------------*/
-ImprovedTube.subtitlesBackgroundOpacity = function () {
-	var option = this.storage.subtitles_background_opacity;
-
-	if (this.isset(option)) {
-		var player = this.elements.player,
-			button = this.elements.player_subtitles_button;
-
-		if (player && player.getSubtitlesUserSettings && button && button.getAttribute('aria-pressed') === 'true') {
-			var settings = player.getSubtitlesUserSettings();
-
-			if (settings) {
-				settings.backgroundOpacity = option / 100;
-
-				player.updateSubtitlesUserSettings(settings);
-			}
-		}
-	}
-};
-/*------------------------------------------------------------------------------
-SUBTITLES WINDOW COLOR
-------------------------------------------------------------------------------*/
-ImprovedTube.subtitlesWindowColor = function () {
-	var option = this.storage.subtitles_window_color;
-
-	if (this.isset(option)) {
-		var player = this.elements.player,
-			button = this.elements.player_subtitles_button;
-
-		if (player && player.getSubtitlesUserSettings && button && button.getAttribute('aria-pressed') === 'true') {
-			var settings = player.getSubtitlesUserSettings();
-
-			if (settings) {
-				settings.windowColor = option;
-
-				player.updateSubtitlesUserSettings(settings);
-			}
-		}
-	}
-};
-/*------------------------------------------------------------------------------
-SUBTITLES WINDOW OPACITY
-------------------------------------------------------------------------------*/
-ImprovedTube.subtitlesWindowOpacity = function () {
-	var option = this.storage.subtitles_window_opacity;
-
-	if (this.isset(option)) {
-		var player = this.elements.player,
-			button = this.elements.player_subtitles_button;
-
-		if (player && player.getSubtitlesUserSettings && button && button.getAttribute('aria-pressed') === 'true') {
-			var settings = player.getSubtitlesUserSettings();
-
-			if (settings) {
-				settings.windowOpacity = Number(option) / 100;
-
-				player.updateSubtitlesUserSettings(settings);
-			}
-		}
-	}
-};
-/*------------------------------------------------------------------------------
-SUBTITLES CHARACTER EDGE STYLE
-------------------------------------------------------------------------------*/
-ImprovedTube.subtitlesCharacterEdgeStyle = function () {
-	var option = this.storage.subtitles_character_edge_style;
-
-	if (this.isset(option)) {
-		var player = this.elements.player,
-			button = this.elements.player_subtitles_button;
-
-		if (player && player.getSubtitlesUserSettings && button && button.getAttribute('aria-pressed') === 'true') {
-			var settings = player.getSubtitlesUserSettings();
-
-			if (settings) {
-				settings.charEdgeStyle = Number(option);
-
-				player.updateSubtitlesUserSettings(settings);
-			}
-		}
-	}
-};
-/*------------------------------------------------------------------------------
-SUBTITLES FONT OPACITY
-------------------------------------------------------------------------------*/
-ImprovedTube.subtitlesFontOpacity = function () {
-	var option = this.storage.subtitles_font_opacity;
-
-	if (this.isset(option)) {
-		var player = this.elements.player,
-			button = this.elements.player_subtitles_button;
-
-		if (player && player.getSubtitlesUserSettings && button && button.getAttribute('aria-pressed') === 'true') {
-			var settings = player.getSubtitlesUserSettings();
-
-			if (settings) {
-				settings.textOpacity = option / 100;
-
-				player.updateSubtitlesUserSettings(settings);
-			}
-		}
+		player.updateSubtitlesUserSettings(settings);
 	}
 };
 /*------------------------------------------------------------------------------

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -611,7 +611,7 @@ ImprovedTube.playerLoudnessNormalization = function () {
 SCREENSHOT
 ------------------------------------------------------------------------------*/
 ImprovedTube.screenshot = function () {
-	var video = ImprovedTube.elements.video,
+	const video = ImprovedTube.elements.video,
 		style = document.createElement('style'),
 		cvs = document.createElement('canvas'),
 		ctx = cvs.getContext('2d');
@@ -625,27 +625,28 @@ ImprovedTube.screenshot = function () {
 
 	setTimeout(function () {
 		ctx.drawImage(video, 0, 0, cvs.width, cvs.height);
-		var subText = '';
-		var captionElements = document.querySelectorAll('.captions-text .ytp-caption-segment');
-			captionElements.forEach(function (caption) {subText += caption.textContent.trim() + ' ';});	
-			
-		if(ImprovedTube.storage.embed_subtitle === true){ImprovedTube.renderSubtitle(ctx,captionElements);}
+		let subText = '',
+			captionElements = document.querySelectorAll('.captions-text .ytp-caption-segment');
+
+		captionElements.forEach(function (caption) {subText += caption.textContent.trim() + ' ';});
+
+		if (ImprovedTube.storage.embed_subtitle != false) {
+			ImprovedTube.renderSubtitle(ctx,captionElements);
+		}
 
 		cvs.toBlob(function (blob) {
-			if (ImprovedTube.storage.player_screenshot_save_as !== 'clipboard') {
-				var a = document.createElement('a');
-				a.href = URL.createObjectURL(blob); console.log("screeeeeeenshot tada!");
-
-
-				a.download = (ImprovedTube.videoId() || location.href.match) + ' ' + new Date(ImprovedTube.elements.player.getCurrentTime() * 1000).toISOString().substr(11, 8).replace(/:/g, '-') + ' ' + ImprovedTube.videoTitle() + (subText ? ' - ' + subText.trim() : '') + '.png';
-
-				a.click();
-			} else {
+			if (ImprovedTube.storage.player_screenshot_save_as == 'clipboard') {
 				navigator.clipboard.write([
 					new ClipboardItem({
 						'image/png': blob
 					})
 				]);
+			} else {
+				let a = document.createElement('a');
+				a.href = URL.createObjectURL(blob);
+				console.log("screeeeeeenshot tada!");
+				a.download = (ImprovedTube.videoId() || location.href.match) + ' ' + new Date(ImprovedTube.elements.player.getCurrentTime() * 1000).toISOString().substr(11, 8).replace(/:/g, '-') + ' ' + ImprovedTube.videoTitle() + (subText ? ' - ' + subText.trim() : '') + '.png';
+				a.click();
 			}
 		});
 

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -220,20 +220,16 @@ ImprovedTube.subtitlesLanguage = function () {
 SUBTITLES FONT FAMILY
 ------------------------------------------------------------------------------*/
 ImprovedTube.subtitlesFontFamily = function () {
-	var option = this.storage.subtitles_font_family;
+	const option = this.storage.subtitles_font_family,
+		player = this.elements.player,
+		button = this.elements.player_subtitles_button;
 
-	if (this.isset(option)) {
-		var player = this.elements.player,
-			button = this.elements.player_subtitles_button;
+	if (option && player && player.getSubtitlesUserSettings && button && button.getAttribute('aria-pressed') === 'true') {
+		let settings = player.getSubtitlesUserSettings();
 
-		if (player && player.getSubtitlesUserSettings && button && button.getAttribute('aria-pressed') === 'true') {
-			var settings = player.getSubtitlesUserSettings();
-
-			if (settings) {
-				settings.fontFamily = Number(option);
-
-				player.updateSubtitlesUserSettings(settings);
-			}
+		if (settings) {
+			settings.fontFamily = Number(option);
+			player.updateSubtitlesUserSettings(settings);
 		}
 	}
 };

--- a/menu/satus.js
+++ b/menu/satus.js
@@ -2495,22 +2495,39 @@ satus.components.switch = function(component, skeleton) {
 };
 
 satus.components.switch.flip = function(val) {
+	let where = this;
+
+	function flipTrue() {
+		where.dataset.value = 'true';
+		if (where.skeleton.value == true) {
+			// skeleton.value: true makes this a default true flip switch where the only active state we save is false
+			where.storage.value = 'satus_remove';
+		} else {
+			where.storage.value = true;
+		}
+	};
+	function flipFalse() {
+		where.dataset.value = 'false';
+		if (where.skeleton.value == true) {
+			// skeleton.value: true makes this a default true flip switch where the only active state we save is false
+			where.storage.value = false;
+		} else {
+			where.storage.value = 'satus_remove';
+		}
+	};
+			
 	switch(val) {
 		case true:
-			this.dataset.value = 'true';
-			this.storage.value = true;
+			flipTrue();
 			break;
 		case false:
-			this.dataset.value = 'false';
-			this.storage.value = false;
+			flipFalse();
 			break;
 		case undefined:
-			if (this.dataset.value === 'true') {
-				this.dataset.value = 'false';
-				this.storage.value = false;
+			if (this.dataset.value === 'false') {
+				flipTrue();
 			} else {
-				this.dataset.value = 'true';
-				this.storage.value = true;
+				flipFalse();
 			}
 			break;
 	}

--- a/menu/satus.js
+++ b/menu/satus.js
@@ -791,10 +791,18 @@ satus.render = function(skeleton, container, property, childrenOnly, prepend, sk
 						set: function(val) {
 							value = val;
 	
-							if (satus.storage.get(key) != val) {
-								satus.storage.set(key, val);
-		
-								parent.dispatchEvent(new CustomEvent('change'));
+							if (skeleton.storage !== false) {
+								if (val === 'satus_remove') {
+									// 'satus_remove' is a special key signalling default option, remove instead of storing
+									satus.storage.remove(key);
+
+									parent.dispatchEvent(new CustomEvent('change'));
+								} else if (satus.storage.get(key) != val) {
+									// only store if actually different value
+									satus.storage.set(key, val);
+
+									parent.dispatchEvent(new CustomEvent('change'));
+								}
 							}
 						}
 					}

--- a/menu/satus.js
+++ b/menu/satus.js
@@ -2012,20 +2012,12 @@ satus.components.radio = function(component, skeleton) {
 /*--------------------------------------------------------------
 >>> SLIDER
 --------------------------------------------------------------*/
-
 satus.components.slider = function(component, skeleton) {
-	var content = component.createChildElement('div', 'content'),
+	const content = component.createChildElement('div', 'content'),
 		children_container = content.createChildElement('div', 'children-container'),
 		text_input = content.createChildElement('input'),
 		track_container = component.createChildElement('div', 'track-container'),
 		input = track_container.createChildElement('input', 'input');
-
-	component.childrenContainer = children_container;
-	component.textInput = text_input;
-	component.input = input;
-	component.track = track_container.createChildElement('div', 'track');
-
-	text_input.type = 'text';
 
 	input.type = 'range';
 	input.min = skeleton.min || 0;
@@ -2033,8 +2025,16 @@ satus.components.slider = function(component, skeleton) {
 	input.step = skeleton.step || 1;
 	input.value = component.storage?.value || skeleton.value || 0;
 
+	component.childrenContainer = children_container;
+	component.input = input;
+	component.track = track_container.createChildElement('div', 'track');
+	component.track.style.width = 100 / (input.max - input.min) * (input.value - input.min) + '%';
+	component.textInput = text_input;
+	component.textInput.type = 'text';
+	component.textInput.value = input.value;
+
 	text_input.addEventListener('blur', function() {
-		var component = this.parentNode.parentNode;
+		const component = this.parentNode.parentNode;
 
 		component.input.value = Number(this.value.replace(/[^0-9.]/g, ''));
 
@@ -2043,7 +2043,7 @@ satus.components.slider = function(component, skeleton) {
 
 	text_input.addEventListener('keydown', function(event) {
 		if (event.key === 'Enter') {
-			var component = this.parentNode.parentNode;
+			const component = this.parentNode.parentNode;
 
 			component.input.value = Number(this.value.replace(/[^0-9.]/g, ''));
 
@@ -2052,7 +2052,7 @@ satus.components.slider = function(component, skeleton) {
 	});
 
 	input.addEventListener('input', function() {
-		var component = this.parentNode.parentNode;
+		const component = this.parentNode.parentNode;
 
 		component.value = Number(this.value);
 
@@ -2060,17 +2060,22 @@ satus.components.slider = function(component, skeleton) {
 	});
 
 	component.update = function() {
-		var input = this.input;
+		const input = this.input;
 
 		this.textInput.value = input.value;
+		if (component.storage) {
+			if (component.skeleton.value == Number(input.value)) {
+				component.storage.value = 'satus_remove';
+			} else {
+				component.storage.value = Number(input.value);
+			}
+		}
 
 		this.track.style.width = 100 / (input.max - input.min) * (input.value - input.min) + '%';
 	};
 
-	component.update();
-
 	if (skeleton.on) {
-		for (var type in skeleton.on) {
+		for (const type in skeleton.on) {
 			input.addEventListener(type, function(event) {
 				this.parentNode.parentNode.dispatchEvent(new Event(event.type));
 			});

--- a/menu/satus.js
+++ b/menu/satus.js
@@ -71,14 +71,19 @@ components.modal.confirm
 // declarations for optional ok() and cancel(). Simplified takes care of closing popup on its own.
 components.grid
 components.textField
-			chart	chart.bar
+			chart
+			chart.bar
 			select
 components.divider()	base(component)	section
-			alert	time	sidebar
+			alert
+			time
+			sidebar
 			layers
 			list
 			colorPicker
-			radio	slider
+			radio
+// radio button controls storage.key defined by radio.group: 'key'
+			slider
 			tabs
 			shortcut
 			checkbox
@@ -1585,13 +1590,10 @@ satus.components.chart.bar = function(component, skeleton) {
 >>> SELECT
 --------------------------------------------------------------*/
 satus.components.select = function(component, skeleton) {
-	let content = component.createChildElement('div', 'content');
-
-	component.childrenContainer = content;
+	component.childrenContainer = component.createChildElement('div', 'content');
 	component.valueElement = document.createElement('span');
-	component.selectElement = document.createElement('select');
-
 	component.valueElement.className = 'satus-select__value';
+	component.selectElement = document.createElement('select');
 
 	component.appendChild(component.valueElement);
 	component.appendChild(component.selectElement);
@@ -1602,11 +1604,11 @@ satus.components.select = function(component, skeleton) {
 		component.options = component.options();
 	}
 
-	for (let i = 0, l = component.options.length; i < l; i++) {
-		var option = document.createElement('option');
+	for (const options of component.options) {
+		const option = document.createElement('option');
 
-		option.value = component.options[i].value;
-		satus.text(option, component.options[i].text);
+		option.value = options.value;
+		satus.text(option, options.text);
 		component.selectElement.appendChild(option);
 	}
 
@@ -3209,9 +3211,7 @@ satus.user.device.connection = function() {
 # SEARCH
 --------------------------------------------------------------*/
 satus.search = function(query, object, callback) {
-	let elements = ['switch', 'select', 'slider', 'shortcut', 'radio', 'color-picker', 'label', 'button'],
-		threads = 0,
-		results = {},
+	const included = ['switch', 'select', 'slider', 'shortcut', 'radio', 'color-picker', 'label', 'button'],
 		excluded = [
 			'baseProvider',
 			'layersProvider',
@@ -3222,6 +3222,8 @@ satus.search = function(query, object, callback) {
 			'parentElement',
 			'rendered'
 		];
+	let threads = 0,
+		results = {};
 
 	query = query.toLowerCase();
 
@@ -3233,7 +3235,7 @@ satus.search = function(query, object, callback) {
 
 				if (item.component && item.text
 					// list of elements we allow search on
-					&& elements.includes(item.component)
+					&& included.includes(item.component)
 					// only pass buttons whose parents are variant: 'card' or special case 'appearance' (this one abuses variant tag for CSS)
 					&& (item.component != 'button' || item.parentObject?.variant == "card" || item.parentObject?.variant == "appearance")
 					// try to match query against localized description, fallback on component name

--- a/menu/satus.js
+++ b/menu/satus.js
@@ -67,6 +67,8 @@ text(element, value)
 
 components.modal(component, skeleton)
 components.modal.confirm
+// modal variant: 'confirm' supports two forms: Full with user providing own skeleton.buttons, and simplified with only function
+// declarations for optional ok() and cancel(). Simplified takes care of closing popup on its own.
 components.grid
 components.textField
 			chart	chart.bar
@@ -81,7 +83,9 @@ components.divider()	base(component)	section
 			shortcut
 			checkbox
 components.switch
-components.switch.flip
+components.switch.flip(state)
+//switch variant: 'manual' disables automatic flipping on click, user provided on.click function should handle this
+//by calling this.flip(true|false) manually.
 ----------------------------------------------------------------
 >>> COLOR:
 String to array
@@ -2485,8 +2489,8 @@ satus.components.switch = function(component, skeleton) {
 	component.dataset.value = value;
 	component.flip = satus.components.switch.flip;
 
-	// 'custom' disables default onclick, user provided function should handle this functionality manually
-	if (!skeleton.custom) {
+	// switch variant: 'manual' disables automatic flipping on click, user provided function should handle switching manually
+	if (skeleton.variant != 'manual') {
 		component.addEventListener('click', function() {
 			this.flip();
 		}, true);

--- a/menu/satus.js
+++ b/menu/satus.js
@@ -2447,7 +2447,6 @@ satus.components.shortcut = function(component, skeleton) {
 /*--------------------------------------------------------------
 >>> CHECKBOX
 --------------------------------------------------------------*/
-
 satus.components.checkbox = function(component, skeleton) {
 	component.input = component.createChildElement('input');
 	component.input.type = 'checkbox';
@@ -2456,18 +2455,28 @@ satus.components.checkbox = function(component, skeleton) {
 
 	component.childrenContainer = component.createChildElement('div', 'content');
 
-	component.dataset.value = component.storage.value || skeleton.value;
-	component.input.checked = component.storage.value || skeleton.value;
+	component.dataset.value = component.storage?.value || skeleton.value || false;
+	component.input.checked = component.storage?.value || skeleton.value || false;
 
 	component.input.addEventListener('change', function() {
-		var component = this.parentNode;
+		const component = this.parentNode;
 
 		if (this.checked === true) {
-			component.storage.value = true;
 			component.dataset.value = 'true';
+			if (component.skeleton.value == true) {
+				// skeleton.value: true makes this a default true checkbox where the only active state we save is false
+				component.storage.value = 'satus_remove';
+			} else {
+				component.storage.value = true;
+			}
 		} else {
-			component.storage.value = false;
 			component.dataset.value = 'false';
+			if (component.skeleton.value == true) {
+				// skeleton.value: true makes this a default true checkbox where the only active state we save is false
+				component.storage.value = false;
+			} else {
+				component.storage.value = 'satus_remove';
+			}
 		}
 	});
 };

--- a/menu/satus.js
+++ b/menu/satus.js
@@ -3195,9 +3195,8 @@ satus.user.device.connection = function() {
 /*--------------------------------------------------------------
 # SEARCH
 --------------------------------------------------------------*/
-
 satus.search = function(query, object, callback) {
-	var elements = ['switch', 'select', 'slider', 'shortcut', 'radio', 'color-picker', 'label', 'button'],
+	let elements = ['switch', 'select', 'slider', 'shortcut', 'radio', 'color-picker', 'label', 'button'],
 		threads = 0,
 		results = {},
 		excluded = [
@@ -3216,9 +3215,8 @@ satus.search = function(query, object, callback) {
 	function parse(items, parent) {
 		threads++;
 
-		for (const key in items) {
+		for (const [key, item] of Object.entries(items)) {
 			if (!excluded.includes(key)) {
-				var item = items[key];
 
 				if (item.component && item.text
 					// list of elements we allow search on
@@ -3231,12 +3229,10 @@ satus.search = function(query, object, callback) {
 					results[key] = Object.assign({}, item);
 				}
 
-				if (
-					satus.isObject(item) &&
-					!satus.isArray(item) &&
-					!satus.isElement(item) &&
-					!satus.isFunction(item)
-				) {
+				if (satus.isObject(item)
+					&& !satus.isArray(item)
+					&& !satus.isElement(item)
+					&& !satus.isFunction(item)) {
 					parse(item, items);
 				}
 			}

--- a/menu/satus.js
+++ b/menu/satus.js
@@ -791,18 +791,16 @@ satus.render = function(skeleton, container, property, childrenOnly, prepend, sk
 						set: function(val) {
 							value = val;
 	
-							if (skeleton.storage !== false) {
-								if (val === 'satus_remove') {
-									// 'satus_remove' is a special key signalling default option, remove instead of storing
-									satus.storage.remove(key);
+							if (val === 'satus_remove') {
+								// 'satus_remove' is a special key signalling default option, remove instead of storing
+								satus.storage.remove(key);
 
-									parent.dispatchEvent(new CustomEvent('change'));
-								} else if (satus.storage.get(key) != val) {
-									// only store if actually different value
-									satus.storage.set(key, val);
+								parent.dispatchEvent(new CustomEvent('change'));
+							} else if (satus.storage.get(key) != val) {
+								// only store if actually different value
+								satus.storage.set(key, val);
 
-									parent.dispatchEvent(new CustomEvent('change'));
-								}
+								parent.dispatchEvent(new CustomEvent('change'));
 							}
 						}
 					}

--- a/menu/satus.js
+++ b/menu/satus.js
@@ -2473,7 +2473,7 @@ satus.components.checkbox = function(component, skeleton) {
 --------------------------------------------------------------*/
 
 satus.components.switch = function(component, skeleton) {
-	var value = satus.isset(component.storage.value) ? component.storage.value : skeleton.value;
+	let value = component.storage?.value || skeleton.value || false;
 
 	if (satus.isFunction(value)) {
 		value = value();

--- a/menu/satus.js
+++ b/menu/satus.js
@@ -1581,7 +1581,7 @@ satus.components.chart.bar = function(component, skeleton) {
 >>> SELECT
 --------------------------------------------------------------*/
 satus.components.select = function(component, skeleton) {
-	var content = component.createChildElement('div', 'content');
+	let content = component.createChildElement('div', 'content');
 
 	component.childrenContainer = content;
 	component.valueElement = document.createElement('span');
@@ -1596,19 +1596,13 @@ satus.components.select = function(component, skeleton) {
 
 	if (satus.isFunction(component.options)) {
 		component.options = component.options();
-
-		if (!satus.isset(component.options)) {
-			component.options = [];
-		}
 	}
 
-	for (var i = 0, l = component.options.length; i < l; i++) {
+	for (let i = 0, l = component.options.length; i < l; i++) {
 		var option = document.createElement('option');
 
 		option.value = component.options[i].value;
-
 		satus.text(option, component.options[i].text);
-
 		component.selectElement.appendChild(option);
 	}
 
@@ -1632,18 +1626,18 @@ satus.components.select = function(component, skeleton) {
 	};
 
 	component.selectElement.addEventListener('change', function() {
-		var component = this.parentNode;
+		let component = this.parentNode;
 
 		component.storage.value = this.value;
 
 		component.render();
 	});
 
-	component.value = component.storage.value || component.options[0].value;
+	// initial select selectElement value is either stored value, or one with default special 'satus_remove' value, failing that first element is selected
+	component.value = component.storage.value || (component.options.find(element => element.value == 'satus_remove') ? 'satus_remove': false) || component.options[0].value;
 
 	component.render();
 };
-
 /*--------------------------------------------------------------
 >>> DIVIDER
 --------------------------------------------------------------*/

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -1068,7 +1068,7 @@ extension.skeleton.main.layers.section.player.on.click = {
 			text: 'saveAs',
 			options: [{
 				text: 'file',
-				value: 'file'
+				value: 'satus_remove'
 			}, {
 				text: 'clipboard',
 				value: 'clipboard'
@@ -1105,28 +1105,28 @@ extension.skeleton.main.layers.section.player.on.click = {
 			component: 'section',
 			variant: 'card',
 			title: 'extraButtonsBelowThePlayer',
-							below_player_screenshot: {
-								component: 'switch',
-								text: 'screenshot',
-								value: true
-							},
-							below_player_pip: {
-								component: 'switch',
-								text: 'pictureInPicture',
-								value: true
-							},
-							below_player_loop: {
-								component: 'switch',
-								text: 'loop',
-								value: true
-							}
-						},
-						player_hide_controls_options: {
-							component: "button",
-							text: "hidePlayerControlsBarButtons",
-							on: {
-								click: 'main.layers.section.appearance.on.click.player.on.click.player_hide_controls_options.on.click'
-							}
-						},
-	}	
+			below_player_screenshot: {
+				component: 'switch',
+				text: 'screenshot',
+				value: true
+			},
+			below_player_pip: {
+				component: 'switch',
+				text: 'pictureInPicture',
+				value: true
+			},
+			below_player_loop: {
+				component: 'switch',
+				text: 'loop',
+				value: true
+			}
+		},
+		player_hide_controls_options: {
+			component: "button",
+			text: "hidePlayerControlsBarButtons",
+			on: {
+				click: 'main.layers.section.appearance.on.click.player.on.click.player_hide_controls_options.on.click'
+			}
+		},
+	}
 };

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -526,7 +526,7 @@ extension.skeleton.main.layers.section.player.on.click = {
 						text: 'fontColor',
 						options: [{
 							text: 'white',
-							value: '#fff'
+							value: 'satus_remove'
 						}, {
 							text: 'yellow',
 							value: '#ff0'
@@ -561,7 +561,7 @@ extension.skeleton.main.layers.section.player.on.click = {
 							value: -1
 						}, {
 							text: '100%',
-							value: 0
+							value: 'satus_remove'
 						}, {
 							text: '150%',
 							value: 1
@@ -602,7 +602,7 @@ extension.skeleton.main.layers.section.player.on.click = {
 							value: '#f00'
 						}, {
 							text: 'black',
-							value: '#000'
+							value: 'satus_remove'
 						}]
 					},
 					subtitles_background_opacity: {
@@ -639,7 +639,7 @@ extension.skeleton.main.layers.section.player.on.click = {
 							value: '#f00'
 						}, {
 							text: 'black',
-							value: '#000'
+							value: 'satus_remove'
 						}]
 					},
 					subtitles_window_opacity: {
@@ -655,7 +655,7 @@ extension.skeleton.main.layers.section.player.on.click = {
 						text: 'characterEdgeStyle',
 						options: [{
 							text: 'none',
-							value: 0
+							value: 'satus_remove'
 						}, {
 							text: 'dropShadow',
 							value: 4

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -845,7 +845,6 @@ extension.skeleton.main.layers.section.player.on.click = {
 						block_vp9: {
 							component: 'switch',
 							text: 'blockVp9',
-							value: false,
 							custom: true,
 							on: {
 								click: function () {
@@ -877,7 +876,6 @@ extension.skeleton.main.layers.section.player.on.click = {
 						block_h264: {
 							component: 'switch',
 							text: 'blockH264',
-							value: false,
 							custom: true,
 							on: {
 								click: function () {
@@ -947,7 +945,6 @@ extension.skeleton.main.layers.section.player.on.click = {
 			component: 'switch',
 			text: 'codecH264',
 			storage: 'player_h264',
-			value: false,
 			custom: true,
 			on: {
 				click: function () {

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -858,8 +858,6 @@ extension.skeleton.main.layers.section.player.on.click = {
 												ok: function () {
 													where.flip(true);
 													where.parentElement.skeleton.sanitize();
-												},
-												cancel: function () {
 												}
 											}, extension.skeleton.rendered);
 										} else {
@@ -889,8 +887,6 @@ extension.skeleton.main.layers.section.player.on.click = {
 												ok: function () {
 													where.flip(true);
 													where.parentElement.skeleton.sanitize();
-												},
-												cancel: function () {
 												}
 											}, extension.skeleton.rendered);
 										} else {
@@ -905,13 +901,10 @@ extension.skeleton.main.layers.section.player.on.click = {
 							}
 						},
 						sanitize: function () {
-							if (satus.storage.get('player_h264')) {
-								if ((!satus.storage.get('block_vp9') || !satus.storage.get('block_av1') && satus.storage.get('block_h264')) ||
-									(satus.storage.get('block_vp9') && satus.storage.get('block_av1') && satus.storage.get('block_h264'))) {
-									satus.storage.set('player_h264', false);
-								}
-							} else if (satus.storage.get('block_vp9') && satus.storage.get('block_av1') && !satus.storage.get('block_h264')) {
+							if (satus.storage.get('block_vp9') && satus.storage.get('block_av1') && !satus.storage.get('block_h264')) {
 								satus.storage.set('player_h264', true);
+							} else {
+								satus.storage.remove('player_h264');
 							}
 						}
 					}
@@ -925,7 +918,7 @@ extension.skeleton.main.layers.section.player.on.click = {
 				},
 				on: {
 					render: function () {
-						var codecs = (satus.storage.get('block_h264') ? '' : 'h.264 ') + (satus.storage.get('block_vp9') ? '' : 'vp9 ') + (satus.storage.get('block_av1') ? '' : 'av1');
+						let codecs = (satus.storage.get('block_h264') ? '' : 'h.264 ') + (satus.storage.get('block_vp9') ? '' : 'vp9 ') + (satus.storage.get('block_av1') ? '' : 'av1');
 
 						if (codecs.includes('h.264') || codecs.includes('vp9')) {
 							this.style = '';
@@ -948,14 +941,14 @@ extension.skeleton.main.layers.section.player.on.click = {
 			custom: true,
 			on: {
 				click: function () {
-					let skeleton = this.parentNode.skeleton;
 					// refresh player_codecs/optimize_codec_for_hardware_acceleration elements when we change codecs
-					let refresh = function () {
+					function refresh() {
 						document.getElementById('player_quality').dispatchEvent(new CustomEvent('render'));
 						document.getElementById('player_codecs').dispatchEvent(new CustomEvent('render'));
 						document.getElementById('optimize_codec_for_hardware_acceleration').dispatchEvent(new CustomEvent('render'));
 						document.getElementById('player_quality_without_focus').dispatchEvent(new CustomEvent('render'));
-					}
+					};
+
 					if (this.dataset.value === 'false') {
 						let where = this;
 						satus.render({
@@ -967,20 +960,18 @@ extension.skeleton.main.layers.section.player.on.click = {
 								where.flip(true);
 								satus.storage.set('block_vp9', true);
 								satus.storage.set('block_av1', true);
-								satus.storage.set('block_h264', false);
+								satus.storage.remove('block_h264');
 								refresh();
-							},
-							cancel: function () {
-								// nothing happens when we cancel
 							}
 						}, extension.skeleton.rendered);
 					} else {
 						// manually turn switch OFF
 						this.flip(false);
 						// reset all codecs to unlocked state
-						satus.storage.set('block_vp9', false);
-						satus.storage.set('block_av1', false);
-						satus.storage.set('block_h264', false);
+						satus.storage.remove('block_vp9');
+						satus.storage.remove('block_av1');
+						satus.storage.remove('block_h264');
+						satus.storage.remove('player_h264');
 						refresh();
 					}
 				}

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -844,8 +844,8 @@ extension.skeleton.main.layers.section.player.on.click = {
 						},
 						block_vp9: {
 							component: 'switch',
+							variant: 'manual',
 							text: 'blockVp9',
-							custom: true,
 							on: {
 								click: function () {
 									if (this.dataset.value === 'false') {
@@ -873,8 +873,8 @@ extension.skeleton.main.layers.section.player.on.click = {
 						},
 						block_h264: {
 							component: 'switch',
+							variant: 'manual',
 							text: 'blockH264',
-							custom: true,
 							on: {
 								click: function () {
 									if (this.dataset.value === 'false') {
@@ -936,9 +936,9 @@ extension.skeleton.main.layers.section.player.on.click = {
 		},
 		h264: {
 			component: 'switch',
+			variant: 'manual',
 			text: 'codecH264',
 			storage: 'player_h264',
-			custom: true,
 			on: {
 				click: function () {
 					// refresh player_codecs/optimize_codec_for_hardware_acceleration elements when we change codecs
@@ -971,7 +971,6 @@ extension.skeleton.main.layers.section.player.on.click = {
 						satus.storage.remove('block_vp9');
 						satus.storage.remove('block_av1');
 						satus.storage.remove('block_h264');
-						satus.storage.remove('player_h264');
 						refresh();
 					}
 				}

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -160,7 +160,7 @@ extension.skeleton.main.layers.section.player.on.click = {
 						text: 'language',
 						id: 'language_closed_caption',
 						options: [{
-							value: 'default',
+							value: 'satus_remove',
 							text: 'default_CC'
 						}, {
 							value: 'af',

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -6,9 +6,7 @@ extension.skeleton.main.layers.section.player = {
 	component: 'button',
 	variant: 'player',
 	category: true,
-	on: {
-		click: {}
-	},
+	on: {},
 
 	icon: {
 		component: 'span',
@@ -702,7 +700,7 @@ extension.skeleton.main.layers.section.player.on.click = {
 			id: 'player_quality',
 			options: [{
 				text: 'auto',
-				value: 'auto'
+				value: 'satus_remove'
 			}, {
 				text: '144p',
 				value: 'tiny'

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -509,7 +509,7 @@ extension.skeleton.main.layers.section.player.on.click = {
 							value: 3
 						}, {
 							text: 'Proportional Sans-Serif',
-							value: 4
+							value: 'satus_remove'
 						}, {
 							text: 'Casual',
 							value: 5


### PR DESCRIPTION
Special 'satus_remove' value signaling default option. Storing 'satus_remove' in any config variable automagically deletes it. For example User switching player_quality back to auto will set it to 'satus_remove' value which in turn will automatically delete player_quality key from config. 

Converted components.switch to only store active usage, flipping switch to default position deletes it from config. This respects skeleton.value: true witches that start as default ON like up_next_autoplay. Those only save False value and get automatically deleted when switched to True.

In principle no additional code changes should be required to \web-accessible\ side of extension, but this opens possibility of simplifying code a lot. After automatically converting all user configs on next upgrade we will no longer have to check for config_variable != 'disabled', != 'auto',=== true, === false, this.isset(option) etc.