### PR TITLE
Improve thumbnails per row on the Subscriptions page

### DIFF
--- a/js&css/extension/www.youtube.com/general/general.js
+++ b/js&css/extension/www.youtube.com/general/general.js
@@ -661,14 +661,25 @@ extension.features.changeThumbnailsPerRow = async function () {
 		return;
 
 	const applyGridLayout = () => {
-		const grid = document.querySelector('ytd-rich-grid-renderer');
-		if (!grid) 
-			return;
+		//Check if we are on the subscriptions page
+		if (location.href.indexOf('feed/subscriptions') !== -1) {
+			document.querySelectorAll('[style]').forEach(el => {
+				if (el.style.getPropertyValue('--ytd-rich-grid-items-per-row')) {
+					el.style.setProperty('--ytd-rich-grid-items-per-row', value);
+					el.style.setProperty('--ytd-rich-grid-item-min-width', '220px');
+					el.style.setProperty('--ytd-rich-grid-item-max-width', '1fr');
+				}
+			});
+		} else {		
+			const grid = document.querySelector('ytd-rich-grid-renderer');
+			if (!grid) 
+				return;
 
-		// Apply custom values
-		grid.style.setProperty('--ytd-rich-grid-items-per-row', value);
-		grid.style.setProperty('--ytd-rich-grid-item-min-width', '220px');
-		grid.style.setProperty('--ytd-rich-grid-item-max-width', '1fr');
+			// Apply custom values
+			grid.style.setProperty('--ytd-rich-grid-items-per-row', value);
+			grid.style.setProperty('--ytd-rich-grid-item-min-width', '220px');
+			grid.style.setProperty('--ytd-rich-grid-item-max-width', '1fr');
+		}
   	};
 
 	// Apply initially


### PR DESCRIPTION
This is an improvement from PR #2936.

[@MisterTickle](https://github.com/MisterTickle) commented that it was not working on the Subscriptions page, and indeed was not good enough, sometimes worked, sometimes not.

Since YouTube treats each page a bit differently, I had to look for all elements on the Subs page for the specific class, --ytd-rich-grid-items-per-row, and then apply the number of items. 

If you still see something strange visually, like some rows with only 2 videos, is because of the Shorts; disable them and it should work perfectly. But even if you like shorts, this only happens in 2 to 3 rows at maximum, so it is not a huge problem.

Tested on both Chrome and Edge, and also confirmed that the previous code for the Home page is working fine; the change was only for the Subscriptions page.