### PR TITLE
Issue #2668 - Remove Chapter Title Button from YouTube Progress Bar

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -278,6 +278,9 @@
     "chapters": {
         "message": "Chapters"
     },
+    "chapterTitle": {
+        "message": "Chapter Title"
+    },
     "characterEdgeStyle": {
         "message": "Character edge style"
     },

--- a/js&css/extension/www.youtube.com/appearance/player/player.css
+++ b/js&css/extension/www.youtube.com/appearance/player/player.css
@@ -178,6 +178,9 @@ html[it-player-miniplayer-button=true] .ytp-miniplayer-button,
 html[it-player-view-button=true] .ytp-size-button,
 html[it-player-screen-button=true] .ytp-fullscreen-button,
 html[it-player-remote-button=true] .ytp-remote-button,
+html[it-player-chaptertitle-button=true] .ytp-chapter-container {
+	display: none !important;
+}
 /*--------------------------------------------------------------
 # HIDE ANNOTATIONS
 --------------------------------------------------------------*/

--- a/menu/skeleton-parts/appearance.js
+++ b/menu/skeleton-parts/appearance.js
@@ -297,6 +297,10 @@ extension.skeleton.main.layers.section.appearance.on.click.player = {
 						player_remote_button: {
 							component: "switch",
 							text: "remote"
+						},
+						player_chaptertitle_button: {
+							component:"switch",
+							text:"chapterTitle"
 						}
 					}
 				}


### PR DESCRIPTION
In this PR I worked on issue #2668 which added a new feature that allows users to remove the chapter title button from the YouTube progress bar, enhancing the user experience by preventing accidental clicks on chapter titles that lead to unwanted scrolling.

![2668Issue](https://github.com/user-attachments/assets/abd81bdf-cfae-41a3-beec-793dce342715)



