### PR TITLE
Fix: Always show progress bar (Fixes #2946)

### DIFF
--- a/js&css/extension/www.youtube.com/appearance/player/player.css
+++ b/js&css/extension/www.youtube.com/appearance/player/player.css
@@ -17,6 +17,7 @@ html[it-ambient-lighting='false'] #cinematics {display: none !important;}
 # ALWAYS SHOW PROGRESS BAR
 --------------------------------------------------------------*/
 
+
 html[it-always-show-progress-bar='true'] .html5-video-player:not(.it-mini-player).ytp-autohide .ytp-chrome-bottom {
 	opacity: 1 !important;
 }
@@ -31,6 +32,9 @@ html[it-always-show-progress-bar='true'] .html5-video-player:not(.it-mini-player
 
 html[it-always-show-progress-bar='true'] .DesktopShortsPlayerControlsHostHideProgressBar {
     visibility: visible;
+}
+html[it-always-show-progress-bar='true'] .html5-video-player:not(.it-mini-player).ytp-autohide .ytp-chrome-bottom .ytp-scrubber-button {
+    display: none !important;
 }
 
 /*--------------------------------------------------------------


### PR DESCRIPTION
Fix: Always show progress bar (Fixes #2946)

This fix addresses the issue where enabling the 'always show progress bar' feature causes the red ball (scrubber button) to freeze and not follow the progress bar. The solution hides the red ball when the feature is active, improving the UI as the red ball appears misplaced otherwise.

Details

Issue: When the 'always show progress bar' feature is enabled, the red ball (scrubber button) freezes and fails to track the progress bar correctly.

Solution: Added CSS to hide the scrubber button when the feature is active:

[data-always-show-progress-bar="true"] .html5-video-player:not(.ytp-mini-player).ytp-autohide.ytp-chrome-bottom .ytp-scrubber-button {
    display: none !important;
}

Tested in Chrome with ImprovedTube version 4.1250.

Verified that this fix resolves the visual glitch without impacting other functionalities.