### PR TITLE
feat: hide cinema mode button on YT when the setting is disabled

### DIFF
--- a/js&css/web-accessible/core.js
+++ b/js&css/web-accessible/core.js
@@ -302,6 +302,14 @@ document.addEventListener('it-message-from-extension', function () {
 					}
 					break
 
+				case 'playerCinemaModeButton'	:
+					if (ImprovedTube.storage.player_cinema_mode_button === false) {
+						if (ImprovedTube.elements.buttons['it-cinema-mode-button']) {
+							ImprovedTube.elements.buttons['it-cinema-mode-button']?.remove();
+							ImprovedTube.elements.buttons['it-cinema-mode-styles']?.remove();
+						}
+					}
+
 				case 'playerRepeatButton':
 					if (ImprovedTube.storage.player_repeat_button === false) {
 						if (ImprovedTube.elements.buttons['it-repeat-button']) {


### PR DESCRIPTION
This pull request is an attempt to close #2700.

Now, without having to _reload_ the page, the user should be able to hide and show `ImprovedTube's Cinema Mode` button.

https://github.com/user-attachments/assets/f16bb218-a291-447e-8484-ff5403662928

