### PR TITLE
Fix to catch more scenarios for "Disabling AI auto-dub feature"

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -1633,8 +1633,13 @@ ImprovedTube.disableAutoDubbing = function () {
 		}
 
 		function hasOriginalKeyword(track) {
-			const name = track?.HB?.name?.toLowerCase() || '';
+			var name = track?.HB?.name?.toLowerCase() || '';
 			const localizedOriginalWords = ['original', 'originale', 'originalny', 'originalaudio', 'origineel', 'orijinal']; // Add more if needed
+			if (name === '') {
+				// Try to get the localized name from other variable
+				name = track?.Af.name?.toLowerCase() || '';
+			}
+			
 			return localizedOriginalWords.some(word => name.includes(word));
 		}
 


### PR DESCRIPTION
This is an improvement from PR #2957.

I was testing [this video](https://www.youtube.com/watch?v=DZIASl9q90s), which has a lot of audio dub tracks, so is pretty good to test, and I found an issue.

My fix is simple and just add a new validation to get the original track from another variable, depending on the video, this can happen, so this is more like a covering all bases scenario.

Tested on Edge, but the code should work on all browsers.