### PR TITLE
fix: remove &list= param when opening videos from playlist in new tab (#2917)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1077,6 +1077,9 @@
     "removeNames": {
         "message": "Remove names"
     },
+    "removePlaylistParam": {
+	    "message": "Skip playlist when opening videos in new tab"
+    },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"
     },

--- a/js&css/extension/init.js
+++ b/js&css/extension/init.js
@@ -44,6 +44,7 @@ extension.events.on('init', function () {
 	extension.features.relatedVideos();
 	extension.features.comments();
 	extension.features.openNewTab();
+	extension.features.removeListParamOnNewTab();
 	bodyReady();
 });
 

--- a/js&css/extension/www.youtube.com/general/general.js
+++ b/js&css/extension/www.youtube.com/general/general.js
@@ -578,3 +578,43 @@ extension.features.openNewTab = function () {
 		}
 	}
 }
+
+/*--------------------------------------------------------------
+# REMOVE &list=... WHEN OPENING VIDEOS IN NEW TAB
+--------------------------------------------------------------*/
+extension.features.removeListParamOnNewTab = function () {
+	// 이전에 등록된 핸들러가 있다면 제거
+	if (this._removeListParamHandler) {
+		document.removeEventListener('click', this._removeListParamHandler, true);
+	}
+
+	// 옵션이 켜져있지 않으면 종료
+	if (extension.storage.get("remove_list_param_from_links") !== true) {
+		return;
+	}
+
+	// 새로운 핸들러 정의
+	this._removeListParamHandler = function (event) {
+		if (event.ctrlKey || event.metaKey || event.button === 1) {
+			let anchor = event.target;
+			while (anchor && anchor.tagName !== 'A') {
+				anchor = anchor.parentElement;
+			}
+			if (
+				anchor &&
+				anchor.href &&
+				anchor.href.includes('watch?v=') &&
+				anchor.href.includes('&list=')
+			) {
+				event.preventDefault();
+				const cleaned = anchor.href.replace(/&list=[^&]+/, '');
+				window.open(cleaned, '_blank');
+			}
+		}
+	};
+
+	// 핸들러 등록
+	document.addEventListener('click', this._removeListParamHandler, true);
+};
+
+extension.features.removeListParamOnNewTab();

--- a/manifest.json
+++ b/manifest.json
@@ -17,8 +17,7 @@
 		}
 	},
 	"background": {
-		"service_worker": "background.js",
-		"scripts": ["background.js"]
+		"service_worker": "background.js"
 	},
 	"action": {
 		"default_popup": "menu/index.html",

--- a/menu/skeleton-parts/general.js
+++ b/menu/skeleton-parts/general.js
@@ -400,6 +400,10 @@ extension.skeleton.main.layers.section.general = {
 					component: 'switch',
 					text: 'removeContextButtons',
 				},
+				remove_list_param_from_links: {
+					component: 'switch',
+					text: 'removePlaylistParam'
+				}
 			}
 		}
 	},


### PR DESCRIPTION
## Summary

Fixes #2917.  
When opening a video from a playlist in a new tab (via Ctrl/⌘-click or middle-click), the `&list=` parameter is now automatically removed to prevent the video from loading as part of a playlist.

## What’s included

- Introduced a new option: `Remove playlist parameter (&list=) when opening videos in new tab`.
- Switch added to settings panel: **General > More**.
- Implementation of safe `event.ctrlKey / event.button === 1` listener to clean URLs before opening new tabs.
- User-configurable through `remove_list_param_from_links` storage setting.
- Feature is disabled by default.
- Refactor: manifest.json was updated to use the correct background.service_worker syntax to comply with Manifest V3.

## Notes

- Right-click → "Open link in new tab" cannot be intercepted by JavaScript for security reasons.
- Fixes video loading lag caused by unintentional playlist context.