### PR TITLE
Update active-features.js search returns buttons now, skip those

### DIFF
--- a/menu/skeleton-parts/active-features.js
+++ b/menu/skeleton-parts/active-features.js
@@ -15,9 +15,13 @@ extension.skeleton.header.sectionEnd.menu.on.click.activeFeatures = {
 					satus.search('', extension.skeleton, function (features) {
 						let skeleton = {};
 
-						for (const key in features) {
-							let feature = features[key],
-								default_value = feature.value,
+						for (const [key, feature] of Object.entries(features)) {
+							// search returns buttons now, skip those
+							if (feature.component === 'button') {
+								continue;
+							}
+
+							let default_value = feature.value,
 								value = feature.storage && satus.storage.get(feature.storage)
 									|| feature.radio && satus.storage.get(feature.radio.group) == feature.radio.value
 									|| satus.storage.get(key),


### PR DESCRIPTION
I didnt notice active-features started glitching by showing buttons due to new search including them in results