### PR TITLE
Fixed the remaining duration time bug.

### DIFF
--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -156,6 +156,8 @@ ImprovedTube.formatSecond = function (rTime) {
 };
 
 ImprovedTube.playerRemainingDuration = function () {
+	document.querySelector('.ytp-time-contents').style.setProperty('display', 'none', 'important');
+	
 	var player = ImprovedTube.elements.player;
 	var rTime = ImprovedTube.formatSecond((player.getDuration() - player.getCurrentTime()).toFixed(0));
 	var element = document.querySelector(".ytp-time-remaining-duration");
@@ -163,7 +165,7 @@ ImprovedTube.playerRemainingDuration = function () {
 		var label = document.createElement("span");
 		label.textContent = " (-" + rTime + ")";
 		label.className = "ytp-time-remaining-duration";
-		document.querySelector(".ytp-time-display").appendChild(label);
+		document.querySelector(".ytp-time-display span").appendChild(label);
 	} else {
 		element.textContent = " (-" + rTime + ")";
 	}


### PR DESCRIPTION
This should solve the issues #2925, and #2935 

Tested on both Edge and Chrome.

The change was literally adding a span inside the ytp-time-display class element, but also an important part was the code at the top of the function, which hides the div responsible for showing the "normal" duration time of the videos.

Once the toggle is off, this div should show normally as expected.

If the toggle is on and you change it to off, the changes will not affect the actual video in real time, and for this, a refresh on the page is necessary. I tried to solve this using CSS manipulation, but I got too many issues that were not worth the effort.