### PR TITLE
Improved the thumbnails per row adding more options to choose.

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1439,5 +1439,8 @@
     },
     "pauseWhileIAmTypingOnYouTube": {
         "message": "Pause when I'm typing on YouTube"
+    },
+    "changeThumbnailsPerRow": {
+        "message": "Thumbnails per Row"
     }
 }

--- a/js&css/extension/init.js
+++ b/js&css/extension/init.js
@@ -28,6 +28,7 @@ function bodyReady () {
 	if (extension.ready && extension.domReady) {
 		extension.features.addScrollToTop();
 		extension.features.font();
+		extension.features.changeThumbnailsPerRow?.();
 	}
 }
 

--- a/js&css/extension/www.youtube.com/general/general.js
+++ b/js&css/extension/www.youtube.com/general/general.js
@@ -616,3 +616,31 @@ extension.features.removeListParamOnNewTab = function () {
 };
 
 extension.features.removeListParamOnNewTab();
+
+/*--------------------------------------------------------------
+# CHANGE THE NUMBER OF THUMBNAILS PER ROW
+--------------------------------------------------------------*/
+extension.features.changeThumbnailsPerRow = async function () {
+	var value = await extension.storage.get('change_thumbnails_per_row');
+
+	if (!value || value === 'null') 
+		return;
+
+	const applyGridLayout = () => {
+		const grid = document.querySelector('ytd-rich-grid-renderer');
+		if (!grid) 
+			return;
+
+		// Apply custom values
+		grid.style.setProperty('--ytd-rich-grid-items-per-row', value);
+		grid.style.setProperty('--ytd-rich-grid-item-min-width', '220px');
+		grid.style.setProperty('--ytd-rich-grid-item-max-width', '1fr');
+  	};
+
+	// Apply initially
+	applyGridLayout();
+
+	// Reapply when YouTube replaces content
+	const observer = new MutationObserver(applyGridLayout);
+	observer.observe(document.body, { childList: true, subtree: true });
+};

--- a/menu/skeleton-parts/general.js
+++ b/menu/skeleton-parts/general.js
@@ -234,6 +234,27 @@ extension.skeleton.main.layers.section.general = {
 						value: 'maxresdefault'
 					}],
 					tags: 'preview quality'
+				},
+				change_thumbnails_per_row: {
+					component: 'select',
+					text: 'changeThumbnailsPerRow',
+					options: [{
+						text: 'Four',
+						value: '4'
+					}, {
+						text: 'Five',
+						value: '5'
+					}, {
+						text: 'Six',
+						value: '6'
+					}, {
+						text: 'Seven',
+						value: '7'
+					}, {
+						text: 'Eight',
+						value: '8'
+					}],
+					tags: 'change thumbnails per row'
 				}
 			}, section_2: {
 				component: 'section',


### PR DESCRIPTION
This should solve the issues #2910,  #2904, and #2905 

Added a dropdown in the menu General, subsection Thumbnails, with 5 options to choose from
![image](https://github.com/user-attachments/assets/06068746-9aca-4886-93f1-cab7e698e96a)

Should be updated in real time and saved for future interactions with YouTube.

Is also working on the Subscriptions page on grid mode, seems to not be perfect, though, I noticed some visual bugs, like when selecting 6 videos appearing 5, I had to refresh the page to fix but wasn't 100% on all rows, also could vary depending on the size of the your tab, so maybe need some more adjustments, but for the Home page seems fine.

Also, I tested on an Ultrawide Quad HD monitor (3440x1440), so for sure will work differently on smaller monitors/resolutions, let me know about it.

Tested on both Chrome and Edge.