### PR TITLE
Fixing the duplicated YouTube logo

### DIFF
--- a/js&css/extension/www.youtube.com/appearance/header/header.css
+++ b/js&css/extension/www.youtube.com/appearance/header/header.css
@@ -142,7 +142,7 @@ html[it-header-position=hover]:not([data-page-type=video]) tp-yt-app-drawer:not(
 html[it-header-position=hidden]:not([data-page-type=video]) tp-yt-app-drawer:not([opened]) #header,
 html[it-header-position=static]:not([data-page-type=video]) tp-yt-app-drawer:not([opened]) #header {
 	position: absolute;
-	visibility: visible;
+	visibility: hidden;
 	left: 240px;
 	top: 120px;
 	padding: 0 16px;


### PR DESCRIPTION
This should solve the issue #2939 

I tested on Chrome and Edge, as usual. 

This should only affect the home page, the original functionality was not affected, e.g on YouTube video page.