### PR TITLE
Update player.js PiP only outside tab

### DIFF
--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -415,10 +415,7 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
 				path.setAttributeNS(null, 'd', 'M19 7h-8v6h8V7zm2-4H3C2 3 1 4 1 5v14c0 1 1 2 2 2h18c1 0 2-1 2-2V5c0-1-1-2-2-2zm0 16H3V5h18v14z');
 
 				button.onclick = function () {
-					var video = document.querySelector('#movie_player video');
-					if (video) {
-						video.requestPictureInPicture();
-					}
+					ImprovedTube.enterPip();
 				};
 
 				svg.appendChild(path);	button.appendChild(svg);

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -7,12 +7,12 @@ ImprovedTube.autoplayDisable = function (videoElement) {
 		|| this.storage.channel_trailer_autoplay === false) {
 		const player = this.elements.player || videoElement.closest('.html5-video-player') || videoElement.closest('#movie_player'); // #movie_player: outdated since 2024?
 
-		if (this.video_url !== location.href) {
-			this.user_interacted = false;
-		}
+		if (this.video_url !== location.href) this.user_interacted = false;
 
-		// if (no user clicks) and (no ads playing) and
-		// ( there is a player and ( (it is not in a playlist and auto play is off ) or ( playlist auto play is off and in a playlist ) ) ) or (if we are in a channel and the channel trailer autoplay is off)  )
+		// if (there is a player) and (no user clicks) and (no ads playing)
+		// and ( ( it is not in a playlist and auto play is off )
+		//    or ( playlist auto play is off and in a playlist )
+		//    or ( we are in a channel and the channel trailer autoplay is off ) )
 
 		// user didnt click
 		if (player && !this.user_interacted

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -55,7 +55,7 @@ ImprovedTube.enterPip = function (disable) {
 		video.requestPictureInPicture().then(() => {
 			if (video.paused) {
 				// manually send Play message to "Auto-pause while I'm not in the tab", paused PiP wont do it automatically.
-				document.dispatchEvent(new CustomEvent('it-message-from-youtube', {'detail': {action: 'play'}}));
+				document.dispatchEvent(new CustomEvent('it-play'));
 			}
 			return true;
 		}).catch((err) => console.error('playerAutoPip: Failed to enter Picture-in-Picture mode', err));

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -42,6 +42,39 @@ ImprovedTube.autoplayDisable = function (videoElement) {
 	}
 };
 /*------------------------------------------------------------------------------
+FORCED PLAY VIDEO FROM THE BEGINNING
+------------------------------------------------------------------------------*/
+ImprovedTube.forcedPlayVideoFromTheBeginning = function () {
+	const player = this.elements.player,
+		video = this.elements.video,
+		paused = video?.paused;
+
+	if (player && video && this.storage.forced_play_video_from_the_beginning && location.pathname == '/watch') {
+		player.seekTo(0);
+		// restore previous paused state
+		if (paused) {
+			player.pauseVideo();
+		}
+	}
+};
+/*------------------------------------------------------------------------------
+AUTOPAUSE WHEN SWITCHING TABS
+------------------------------------------------------------------------------*/
+ImprovedTube.playerAutopauseWhenSwitchingTabs = function () {
+	const player = this.elements.player;
+
+	if (this.storage.player_autopause_when_switching_tabs && player) {
+		if (this.focus && this.played_before_blur && this.elements.video.paused) {
+			player.playVideo();
+		} else {
+			this.played_before_blur = !this.elements.video.paused;
+			if (!this.elements.video.paused) {
+				player.pauseVideo();
+			}
+		}
+	}
+};
+/*------------------------------------------------------------------------------
 PICTURE IN PICTURE (PIP)
 ------------------------------------------------------------------------------*/
 ImprovedTube.enterPip = function (disable) {
@@ -74,37 +107,6 @@ ImprovedTube.playerAutoPip = function () {
 		this.enterPip(true);
 	} else if (this.storage.player_autoPip && !this.focus && !video?.paused) {
 		this.enterPip();
-	}
-};
-/*------------------------------------------------------------------------------
-AUTOPAUSE WHEN SWITCHING TABS
-------------------------------------------------------------------------------*/
-ImprovedTube.playerAutopauseWhenSwitchingTabs = function () {
-	const player = this.elements.player;
-
-	if (this.storage.player_autopause_when_switching_tabs && player) {
-		if (this.focus && this.played_before_blur && this.elements.video.paused) {
-			player.playVideo();
-		} else {
-			this.played_before_blur = !this.elements.video.paused;
-			if (!this.elements.video.paused) {
-				player.pauseVideo();
-			}
-		}
-	}
-};
-/*------------------------------------------------------------------------------
-AUTO PIP WHEN SWITCHING TABS
-------------------------------------------------------------------------------*/
-ImprovedTube.playerAutoPip = function () {
-	const video = this.elements.video;
-
-	if (this.focus && this.storage.player_autoPip_outside && document.pictureInPictureElement && typeof document.exitPictureInPicture == 'function') {
-		document.exitPictureInPicture();
-	} else if (!this.focus && !video.paused && this.storage.player_autoPip && video) {
-		if (video && document.pictureInPictureEnabled && typeof video.requestPictureInPicture == 'function') {
-			video.requestPictureInPicture().then().catch((err) => console.error('Failed to enter Picture-in-Picture mode', err));
-		}
 	}
 };
 /*------------------------------------------------------------------------------

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -78,16 +78,14 @@ ImprovedTube.playerAutopauseWhenSwitchingTabs = function () {
 AUTO PIP WHEN SWITCHING TABS
 ------------------------------------------------------------------------------*/
 ImprovedTube.playerAutoPip = function () {
-	const video = ImprovedTube.elements.video;
+	const video = this.elements.video;
 
-	if (this.storage.player_autoPip === true && video) {
-		(async () => {
-			try {
-				await video.requestPictureInPicture();
-			  } catch (error) {
-				console.error('Failed to enter Picture-in-Picture mode', error);
-			  }
-		  })();
+	if (this.focus && this.storage.player_autoPip_outside && document.pictureInPictureElement && typeof document.exitPictureInPicture == 'function') {
+		document.exitPictureInPicture();
+	} else if (!this.focus && !video.paused && this.storage.player_autoPip && video) {
+		if (video && document.pictureInPictureEnabled && typeof video.requestPictureInPicture == 'function') {
+			video.requestPictureInPicture().then().catch((err) => console.error('Failed to enter Picture-in-Picture mode', err));
+		}
 	}
 };
 /*------------------------------------------------------------------------------

--- a/js&css/web-accessible/www.youtube.com/shortcuts.js
+++ b/js&css/web-accessible/www.youtube.com/shortcuts.js
@@ -151,14 +151,9 @@ ImprovedTube.shortcutQuality = function (key) {
 	ImprovedTube.playerQuality(label[resolution.indexOf(key.replace('shortcutQuality', ''))]);
 };
 /*------------------------------------------------------------------------------
-4.7.2 PICTURE IN PICTURE
+4.7.2 PICTURE IN PICTURE (PIP)
 ------------------------------------------------------------------------------*/
-ImprovedTube.shortcutPictureInPicture = function () {
-	const video = ImprovedTube.elements.video;
-	if (video && document.pictureInPictureEnabled && typeof video.requestPictureInPicture == 'function') {
-		video.requestPictureInPicture().then().catch((err) => console.error(err));
-	}
-};
+ImprovedTube.shortcutPictureInPicture = this.enterPip;
 /*------------------------------------------------------------------------------
 4.7.3 TOGGLE CONTROLS
 ------------------------------------------------------------------------------*/

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -98,14 +98,38 @@ extension.skeleton.main.layers.section.player.on.click = {
 			component: 'switch',
 			text: 'Auto_PiP_picture_in_picture',
 			id: 'player_autoPip',
+			custom: true,
 			on: {
 				click: function () {
-					if (this.dataset.value === 'true' && satus.storage.get('player_autopause_when_switching_tabs')) {
-						document.getElementById('only_one_player_instance_playing').flip(true);
-						document.getElementById('autopause_when_switching_tabs').flip(false);
+					if (this.dataset.value === 'false') {
+						let where = this;
+						satus.render({
+							component: 'modal',
+							variant: 'confirm',
+							content: 'PipRequiresUserInteraction',
+							ok: function () {
+								// manually turn switch ON
+								where.flip(true);
+								if (satus.storage.get('player_autopause_when_switching_tabs')) {
+									document.getElementById('only_one_player_instance_playing').flip(true);
+									document.getElementById('autopause_when_switching_tabs').flip(false);
+								}
+							},
+							cancel: function () {
+								// nothing happens when we cancel
+							}
+						}, extension.skeleton.rendered);
+					} else {
+						// manually turn switch OFF
+						this.flip(false);
 					}
 				}
 			}
+		},
+		player_autoPip_outside: {
+			component: 'switch',
+			text: 'playerAutoPipOutside',
+			value: true
 		},
 		player_forced_volume: {
 			component: 'switch',

--- a/menu/styles/sub-options.css
+++ b/menu/styles/sub-options.css
@@ -1,34 +1,34 @@
 /*-----------------
 NESTED (CONDITIONAL) SWITCHES
 -----------------*/
-#remove-home-page-shorts:not([data-value='true']) + .satus-switch,
-#remove-home-page-shorts:not([data-value='true']) + .satus-switch + .satus-switch,
-#remove-home-page-shorts:not([data-value='true']) + .satus-switch + .satus-switch + .satus-switch,
+#remove-home-page-shorts:not([data-value=true]) + .satus-switch,
+#remove-home-page-shorts:not([data-value=true]) + .satus-switch + .satus-switch,
+#remove-home-page-shorts:not([data-value=true]) + .satus-switch + .satus-switch + .satus-switch,
 /*-----------------
 >>> Appearance
 -----------------*/
 /*-transcript compact spacing-*/
-#transcript:not([data-value='true']) + .satus-switch,
+#transcript:not([data-value=true]) + .satus-switch,
  /*-DURATION WITH SPEED-*/
-#show-remaining-duration:not([data-value='true']) + .satus-switch,
+#show-remaining-duration:not([data-value=true]) + .satus-switch,
  /*-comment sidebar scrollbars-*/
-#comments-sidebar:not([data-value='true']) + .satus-switch + #comments-sidebar-simple:not([data-value='true']) + .satus-switch, 
-/* #comments-sidebar:not([data-value='true']) + .satus-switch, */
+#comments-sidebar:not([data-value=true]) + .satus-switch + #comments-sidebar-simple:not([data-value=true]) + .satus-switch, 
+/* #comments-sidebar:not([data-value=true]) + .satus-switch, */
 /*--------------------------------------------------------------
 >>> PLAYER
 --------------------------------------------------------------*/
 #player_autoPip:not([data-value=true]) + .satus-switch,
-#forced-volume:not([data-value='true']) + .satus-slider,
-#forced-playback-speed:not([data-value='true']) + .satus-switch,
-#forced-playback-speed:not([data-value='true']) + .satus-switch + .satus-switch,
-#forced-playback-speed:not([data-value='true']) + .satus-switch + .satus-switch + .satus-slider, 
-/* #player_repeat_button:not([data-value='true']) + .satus-switch, */
-#player_screenshot_button:not([data-value='true'])  + .satus-switch,
-#player_screenshot_button:not([data-value='true'])  + .satus-switch + .satus-select,
+#forced-volume:not([data-value=true]) + .satus-slider,
+#forced-playback-speed:not([data-value=true]) + .satus-switch,
+#forced-playback-speed:not([data-value=true]) + .satus-switch + .satus-switch,
+#forced-playback-speed:not([data-value=true]) + .satus-switch + .satus-switch + .satus-slider, 
+/* #player_repeat_button:not([data-value=true]) + .satus-switch, */
+#player_screenshot_button:not([data-value=true]) + .satus-switch,
+#player_screenshot_button:not([data-value=true]) + .satus-switch + .satus-select,
  /*--------------------------------------------------------------
 	SUBTITLES
 --------------------------------------------------------------*/
-#subtitles-language[data-value='default'] + .satus-switch,
+#subtitles-language[data-value=default] + .satus-switch,
 /*--------------------------------------------------------------
 NIGHT MODE
 --------------------------------------------------------------*/
@@ -37,74 +37,72 @@ NIGHT MODE
 /*====================================*/
 	{display: none !important;}
 
-#remove-home-page-shorts[data-value='true'] + .satus-switch,
-#remove-home-page-shorts[data-value='true'] + .satus-switch + .satus-switch,
-#remove-home-page-shorts[data-value='true'] + .satus-switch + .satus-switch + .satus-switch,
+#remove-home-page-shorts[data-value=true] + .satus-switch,
+#remove-home-page-shorts[data-value=true] + .satus-switch + .satus-switch,
+#remove-home-page-shorts[data-value=true] + .satus-switch + .satus-switch + .satus-switch,
 /*-----------------
 >>> Appearance
 -----------------*/
 /*-transcript compact spacing-*/
-#transcript[data-value='true'] + .satus-switch,
+#transcript[data-value=true] + .satus-switch,
  /*-DURATION WITH SPEED-*/
-#show-remaining-duration[data-value='true'] + .satus-switch,
+#show-remaining-duration[data-value=true] + .satus-switch,
  /*-comment sidebar scrollbars-*/
-#comments-sidebar[data-value='true'] + .satus-switch,
+#comments-sidebar[data-value=true] + .satus-switch,
 /*--------------------------------------------------------------
 >>> PLAYER
 --------------------------------------------------------------*/
 #player_autoPip[data-value=true] + .satus-switch,
-#forced-volume[data-value='true'] + .satus-slider, 
-#forced-playback-speed[data-value='true'] + .satus-switch,
-#forced-playback-speed[data-value='true'] + .satus-switch + .satus-switch,
-#forced-playback-speed[data-value='true'] + .satus-switch + .satus-switch + .satus-slider, 
+#forced-volume[data-value=true] + .satus-slider, 
+#forced-playback-speed[data-value=true] + .satus-switch,
+#forced-playback-speed[data-value=true] + .satus-switch + .satus-switch,
+#forced-playback-speed[data-value=true] + .satus-switch + .satus-switch + .satus-slider, 
 #player_repeat_button + .satus-switch, 
 #player_cinema_mode_button +.satus-switch,
 #player_auto_cinema_mode +.satus-switch,
-#player_screenshot_button[data-value='true']  + .satus-switch,
-#player_screenshot_button[data-value='true']  + .satus-switch + .satus-select,
+#player_screenshot_button[data-value=true] + .satus-switch,
+#player_screenshot_button[data-value=true] + .satus-switch + .satus-select,
  /*--------------------------------------------------------------
 	SUBTITLES
 --------------------------------------------------------------*/
-#subtitles-language:not([data-value='default']) + .satus-switch,
+#subtitles-language:not([data-value=default]) + .satus-switch,
 /*--------------------------------------------------------------
 NIGHT MODE
 --------------------------------------------------------------*/
 #activate[data-value='sunset_to_sunrise'] + .satus-time--from,
 #activate[data-value='sunset_to_sunrise'] + * + .satus-time--to 
 /*====================================*/
-	{margin-left:20px; margin-top:-4px; margin-bottom:2px; max-width: calc( 100% - 22px ) !important;   border-radius: 2px;  border-left: 1px inset;  }
+	{margin-left:20px; margin-top:-4px; margin-bottom:2px; max-width: calc( 100% - 22px ) !important; border-radius: 2px; border-left: 1px inset;}
 
-#remove-home-page-shorts[data-value='true'] + .satus-switch:not(:hover),
-#remove-home-page-shorts[data-value='true'] + .satus-switch + .satus-switch:not(:hover),
-#remove-home-page-shorts[data-value='true'] + .satus-switch + .satus-switch + .satus-switch:not(:hover),
+#remove-home-page-shorts[data-value=true] + .satus-switch:not(:hover),
+#remove-home-page-shorts[data-value=true] + .satus-switch + .satus-switch:not(:hover),
+#remove-home-page-shorts[data-value=true] + .satus-switch + .satus-switch + .satus-switch:not(:hover),
 /*-----------------
 >>> Appearance
 -----------------*/
 /*-transcript compact spacing-*/
-#transcript[data-value='true'] + .satus-switch:not(:hover),
+#transcript[data-value=true] + .satus-switch:not(:hover),
  /*-DURATION WITH SPEED-*/
-#show-remaining-duration[data-value='true'] + .satus-switch:not(:hover),
+#show-remaining-duration[data-value=true] + .satus-switch:not(:hover),
  /*-comment sidebar scrollbars-*/
-#comments-sidebar[data-value='true'] + .satus-switch:not(:hover),
+#comments-sidebar[data-value=true] + .satus-switch:not(:hover),
 /*--------------------------------------------------------------
 >>> PLAYER
 --------------------------------------------------------------*/
-#forced-volume[data-value='true'] + .satus-slider:not(:hover), 
-#forced-playback-speed[data-value='true'] + .satus-switch:not(:hover),
-#forced-playback-speed[data-value='true'] + .satus-switch + .satus-switch:not(:hover),
-#forced-playback-speed[data-value='true'] + .satus-switch + .satus-switch + .satus-slider:not(:hover), 
-#player_screenshot_button[data-value='true']  + .satus-switch:not(:hover),
-#player_screenshot_button[data-value='true']  + .satus-switch + .satus-select:not(:hover),
+#forced-volume[data-value=true] + .satus-slider:not(:hover), 
+#forced-playback-speed[data-value=true] + .satus-switch:not(:hover),
+#forced-playback-speed[data-value=true] + .satus-switch + .satus-switch:not(:hover),
+#forced-playback-speed[data-value=true] + .satus-switch + .satus-switch + .satus-slider:not(:hover), 
+#player_screenshot_button[data-value=true] + .satus-switch:not(:hover),
+#player_screenshot_button[data-value=true] + .satus-switch + .satus-select:not(:hover),
  /*--------------------------------------------------------------
 	SUBTITLES
 --------------------------------------------------------------*/
-#subtitles-language:not([data-value='default']) + .satus-switch:not(:hover),
+#subtitles-language:not([data-value=default]) + .satus-switch:not(:hover),
 /*--------------------------------------------------------------
 NIGHT MODE
 --------------------------------------------------------------*/
 #activate[data-value='sunset_to_sunrise'] + .satus-time--from:not(:hover),
 #activate[data-value='sunset_to_sunrise'] + * + .satus-time--to:not(:hover) 
 /*====================================*/
- { background-color:rgb(69,180,210,0.09); }
- 
- 
+	{background-color:rgb(69,180,210,0.09);}

--- a/menu/styles/sub-options.css
+++ b/menu/styles/sub-options.css
@@ -17,6 +17,7 @@ NESTED (CONDITIONAL) SWITCHES
 /*--------------------------------------------------------------
 >>> PLAYER
 --------------------------------------------------------------*/
+#player_autoPip:not([data-value=true]) + .satus-switch,
 #forced-volume:not([data-value='true']) + .satus-slider,
 #forced-playback-speed:not([data-value='true']) + .satus-switch,
 #forced-playback-speed:not([data-value='true']) + .satus-switch + .satus-switch,
@@ -51,6 +52,7 @@ NIGHT MODE
 /*--------------------------------------------------------------
 >>> PLAYER
 --------------------------------------------------------------*/
+#player_autoPip[data-value=true] + .satus-switch,
 #forced-volume[data-value='true'] + .satus-slider, 
 #forced-playback-speed[data-value='true'] + .satus-switch,
 #forced-playback-speed[data-value='true'] + .satus-switch + .satus-switch,


### PR DESCRIPTION
- new Option "Auto PiP outside source Tab" https://github.com/code-charity/youtube/issues/1850
- only Auto PiP playing videos https://github.com/code-charity/youtube/issues/1352
- adds warning about current Chrome limitations "PiP requires recent User interaction with source page. This is Chrome Picture-in-Picture API limitations and we cant do anything to bypass it. Works best with Autoplay disabled and manual Play control or deliberately clicking somewhere on the page before switching Tabs."
- checks to not throw errors in FF/browsers not supporting Chrome PiP API.
- hiding Auto PiP Options altogether in FF/browsers not supporting Chrome PiP API.
- dont "Auto-pause while I'm not in the tab" if User engaged Chrome PiP manually https://github.com/code-charity/youtube/issues/1907
- dedicated ImprovedTube.enterPip(disable) function for entering/exiting PiP, required to keep everything in sync.