### PR TITLE
Update manifest.json forgot comma

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -77,7 +77,7 @@
 				"js&css/web-accessible/www.youtube.com/shortcuts.js",
 				"js&css/web-accessible/www.youtube.com/blocklist.js",
 				"js&css/web-accessible/www.youtube.com/settings.js",
-				"js&css/web-accessible/init.js"
+				"js&css/web-accessible/init.js",
 				"stuff/icons/48.png"
 			],
 			"matches": [

--- a/manifest.json
+++ b/manifest.json
@@ -57,7 +57,6 @@
 		}
 	],
 	"host_permissions": [ "https://www.youtube.com/*" ],
-	"offline_enabled": true,
 	"optional_permissions": [
 		"downloads"
 	],

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,9 @@
 		"48": "stuff/icons/48.png"
 	},
 	"background": {
-		"service_worker": "background.js"
+		"scripts": [
+			"background.js"
+		]
 	},
 	"action": {
 		"default_popup": "menu/index.html",

--- a/manifest.json
+++ b/manifest.json
@@ -12,9 +12,7 @@
 		"48": "stuff/icons/48.png"
 	},
 	"background": {
-		"scripts": [
-			"background.js"
-		]
+		"service_worker": "background.js"
 	},
 	"action": {
 		"default_popup": "menu/index.html",


### PR DESCRIPTION
I was going to also fix FF compatibility, but:
~~with "service_worker": changed to "scripts":~~ https://stackoverflow.com/questions/75043889/manifest-v3-background-scripts-service-worker-on-firefox/78088358#78088358 needs both
```
"background": {
    "service_worker": "background.js",
    "scripts": ["background.js"]
},
```
 for full cross compatibility with Firefox under V3 manifest
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background#browser_support
Issue: warnins in both browsers :/. Firefox one:
```
Warning details

Reading manifest: Warning processing background.service_worker: An unexpected property was found in the WebExtension manifest.
```
Chrome one:
`'background.scripts' requires manifest version of 2 or lower.`