### PR TITLE
Captions rename for live updating, add option to force disable

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -216,7 +216,7 @@ ImprovedTube.playerSubtitles = function () {
 				break
 
 			case 'disabled':
-				if (player.isSubtitlesOn) { player.toggleSubtitles(); }
+				if (player.isSubtitlesOn()) { player.toggleSubtitles(); }
 				break
 		}
 	}
@@ -253,15 +253,15 @@ SUBTITLES WINDOW OPACITY
 SUBTITLES CHARACTER EDGE STYLE
 SUBTITLES FONT OPACITY
 default = {
-    "fontFamily": 4,
-    "color": "#fff",
-    "fontSizeIncrement": 0,
-    "background": "#080808",
-    "backgroundOpacity": 0.75,
-    "windowColor": "#080808",
-    "windowOpacity": 0,
-    "charEdgeStyle": 0,
-    "textOpacity": 1,
+	"fontFamily": 4,
+	"color": "#fff",
+	"fontSizeIncrement": 0,
+	"background": "#080808",
+	"backgroundOpacity": 0.75,
+	"windowColor": "#080808",
+	"windowOpacity": 0,
+	"charEdgeStyle": 0,
+	"textOpacity": 1,
 },
 ------------------------------------------------------------------------------*/
 ImprovedTube.subtitlesUserSettings = function () {
@@ -569,7 +569,7 @@ ImprovedTube.screenshot = function () {
 
 	cvs.toBlob(function (blob) {
 		if (ImprovedTube.storage.player_screenshot_save_as == 'clipboard') {
-			window.focus(); 
+			window.focus();
 			navigator.clipboard.write([
 				new ClipboardItem({
 					'image/png': blob

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -228,13 +228,17 @@ ImprovedTube.subtitlesLanguage = function () {
 	const option = this.storage.subtitles_language,
 		player = this.elements.player,
 		button = this.elements.player_subtitles_button;
+	let subtitlesState;
 
-	if (option && player && player.getOption && button && button.getAttribute('aria-pressed') === 'true') {
+	if (option && player && player.getOption && player.isSubtitlesOn && player.toggleSubtitles && button) {
 		const tracklists = player.getOption('captions', 'tracklist', {includeAsr: true}),
 			matchedTrack = tracklists.find(element => element.languageCode.includes(option) && (!element.vss_id.includes("a.") || this.storage.auto_generate));
 
 		if (matchedTrack) {
+			subtitlesState = player.isSubtitlesOn();
 			player.setOption('captions', 'track', matchedTrack);
+			// setOption forces Subtitles ON, restore state from before calling it.
+			if (!subtitlesState) { player.toggleSubtitles(); }
 		}
 	}
 };

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -309,7 +309,7 @@ ImprovedTube.subtitlesDisableLyrics = function () {
 		var player = this.elements.player,
 			button = this.elements.player_subtitles_button;
 
-		if (player && player.toggleSubtitles && button  && !button.title.includes('unavailable')) {
+		if (player && player.toggleSubtitles && button && !button.title.includes('unavailable')) {
 			// Music detection only uses 3 identifiers for Lyrics: lyrics, sing-along, karaoke.
 			// Easier to simply use those here. Can replace with music detection later.
 			const terms = ["sing along", "sing-along", "karaoke", "lyric", "卡拉OK", "卡拉OK", "الكاريوكي", "караоке", "カラオケ","노래방"];

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -230,7 +230,7 @@ ImprovedTube.subtitlesLanguage = function () {
 		button = this.elements.player_subtitles_button;
 	let subtitlesState;
 
-	if (option && player && player.getOption && player.isSubtitlesOn && player.toggleSubtitles && button) {
+	if (option && player && player.getOption && player.isSubtitlesOn && player.toggleSubtitles && button && !button.title.includes('unavailable')) {
 		const tracklists = player.getOption('captions', 'tracklist', {includeAsr: true}),
 			matchedTrack = tracklists.find(element => element.languageCode.includes(option) && (!element.vss_id.includes("a.") || this.storage.auto_generate));
 
@@ -280,7 +280,7 @@ ImprovedTube.subtitlesUserSettings = function () {
 		player = this.elements.player,
 		button = this.elements.player_subtitles_button;
 
-	if (option.length && player.getSubtitlesUserSettings && button) {
+	if (option.length && player.getSubtitlesUserSettings && button && !button.title.includes('unavailable')) {
 		let settings = player.getSubtitlesUserSettings();
 		
 		for (const value of option) {
@@ -305,11 +305,11 @@ ImprovedTube.subtitlesUserSettings = function () {
 SUBTITLES DISABLE SUBTILES FOR LYRICS
 ------------------------------------------------------------------------------*/
 ImprovedTube.subtitlesDisableLyrics = function () {
-	if (this.storage.subtitles_disable_lyrics === true) {
+	if (this.storage.subtitles_disable_lyrics) {
 		var player = this.elements.player,
 			button = this.elements.player_subtitles_button;
 
-		if (player && player.toggleSubtitles && button && button.getAttribute('aria-pressed') === 'true') {
+		if (player && player.toggleSubtitles && button  && !button.title.includes('unavailable')) {
 			// Music detection only uses 3 identifiers for Lyrics: lyrics, sing-along, karaoke.
 			// Easier to simply use those here. Can replace with music detection later.
 			const terms = ["sing along", "sing-along", "karaoke", "lyric", "卡拉OK", "卡拉OK", "الكاريوكي", "караоке", "カラオケ","노래방"];

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -280,7 +280,7 @@ ImprovedTube.subtitlesUserSettings = function () {
 		player = this.elements.player,
 		button = this.elements.player_subtitles_button;
 
-	if (option.length && player.getSubtitlesUserSettings && button && button.getAttribute('aria-pressed') === 'true') {
+	if (option.length && player.getSubtitlesUserSettings && button) {
 		let settings = player.getSubtitlesUserSettings();
 		
 		for (const value of option) {

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -205,12 +205,19 @@ function getRandomInvidiousInstance() { return invidiousInstances[Math.floor(Mat
 /*------------------------------------------------------------------------------
 SUBTITLES
 ------------------------------------------------------------------------------*/
-ImprovedTube.subtitles = function () {
-	if (this.storage.player_subtitles === true) {
-		var player = this.elements.player;
+ImprovedTube.playerSubtitles = function () {
+	const player = this.elements.player;
+	
+	if (player && player.isSubtitlesOn && player.toggleSubtitles && player.toggleSubtitlesOn) {
+		switch(this.storage.player_subtitles) {
+			case true:
+			case 'enabled':
+				player.toggleSubtitlesOn();
+				break
 
-		if (player && player.toggleSubtitlesOn) {
-			player.toggleSubtitlesOn();
+			case 'disabled':
+				if (player.isSubtitlesOn) { player.toggleSubtitles(); }
+				break
 		}
 	}
 };

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -160,8 +160,18 @@ extension.skeleton.main.layers.section.player.on.click = {
 					variant: 'card',
 
 					player_subtitles: {
-						component: 'switch',
-						text: 'subtitles'
+						component: 'select',
+						text: 'subtitles',
+						options: [{
+							value: 'auto',
+							text: 'auto'
+						}, {
+							value: 'enabled',
+							text: 'enabled'
+						}, {
+							value: 'disabled',
+							text: 'disabled'
+						}]
 					},
 					subtitles_language: {
 						component: 'select',


### PR DESCRIPTION
new options, compatible with old user settings
```
player_subtitles: {
	text: 'auto' default YT behavior (yt detects user language and decides on its own)
	text: 'enabled' always enables 
	text: 'disabled' always disables
```
Can switch live without reloading page.

subtitlesLanguage no longer forces subtitles on
subtitlesUserSettings apply even when disabled - turned on later will have settings already applied