### PR TITLE
Fix missing message fields in Indonesian locale & formatted urdu JSON…

### DIFF
--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -120,16 +120,16 @@
         "message": "Apakah Anda yakin ingin menyinkronkan pengaturan saat ini?"
     },
     "ARROWDOWN": {
-        "message": null
+        "message": "⇩"
     },
     "ARROWLEFT": {
-        "message": null
+        "message": "⇦"
     },
     "ARROWRIGHT": {
-        "message": null
+        "message": "⇨"
     },
     "ARROWUP": {
-        "message": null
+        "message": "⇧"
     },
     "atHistory": {
         "message": "di 'Sejarah'"

--- a/_locales/ur/messages.json
+++ b/_locales/ur/messages.json
@@ -239,7 +239,6 @@
     "blockVp8": {
         "message": "VP8 روکیں"
     },
-    {
     "blockVp9": {
         "message": "VP9 روکیں"
     },


### PR DESCRIPTION
Fixes #2831 

This PR fixes the issue where the `_locales/id/messages.json` file had `null` values for certain keys.
- Changed `null` to appropriate strings to resolve manifest loading errors.
- renamed ur/message.json to ur/messages.json
- Verified JSON validity.