### PR TITLE
issue #2670 - Feature to remove thumbnail dots

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -678,7 +678,7 @@
         "message": "Hide buttons on thumbnails"
     },
     "hideThumbnailDots": {
-        "message": "Hide dots on thumbnails"
+        "message": "Hide '⫶' (more actions) on thumbnails"
     },
     "hideThumbnails": {
         "message": "Hide thumbnails"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -677,6 +677,9 @@
     "hideThumbnailOverlay": {
         "message": "Hide buttons on thumbnails"
     },
+    "hideThumbnailDots": {
+        "message": "Hide dots on thumbnails"
+    },
     "hideThumbnails": {
         "message": "Hide thumbnails"
     },

--- a/js&css/extension/www.youtube.com/general/general.css
+++ b/js&css/extension/www.youtube.com/general/general.css
@@ -11,6 +11,7 @@
 # Mark watched videos
 # Hide aniamted thubmnails
 # Hide buttons on thumbnails
+# Hide dots on thumbnails
 --------------------------------------------------------------*/
 html[it-cursorLighting=true] #below			{opacity:.4; transition:3s;}
 html[it-cursorLighting=true] #below:hover	{opacity:1; transition:.5s;}
@@ -68,6 +69,13 @@ html[it-hide-animated-thumbnails='true'] #preview>ytd-video-preview,
 --------------------------------------------------------------*/
 html[it-hide-thumbnail-overlay='true'] #hover-overlays,
 html[it-hide-thumbnail-overlay='true'] #player-controls.ytd-video-preview,
+/*--------------------------------------------------------------
+# HIDE DOTS ON THUMBNAILS
+--------------------------------------------------------------*/
+html[it-hide-thumbnail-dots='true'] button#button[aria-label="Action menu"],
+html[it-hide-thumbnail-dots="true"] button.yt-spec-button-shape-next[aria-label="More actions"] {
+    display: none;
+}
 /*--------------------------------------------------------------
 # EMBEDDED VIDEOS
  --------------------------------------------------------------*/

--- a/js&css/web-accessible/init.js
+++ b/js&css/web-accessible/init.js
@@ -146,16 +146,6 @@ document.addEventListener('yt-navigate-finish', function () {
 	} else if (document.documentElement.dataset.pageType === 'channel') {
 		ImprovedTube.channelPlayAllButton();
 	}
-
-	// Adds CSS to hide dots from thumbnails
-	const style = document.createElement("style");
-	style.textContent = `
-		html[it-hide-thumbnail-dots='true'] button#button[aria-label="Action menu"],
-  		html[it-hide-thumbnail-dots="true"] button.yt-spec-button-shape-next[aria-label="More actions"] {
-    		display: none !important;
-  	}
-	`;
-	document.head.appendChild(style);
 });
 
 window.addEventListener('load', function () {

--- a/js&css/web-accessible/init.js
+++ b/js&css/web-accessible/init.js
@@ -146,6 +146,16 @@ document.addEventListener('yt-navigate-finish', function () {
 	} else if (document.documentElement.dataset.pageType === 'channel') {
 		ImprovedTube.channelPlayAllButton();
 	}
+
+	// Adds CSS to hide dots from thumbnails
+	const style = document.createElement("style");
+	style.textContent = `
+		html[it-hide-thumbnail-dots='true'] button#button[aria-label="Action menu"],
+  		html[it-hide-thumbnail-dots="true"] button.yt-spec-button-shape-next[aria-label="More actions"] {
+    		display: none !important;
+  	}
+	`;
+	document.head.appendChild(style);
 });
 
 window.addEventListener('load', function () {

--- a/menu/skeleton-parts/general.js
+++ b/menu/skeleton-parts/general.js
@@ -196,6 +196,11 @@ extension.skeleton.main.layers.section.general = {
 					text: 'hideThumbnailOverlay',
 					tags: 'preview'
 				},
+				hide_thumbnail_Dots: {
+					component: 'switch',
+					text: 'hideThumbnailDots',
+					tags: 'dots'
+				},
 				thumbnails_quality: {
 					component: 'select',
 					text: 'thumbnailsQuality',

--- a/menu/skeleton-parts/general.js
+++ b/menu/skeleton-parts/general.js
@@ -199,6 +199,7 @@ extension.skeleton.main.layers.section.general = {
 				hide_thumbnail_dots: {
 					component: 'switch',
 					text: 'hideThumbnailDots',
+					tags: 'preview'
 				},
 				thumbnails_quality: {
 					component: 'select',

--- a/menu/skeleton-parts/general.js
+++ b/menu/skeleton-parts/general.js
@@ -196,10 +196,9 @@ extension.skeleton.main.layers.section.general = {
 					text: 'hideThumbnailOverlay',
 					tags: 'preview'
 				},
-				hide_thumbnail_Dots: {
+				hide_thumbnail_dots: {
 					component: 'switch',
 					text: 'hideThumbnailDots',
-					tags: 'dots'
 				},
 				thumbnails_quality: {
 					component: 'select',


### PR DESCRIPTION
### Summary:
This pull request works on issue #2670  removes the dots from the thumbnails.

Please review and let me know if any additional changes are required.

Before:
![issue-1](https://github.com/user-attachments/assets/1d59852a-f148-452d-b1af-75b5dd9275d8)


After:
![issue-2](https://github.com/user-attachments/assets/d774312d-acdb-4d01-ad94-dfd219242c2a)

