### PR TITLE
Issue 2798:Prevent playback looping of youtube shorts video

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -177,6 +177,9 @@
     "autoplayDisable": {
         "message": "Force Autoplay Off"
     },
+    "preventShortVideoAutoloop":{
+        "message": "Prevent short videos from auto-looping"
+    },
     "avoidAv1": {
         "message": "Avoid AV1"
     },

--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -142,7 +142,11 @@ ImprovedTube.ytElementsHandler = function (node) {
 		if (!this.elements.ytd_player) {
 			ImprovedTube.elements.ytd_player = node;
 		}
-	} else if (id === 'movie_player') {
+	} else if (id === 'shorts-player') {
+		if (!this.elements.shorts_player) {
+		ImprovedTube.elements.shorts_player = node;
+		}
+	}else if (id === 'movie_player') {
 		if (!this.elements.player) {
 			ImprovedTube.elements.player = node;
 			// if (this.storage.player_autoplay === false)  {   ImprovedTube.elements.player.stopVideo();  }
@@ -249,7 +253,9 @@ ImprovedTube.pageType = function () {
 		document.documentElement.dataset.pageType = 'subscriptions';
 	} else if (/\/@|(\/(channel|user|c)\/)[^/]+(?!\/videos)/.test(location.href)) {
 		document.documentElement.dataset.pageType = 'channel';
-	} else {
+	} else if (/\/shorts\//.test(location.href)) {
+        document.documentElement.dataset.pageType = 'shorts';
+    } else {
 		document.documentElement.dataset.pageType = 'other';
 	}
 };
@@ -259,7 +265,21 @@ ImprovedTube.pageOnFocus = function () {
 	ImprovedTube.playerAutoPip();
 	ImprovedTube.playerQualityWithoutFocus();
 };
-
+ImprovedTube.stop_shorts_autoloop =function(){
+	if(document.documentElement.dataset.pageType === 'shorts'){
+		console.log("===========")
+		const video = ImprovedTube.elements.shorts_player.querySelector('video')
+		video.removeAttribute('loop');
+		const observer = new MutationObserver((mutations) => {
+            mutations.forEach((mutation) => {
+                if (mutation.type === 'attributes' && mutation.attributeName === 'loop') {
+                    video.removeAttribute('loop');
+                }
+            });
+        });
+        observer.observe(video, { attributes: true });
+	}
+}
 ImprovedTube.videoPageUpdate = function () {
 	if (document.documentElement.dataset.pageType === 'video') {
 		var video_id = this.getParam(new URL(location.href).search.substr(1), 'v');

--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -267,7 +267,6 @@ ImprovedTube.pageOnFocus = function () {
 };
 ImprovedTube.stop_shorts_autoloop =function(){
 	if(document.documentElement.dataset.pageType === 'shorts'){
-		console.log("===========")
 		const video = ImprovedTube.elements.shorts_player.querySelector('video')
 		video.removeAttribute('loop');
 		const observer = new MutationObserver((mutations) => {

--- a/js&css/web-accessible/init.js
+++ b/js&css/web-accessible/init.js
@@ -100,7 +100,11 @@ ImprovedTube.init = function () {
 		ImprovedTube.videoPageUpdate();
 		ImprovedTube.initPlayer();
 	}
-
+	if(ImprovedTube.elements.shorts_player){
+		if(ImprovedTube.storage.prevent_shorts_autoloop){
+			ImprovedTube.stop_shorts_autoloop();
+		}
+	}
 	if (window.matchMedia) {
 		document.documentElement.dataset.systemColorScheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 	}
@@ -139,7 +143,11 @@ document.addEventListener('yt-navigate-finish', function () {
 		ImprovedTube.videoPageUpdate();
 		ImprovedTube.initPlayer();
 	}
-
+	if(ImprovedTube.elements.shorts_player){
+		if(ImprovedTube.storage.prevent_shorts_autoloop){
+			ImprovedTube.stop_shorts_autoloop();
+		}
+	}
 	if (document.documentElement.dataset.pageType === 'home' &&	 ImprovedTube.storage.youtube_home_page === 'search' ) {
 		document.querySelector('body').style.setProperty('visibility', 'visible', 'important');
 		ImprovedTube.shortcutGoToSearchBox();

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -79,6 +79,11 @@ extension.skeleton.main.layers.section.player.on.click = {
 			storage: 'pause_while_typing_on_youtube',
 			id: 'pause_while_typing_on_youtube',
 		},
+		prevent_shorts_autoloop:{
+			component: 'switch',
+			text: 'preventShortVideoAutoloop',
+			storage: 'prevent_shorts_autoloop',
+		},
 		autoplay_disable: {
 			component: 'switch',
 			text: 'autoplayDisable',


### PR DESCRIPTION
This PR implements the feature requested in Issue #2798 : Prevent playback looping of youtube shorts video

- New option: Click on the "Player" icon in the extension and toggle the "Prevent short videos from auto-looping" option.
