### PR TITLE
Fix to the remaining time duration

### DIFF
--- a/js&css/web-accessible/core.js
+++ b/js&css/web-accessible/core.js
@@ -413,6 +413,8 @@ document.addEventListener('it-message-from-extension', function () {
 				case 'playerRemainingDuration':
 					if (ImprovedTube.storage.player_remaining_duration === false) {
 						document.querySelector(".ytp-time-remaining-duration")?.remove();
+						document.querySelector('.ytp-time-contents')?.removeAttribute('style');
+						document.querySelector('.ytp-time-contents')?.style.setProperty('display', 'block', 'important');						
 					} else if (ImprovedTube.storage.player_remaining_duration === true) {
 						ImprovedTube.playerRemainingDuration();
 					}

--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -157,10 +157,10 @@ ImprovedTube.formatSecond = function (rTime) {
 
 ImprovedTube.playerRemainingDuration = function () {
 	var duration = document.querySelector(".ytp-time-duration").innerText;
-	var remainingDuration = ImprovedTube.storage.player_remaining_duration;
-	if (remainingDuration) {
+//	var remainingDuration = ImprovedTube.storage.player_remaining_duration;
+//	if (remainingDuration) {
 		document.querySelector('.ytp-time-contents').style.setProperty('display', 'none', 'important');
-	}
+//	}  https://github.com/code-charity/youtube/pull/2956/files
 
 	var player = ImprovedTube.elements.player;
 	var rTime = ImprovedTube.formatSecond((player.getDuration() - player.getCurrentTime()).toFixed(0));	

--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -156,18 +156,22 @@ ImprovedTube.formatSecond = function (rTime) {
 };
 
 ImprovedTube.playerRemainingDuration = function () {
-	document.querySelector('.ytp-time-contents').style.setProperty('display', 'none', 'important');
-	
+	var duration = document.querySelector(".ytp-time-duration").innerText;
+	var remainingDuration = ImprovedTube.storage.player_remaining_duration;
+	if (remainingDuration) {
+		document.querySelector('.ytp-time-contents').style.setProperty('display', 'none', 'important');
+	}
+
 	var player = ImprovedTube.elements.player;
-	var rTime = ImprovedTube.formatSecond((player.getDuration() - player.getCurrentTime()).toFixed(0));
+	var rTime = ImprovedTube.formatSecond((player.getDuration() - player.getCurrentTime()).toFixed(0));	
 	var element = document.querySelector(".ytp-time-remaining-duration");
 	if (!element) {
 		var label = document.createElement("span");
-		label.textContent = " (-" + rTime + ")";
+		label.textContent = duration + " / (-" + rTime + ")";
 		label.className = "ytp-time-remaining-duration";
 		document.querySelector(".ytp-time-display span").appendChild(label);
-	} else {
-		element.textContent = " (-" + rTime + ")";
+	} else {		
+		return element.textContent = duration + " / (-" + rTime + ")";
 	}
 };
 /*------------------------------------------------------------------------------


### PR DESCRIPTION
This should solve issue #2951 and show the time remaining as shown in the image below
![image](https://github.com/user-attachments/assets/0d1dfae3-a164-49c5-8e26-3f6c8215f63e)

Also, this commit improve the way to both time remaining and "normal time" appears, changing in real time both, so will not be necessary to reload page after you toggle on/off the "Show video remaining duration" option.

Tested on Chrome and Edge.
