### PR TITLE
feat: add styles to hide 'Includes Paid Promotion' elements

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -650,6 +650,9 @@
     "hideHomePageShorts": {
         "message": "Hide Shorts on the home page"
     },
+    "hideIncludesPaidPromotion": {
+        "message": "Hide \"Includes Paid Promotion\""
+    },
     "hideMore": {
         "message": "Hide '...'"
     },

--- a/js&css/extension/www.youtube.com/appearance/player/player.css
+++ b/js&css/extension/www.youtube.com/appearance/player/player.css
@@ -7,6 +7,7 @@
 # Hide annotations
 # Hide endscreen
 # Hide cards
+# Hide "Includes Paid Promotion"
 # Show cards on mouse hover
 # Hide "Scroll for details"
 # Player Size
@@ -652,4 +653,13 @@ html[it-hide-scroll-for-details='true'] button.ytp-fullerscreen-edu-button {
 
 html[it-hide-scroll-for-details='true'] ytd-app[scrolling_] {
 	overflow: hidden !important;
+}
+
+/*--------------------------------------------------------------
+# HIDE Includes Paid Promotion
+--------------------------------------------------------------*/
+html[data-page-type=video][it-hide-includes-paid-promotion=true] .ytp-paid-content-overlay,
+html[data-page-type=home][it-hide-includes-paid-promotion=true] .YtmPaidContentOverlayLink,
+html[data-page-type=other][it-hide-includes-paid-promotion=true] .YtmPaidContentOverlayLink  {
+  display: none !important;
 }

--- a/menu/skeleton-parts/appearance.js
+++ b/menu/skeleton-parts/appearance.js
@@ -226,6 +226,11 @@ extension.skeleton.main.layers.section.appearance.on.click.player = {
 				component: "switch",
 				text: "hideEndscreen"
 			},
+			hide_includes_paid_promotion:{
+			component: 'switch',
+			text: 'hideIncludesPaidPromotion',
+			storage: 'hide_includes_paid_promotion',
+			},
 			remove_black_bars: {
 				component: "switch",
 				text: "removeBlackBars",

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -84,6 +84,11 @@ extension.skeleton.main.layers.section.player.on.click = {
 			text: 'autoplayDisable',
 			storage: 'player_autoplay_disable'
 		},
+		hide_includes_paid_promotion:{
+			component: 'switch',
+			text: 'hideIncludesPaidPromotion',
+			storage: 'hide_includes_paid_promotion',
+		},
 		up_next_autoplay: {
 			component: 'switch',
 			text: 'upNextAutoplay',

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -84,11 +84,6 @@ extension.skeleton.main.layers.section.player.on.click = {
 			text: 'autoplayDisable',
 			storage: 'player_autoplay_disable'
 		},
-		hide_includes_paid_promotion:{
-			component: 'switch',
-			text: 'hideIncludesPaidPromotion',
-			storage: 'hide_includes_paid_promotion',
-		},
 		up_next_autoplay: {
 			component: 'switch',
 			text: 'upNextAutoplay',


### PR DESCRIPTION
This pull request attempts to close #2634.

As discussed in #2634, certain videos include a clickable link on top of the video titled, `Includes Paid Promotion` as shown in the video below:

https://github.com/user-attachments/assets/5a67afbb-2bb1-4991-bf4f-4ad20b29ef76

With the changes made, the extension now _hides_ the HTML elements related to the `Includes Paid Promotion` link:

https://github.com/user-attachments/assets/d4772053-d1cf-40d5-abe3-0e4b86c61546

Please let me know if there's anything else I should change - I'm happy to learn and fix more issues!


 