### PR TITLE
feat(disableLikesAnimation): Added option to disable animated likes counter on YouTube and display static, aligned number

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1445,5 +1445,8 @@
     },
     "changeThumbnailsPerRow": {
         "message": "Thumbnails per Row"
+    },
+    "disableLikesAnimation": {
+        "message": "Disable likes animation"
     }
 }

--- a/js&css/extension/www.youtube.com/appearance/details/details.css
+++ b/js&css/extension/www.youtube.com/appearance/details/details.css
@@ -84,10 +84,10 @@ html[it-hide-report-button='true'] #menu button:has(svg path[d^="m13.18 4 .24 1.
 html[it-hide-report-button='true'] #flexible-item-buttons button:has(svg path[d^="m13.18 4 .24 1.2.16.8H19v7h-5.18l-.24-1.2-.16-.8H6V4h7.18M14"]), 
 	/*------HIDE MORE BUTTON------*/
 html[it-hide-more-button='true'] #menu #button [class*="dropdown"],
-html[it-hide-more-button='true'] #menu button:has(svg path[d^="M7.5 12c0 .83-.67 1.5-1. 1."]), 
+html[it-hide-more-button='true'] #menu button:has(svg path[d^="M7.5 12c0 .83-.67 1. 1."]),
    /* previous "more"-svg and dom: */
 html[it-hide-more-button='true'] #menu yt-button-shape#button-shape,
-html[it-hide-more-button='true'] #menu button:has(svg path[d^="M7.5,12c0,0.83-0.67,1.5-1.5"]), 
+html[it-hide-more-button='true'] #menu button:has(svg path[d^="M7.5,12c0,0.83-0.67,1.5"]),
 html[it-hide-more-button='true'] #flexible-item-buttons button:has(svg path[d^="M7.5,12c0,0.83-0.67,1.5-1.5"]),
 	/*------# HIDE DETAILS-------------*/
 html[it-hide-details='true'] ytd-video-primary-info-renderer,
@@ -164,4 +164,15 @@ html[it-exact-upload-date='true'] #info #date + #info-strings>#dot,
 	display: inline-block !important;
 	margin-left: 4px !important;
 	color: var(--yt-spec-text-secondary) !important;
+}
+/*--------------------------------------------------------------
+# DISABLE LIKES ANIMATION
+--------------------------------------------------------------*/
+html[it-disable-likes-animation='true'] yt-animated-rolling-number {
+	display: none !important;
+}
+
+html[it-disable-likes-animation='true'] #top-level-buttons-computed #segmented-like-button ytd-toggle-button-renderer span {
+	font-variant-numeric: tabular-nums;
+	vertical-align: baseline;
 }

--- a/js&css/extension/www.youtube.com/appearance/details/details.css
+++ b/js&css/extension/www.youtube.com/appearance/details/details.css
@@ -84,7 +84,7 @@ html[it-hide-report-button='true'] #menu button:has(svg path[d^="m13.18 4 .24 1.
 html[it-hide-report-button='true'] #flexible-item-buttons button:has(svg path[d^="m13.18 4 .24 1.2.16.8H19v7h-5.18l-.24-1.2-.16-.8H6V4h7.18M14"]), 
 	/*------HIDE MORE BUTTON------*/
 html[it-hide-more-button='true'] #menu #button [class*="dropdown"],
-html[it-hide-more-button='true'] #menu button:has(svg path[d^="M7.5 12c0 .83-.67 1. 1."]),
+html[it-hide-more-button='true'] #menu button:has(svg path[d^="M7.5 12c0 .83-.67 1."]),
    /* previous "more"-svg and dom: */
 html[it-hide-more-button='true'] #menu yt-button-shape#button-shape,
 html[it-hide-more-button='true'] #menu button:has(svg path[d^="M7.5,12c0,0.83-0.67,1.5"]),

--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -811,3 +811,37 @@ if (ImprovedTube.storage.header_transparent2 === true) {
 		}
 	});
 }
+/*------------------------------------------------------------------------------
+DISABLE LIKES ANIMATION
+------------------------------------------------------------------------------*/
+ImprovedTube.disableLikesAnimation = function () {
+    if (this.storage.disable_likes_animation === true) {
+        // Find all like counters with animation
+        var likeAnimated = document.querySelectorAll('yt-animated-rolling-number');
+        likeAnimated.forEach(function (el) {
+            // Replace with static number
+            var staticValue = el.getAttribute('value') || el.textContent;
+            if (staticValue) {
+                var span = document.createElement('span');
+                span.textContent = staticValue;
+                span.style.verticalAlign = 'baseline';
+                span.style.fontVariantNumeric = 'tabular-nums'; // align digits
+                el.replaceWith(span);
+            }
+        });
+    }
+    if (this.storage.disable_likes_animation === true) {
+        document.documentElement.setAttribute('it-disable-likes-animation', 'true');
+    } else {
+        document.documentElement.removeAttribute('it-disable-likes-animation');
+    }
+};
+
+// Call this on page load and on navigation
+(function() {
+    var run = function() { ImprovedTube.disableLikesAnimation && ImprovedTube.disableLikesAnimation(); };
+    document.addEventListener('yt-page-data-updated', run);
+    document.addEventListener('yt-navigate-finish', run);
+    window.addEventListener('load', run);
+    setTimeout(run, 2000); // fallback for late loads
+})();

--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -814,8 +814,8 @@ if (ImprovedTube.storage.header_transparent2 === true) {
 /*------------------------------------------------------------------------------
 DISABLE LIKES ANIMATION
 ------------------------------------------------------------------------------*/
+if (ImprovedTube.storage.disable_likes_animation === true) {
 ImprovedTube.disableLikesAnimation = function () {
-    if (this.storage.disable_likes_animation === true) {
         // Find all like counters with animation
         var likeAnimated = document.querySelectorAll('yt-animated-rolling-number');
         likeAnimated.forEach(function (el) {
@@ -830,8 +830,6 @@ ImprovedTube.disableLikesAnimation = function () {
             }
         });
     }
-};
-
 // Call this on page load and on navigation
 (function() {
     var run = function() { ImprovedTube.disableLikesAnimation && ImprovedTube.disableLikesAnimation(); };
@@ -840,3 +838,4 @@ ImprovedTube.disableLikesAnimation = function () {
     window.addEventListener('load', run);
     setTimeout(run, 2000); // fallback for late loads
 })();
+};

--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -830,11 +830,6 @@ ImprovedTube.disableLikesAnimation = function () {
             }
         });
     }
-    if (this.storage.disable_likes_animation === true) {
-        document.documentElement.setAttribute('it-disable-likes-animation', 'true');
-    } else {
-        document.documentElement.removeAttribute('it-disable-likes-animation');
-    }
 };
 
 // Call this on page load and on navigation

--- a/menu/skeleton-parts/appearance.js
+++ b/menu/skeleton-parts/appearance.js
@@ -467,10 +467,10 @@ extension.skeleton.main.layers.section.appearance.on.click.details = {
 				tags: "hide,remove"
 			},
 			disable_likes_animation: {
-                component: "switch",
-                text: "disableLikesAnimation",
-                tags: "likes,animation,disable"
-            },
+		                component: "switch",
+		                text: "disableLikesAnimation",
+		                tags: "likes,animation,disable"
+		        },
 			api: {
 				component: 'section',
 				variant: 'card',

--- a/menu/skeleton-parts/appearance.js
+++ b/menu/skeleton-parts/appearance.js
@@ -466,6 +466,11 @@ extension.skeleton.main.layers.section.appearance.on.click.details = {
 				text: "hideDate",
 				tags: "hide,remove"
 			},
+			disable_likes_animation: {
+                component: "switch",
+                text: "disableLikesAnimation",
+                tags: "likes,animation,disable"
+            },
 			api: {
 				component: 'section',
 				variant: 'card',


### PR DESCRIPTION
### Pull Request Description:

This PR introduces a new appearance option to disable the animated "slot machine" effect for the YouTube likes counter. When enabled, the likes count is shown as a static, properly aligned number, improving readability and accessibility for users who prefer a non-animated display.

**Key changes:**

- Adds a toggle ("Disable likes animation") to the Appearance > Details menu.
- Localizes the new option for English (with easy extensibility for other languages).
- Updates JavaScript to replace the animated likes counter with a static number and sets a CSS attribute for styling.
- Adds CSS to hide the animated counter and ensure the static number is visually aligned and uses tabular numerals.
- Ensures the feature works on page load and navigation events.

| Before | After |
|--------|-------|
| <img width="321" alt="Before" src="https://github.com/user-attachments/assets/0a3e6731-951f-400e-a1ac-616de0637096" /> | <img width="314" alt="After" src="https://github.com/user-attachments/assets/52037316-5c7e-4a93-aba4-4ebb0a18aebc" /> |

**Testing:**

- Enable/disable the option in Appearance > Details.
- Observe the likes counter: with the option enabled, the animation is removed and the number is static and aligned.
- The feature gracefully handles cases where YouTube does not display the animated counter.

Related:  
Issue: #2943
