### PR TITLE
Issue #2671 - Remove the thumbnail icon the front page

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -683,6 +683,9 @@
     "hideVideoTitleFullScreen": {
         "message": "Hide video title in fullscreen"
     },
+    "hideThumbnailIcon": {
+        "message": "Hide thumbnail icon"
+    },
     "hideViewsCount": {
         "message": "Hide views count"
     },

--- a/js&css/extension/www.youtube.com/general/general.css
+++ b/js&css/extension/www.youtube.com/general/general.css
@@ -11,6 +11,7 @@
 # Mark watched videos
 # Hide aniamted thubmnails
 # Hide buttons on thumbnails
+# Hide thumbnail icon
 --------------------------------------------------------------*/
 html[it-cursorLighting=true] #below			{opacity:.4; transition:3s;}
 html[it-cursorLighting=true] #below:hover	{opacity:1; transition:.5s;}
@@ -68,6 +69,10 @@ html[it-hide-animated-thumbnails='true'] #preview>ytd-video-preview,
 --------------------------------------------------------------*/
 html[it-hide-thumbnail-overlay='true'] #hover-overlays,
 html[it-hide-thumbnail-overlay='true'] #player-controls.ytd-video-preview,
+/*--------------------------------------------------------------
+# HIDE THUMBNAIL ICON
+--------------------------------------------------------------*/
+html[it-hide-thumbnail-icon='true'] .yt-spec-avatar-shape.yt-spec-avatar-shape__button.yt-spec-avatar-shape__button--button-medium.yt-spec-avatar-shape__button--tappable,
 /*--------------------------------------------------------------
 # EMBEDDED VIDEOS
  --------------------------------------------------------------*/

--- a/js&css/web-accessible/init.js
+++ b/js&css/web-accessible/init.js
@@ -146,6 +146,15 @@ document.addEventListener('yt-navigate-finish', function () {
 	} else if (document.documentElement.dataset.pageType === 'channel') {
 		ImprovedTube.channelPlayAllButton();
 	}
+
+	 // Inject CSS to hide YouTube frontpage thumbnails
+	 const style = document.createElement("style");
+	 style.textContent = `
+		  .yt-spec-avatar-shape.yt-spec-avatar-shape__button.yt-spec-avatar-shape__button--button-medium.yt-spec-avatar-shape__button--tappable {
+			  display: none !important;
+		  }
+		  `;
+	 document.head.appendChild(style);
 });
 
 window.addEventListener('load', function () {

--- a/js&css/web-accessible/init.js
+++ b/js&css/web-accessible/init.js
@@ -146,15 +146,6 @@ document.addEventListener('yt-navigate-finish', function () {
 	} else if (document.documentElement.dataset.pageType === 'channel') {
 		ImprovedTube.channelPlayAllButton();
 	}
-
-	 // Inject CSS to hide YouTube frontpage thumbnails
-	 const style = document.createElement("style");
-	 style.textContent = `
-		  .yt-spec-avatar-shape.yt-spec-avatar-shape__button.yt-spec-avatar-shape__button--button-medium.yt-spec-avatar-shape__button--tappable {
-			  display: none !important;
-		  }
-		  `;
-	 document.head.appendChild(style);
 });
 
 window.addEventListener('load', function () {

--- a/menu/skeleton-parts/general.js
+++ b/menu/skeleton-parts/general.js
@@ -196,6 +196,11 @@ extension.skeleton.main.layers.section.general = {
 					text: 'hideThumbnailOverlay',
 					tags: 'preview'
 				},
+				hide_thumbnail_icon: {
+					component: "switch",
+					text: "hideThumbnailIcon",
+					tags: "preview",
+				  },
 				thumbnails_quality: {
 					component: 'select',
 					text: 'thumbnailsQuality',


### PR DESCRIPTION
This PR addresses this issue #2671. This PR introduces a feature to hide YouTube thumbnails on the homepage and elsewhere using dynamically injected CSS. The solution ensures that thumbnails are hidden without modifying the underlying structure of YouTube’s DOM. 

## Testing Locally
- Check into this branch locally 
- Navigate to `chrome://extensions/`
- In the top right cornet, toggle developer mode on.
- In the top left, click on the `Load unpacked` button
- Select the root folder where the `manifest.json` file leaves
- This should add the extension locally to your browser
- Navigate to `https://www.youtube.com`, confirm that the thumbnails for the front page videos are hidden.
- Look at the snippet below to confirm the change.

https://github.com/user-attachments/assets/8503bc0c-7405-4304-9323-6e417f63d6e6