### PR TITLE
Validation to hide Shorts on the Subscriptions page, in List mode.

### DIFF
--- a/js&css/extension/www.youtube.com/general/general.css
+++ b/js&css/extension/www.youtube.com/general/general.css
@@ -100,6 +100,7 @@ html[it-pathname='/feed/subscriptions'][it-remove-subscriptions-shorts="true"] y
 /*are the two lines above outdated?*/
 html[it-pathname='/'][it-remove-home-page-shorts="true"] ytd-rich-section-renderer:has(ytd-rich-shelf-renderer[is-shorts]), 
 html[it-pathname='/feed/subscriptions'][it-remove-subscriptions-shorts="true"] ytd-rich-section-renderer:has(ytd-rich-shelf-renderer[is-shorts]),
+html[it-pathname='/feed/subscriptions'][it-remove-subscriptions-shorts="true"] ytd-item-section-renderer:has(a[href="/feed/subscriptions/shorts"]),
 html[it-pathname='/feed/history'][it-remove-history-shorts="true"] ytd-reel-shelf-renderer,
 html[it-pathname='/feed/trending'][it-remove-trending-shorts="true"] ytd-reel-shelf-renderer {
 	display: none !important;

--- a/menu/skeleton-parts/general.js
+++ b/menu/skeleton-parts/general.js
@@ -111,7 +111,8 @@ extension.skeleton.main.layers.section.general = {
 				},
 				remove_subscriptions_shorts: {
 					component: 'switch',
-					text: 'atSubscriptions'
+					text: 'atSubscriptions',
+					id: 'remove-subscriptions-shorts'
 				},
 				remove_trending_shorts: {
 					component: 'switch',


### PR DESCRIPTION
This should solve the issue #2982 

The old code is working but only for the Grid mode. In List mode, a different class is used, and the property "is-shorts" doesn't exist.

YouTube being YouTube.

Tested on Chrome and Edge, but should work for all browsers, since is a CSS issue with fixed named elements.