### PR TITLE
Added functionality to remove the red line under the caption button.

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1214,6 +1214,9 @@
     "subtitles": {
         "message": "Subtitles"
     },
+    "subtitleLine": {
+        "message": "Hide subtitle red line"
+    },
     "RemoveSubtitlesForLyrics": {
         "message": "Remove subtitles for lyrics"
     },

--- a/js&css/extension/www.youtube.com/appearance/player/player.css
+++ b/js&css/extension/www.youtube.com/appearance/player/player.css
@@ -181,6 +181,9 @@ html[it-player-remote-button=true] .ytp-remote-button,
 html[it-player-chaptertitle-button=true] .ytp-chapter-container {
 	display: none !important;
 }
+html[it-player-subtitlesLine-button=true] button.ytp-subtitles-button.ytp-button::after{
+    display: none;
+}
 /*--------------------------------------------------------------
 # HIDE ANNOTATIONS
 --------------------------------------------------------------*/

--- a/menu/skeleton-parts/appearance.js
+++ b/menu/skeleton-parts/appearance.js
@@ -282,6 +282,10 @@ extension.skeleton.main.layers.section.appearance.on.click.player = {
 							component: "switch",
 							text: "subtitles"
 						},
+						player_subtitlesLine_button: {
+							component: "switch",
+							text: "subtitleLine"
+						},
 						player_miniplayer_button: {
 							component: "switch",
 							text: "nativeMiniPlayer"


### PR DESCRIPTION
This PR addresses issue #2680 by adding an option to the menu to remove the line under the caption button.

![issue-2680](https://github.com/user-attachments/assets/3e67b92e-2506-4979-b715-2196bb65a328)

Please let me know if any adjustments or further changes are needed. Thank you!