### PR TITLE
hide member-only videos in rich item renderer

### DIFF
--- a/js&css/extension/www.youtube.com/general/general.css
+++ b/js&css/extension/www.youtube.com/general/general.css
@@ -275,7 +275,8 @@ html[it-scroll-to-top='true'] #it-scroll-to-top:hover {
 /*--------------------------------------------------------------
 # REMOVE MEMBER ONLY VIDEOS
 --------------------------------------------------------------*/
-html[it-remove-member-only='true'] ytd-grid-video-renderer:has(.badge-style-type-members-only) {
+html[it-remove-member-only='true'] ytd-grid-video-renderer:has(.badge-style-type-members-only),
+html[it-remove-member-only='true'] ytd-rich-item-renderer:has(.badge-style-type-members-only) {
     display: none !important;
 }
 /*--------------------------------------------------------------


### PR DESCRIPTION
Fixes https://github.com/code-charity/youtube/issues/2777

Previously, member-only video hiding only worked on the home page. Now the functionality has been extended to both the home page and videos tab.