### PR TITLE
Fixed issue #2778

### DIFF
--- a/js&css/extension/www.youtube.com/appearance/header/header.css
+++ b/js&css/extension/www.youtube.com/appearance/header/header.css
@@ -83,9 +83,7 @@ html[data-page-type='video'][it-header-position=hidden_on_video_page] ytd-page-m
 html[it-header-position=hover] ytd-page-manager#page-manager,
 html[data-page-type='video'][it-header-position=hover_on_video_page] ytd-page-manager#page-manager,
 html[it-header-position=hidden][data-page-type='channel'] tp-yt-app-header#header,
-html[data-page-type='channel'][it-header-position=hidden_on_video_page] tp-yt-app-header#header,
 html[it-header-position=hover][data-page-type='channel'] tp-yt-app-header#header,
-html[data-page-type='channel'][it-header-position=hover_on_video_page] tp-yt-app-header#header,
 html[it-header-position=static] ytd-page-manager#page-manager {
 	margin-top: 0;
 }


### PR DESCRIPTION
The hidden_on_video_page for channel page option was implementing the margin-top: 0; which it isn't suppose to take, as this option should only affect the video page.