### PR TITLE
Update init.js ImprovedTube.livechat collapsed called too early

### DIFF
--- a/js&css/web-accessible/init.js
+++ b/js&css/web-accessible/init.js
@@ -103,7 +103,6 @@ ImprovedTube.init = function () {
 	if(this.storage.undo_the_new_sidebar === true){this.undoTheNewSidebar();}
 	if(this.storage.description === "sidebar"){this.descriptionSidebar();}
 	this.channelCompactTheme();
-	this.livechat();
 	
 	if (ImprovedTube.elements.player && ImprovedTube.elements.player.setPlaybackRate) {
 		ImprovedTube.videoPageUpdate();


### PR DESCRIPTION
https://github.com/code-charity/youtube/blob/d8065714b67e4bbb891b11eedd72ef68f0afed38/js%26css/web-accessible/www.youtube.com/appearance.js#L316-L322

called in init https://github.com/code-charity/youtube/blob/d8065714b67e4bbb891b11eedd72ef68f0afed38/js%26css/web-accessible/init.js#L106

appearance.js:320 Uncaught TypeError: Cannot read properties of undefined (reading 'click')
    at ImprovedTube.livechat (appearance.js:320:51)
    at ImprovedTube.init (init.js:106:7)
    at HTMLDocument.<anonymous> (core.js:176:17)

git blame shows it has been like this for at lest two years

ImprovedTube.elements.livechat stays initialized as empty object https://github.com/code-charity/youtube/blob/d8065714b67e4bbb891b11eedd72ef68f0afed38/js%26css/web-accessible/core.js#L25

until https://github.com/code-charity/youtube/blob/d8065714b67e4bbb891b11eedd72ef68f0afed38/js%26css/web-accessible/functions.js#L145-L148

