### PR TITLE
Update player.js reverting #2062, fixes #1342 #1652 #1904

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -39,11 +39,11 @@ ImprovedTube.autoplayDisable = function (videoElement) {
 FORCED PLAY VIDEO FROM THE BEGINNING
 ------------------------------------------------------------------------------*/
 ImprovedTube.forcedPlayVideoFromTheBeginning = function () {
-	if (this.storage.forced_play_video_from_the_beginning === true && document.documentElement.dataset.pageType === 'video' && !this.video_url.match(this.regex.video_time)?.[1]) {
-		this.elements.player.seekTo(0);
+	const video = this.elements.video;
+	if (video && this.storage.forced_play_video_from_the_beginning && location.pathname == '/watch') {
+		video.currentTime = 0;
 	}
 };
-
 /*------------------------------------------------------------------------------
 AUTOPAUSE WHEN SWITCHING TABS
 ------------------------------------------------------------------------------*/

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -39,9 +39,14 @@ ImprovedTube.autoplayDisable = function (videoElement) {
 FORCED PLAY VIDEO FROM THE BEGINNING
 ------------------------------------------------------------------------------*/
 ImprovedTube.forcedPlayVideoFromTheBeginning = function () {
-	const video = this.elements.video;
-	if (video && this.storage.forced_play_video_from_the_beginning && location.pathname == '/watch') {
-		video.currentTime = 0;
+	const player = this.elements.player,
+		video = this.elements.video,
+		paused = video?.paused;
+	
+	if (player && video && this.storage.forced_play_video_from_the_beginning && location.pathname == '/watch') {
+		player.seekTo(0);
+		// restore previous paused state
+		if (paused) { player.pauseVideo(); }
 	}
 };
 /*------------------------------------------------------------------------------


### PR DESCRIPTION
reverting #2062, implementation of https://github.com/code-charity/youtube/issues/2061 , bad idea, YT internally uses same parameter markers so we cant really distinguish between YT resuming and someone opening link with timestamp 

this.elements.player.seekTo(0) rewinds, but with side effects of triggering play()

switch from this.elements.player.seekTo(0) to this.elements.video.currentTime = 0 didnt work. YT player actually reads currentTime and will hang while hammering currentTime(whatever) if it doesnt get what it wants :0. Back to seekTo(0) with optional check for paused.