### PR TITLE
Feature: Adding a button below player to jump to the next key scene(s)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1451,5 +1451,8 @@
     },
     "disableAutoDubbing": {
         "message": "Disable auto dubbing"
+    },
+    "jumpToKeyScene": {
+        "message": "Jump to the next key scene"
     }
 }

--- a/js&css/web-accessible/core.js
+++ b/js&css/web-accessible/core.js
@@ -400,6 +400,15 @@ document.addEventListener('it-message-from-extension', function () {
 					}
 					break
 
+				case 'belowPlayerKeyScene':
+					if (ImprovedTube.storage.below_player_keyscene === false) {
+						document.querySelector('.improvedtube-player-button[data-tooltip="NextKeyScene"]')?.remove();
+					} else if (ImprovedTube.storage.below_player_keyscene === true) {
+						document.querySelectorAll('.improvedtube-player-button').forEach(e => e.remove());
+						ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer();
+					}
+					break
+
 				case 'copyVideoId':
 					if (ImprovedTube.storage.copy_video_id === false) {
 						document.querySelector('.improvedtube-player-button[data-tooltip="CopyVideoId"]')?.remove();

--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -476,6 +476,30 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
 				section.insertAdjacentElement('afterend', button)
 			}
 
+			if (this.storage.below_player_keyscene !== false) {
+				var button = document.createElement('button'),
+				svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
+				g = document.createElementNS('http://www.w3.org/2000/svg', 'g'),
+				path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+
+				button.className = 'improvedtube-player-button';
+				button.style.marginRight = '-0.2px';
+				button.dataset.tooltip = 'Key Scene';
+				svg.style.opacity = '.55';
+				svg.setAttributeNS(null, 'viewBox', '0 0 24 24');
+				g.setAttributeNS(null, 'transform', 'translate(5, 0)');				
+				path.setAttributeNS(null, 'd', 'M13 2 L3 14 H10 L8 22 L20 10 H13 L15 2 Z');
+
+				button.onclick = ImprovedTube.jumpToKeyScene;
+
+				g.appendChild(path);
+				svg.appendChild(path);	
+				button.appendChild(svg);
+
+				const screenshotButton = document.querySelector('[data-tooltip="Screenshot"]');
+				screenshotButton.parentElement.insertBefore(button, screenshotButton);
+			}
+
 			if (this.storage.copy_video_id === true) {
 				var button = document.createElement('button'),
 					svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg'),

--- a/js&css/web-accessible/www.youtube.com/shortcuts.js
+++ b/js&css/web-accessible/www.youtube.com/shortcuts.js
@@ -138,6 +138,8 @@ ImprovedTube.shortcutsListeners = {
 		ImprovedTube.input.pressed.shift = false;
 	}
 };
+/*--- jump To Key Scene ----*/
+ImprovedTube.shortcutJumpToKeyScenet = ImprovedTube.jumpToKeyScene;
 /*------------------------------------------------------------------------------
 Ambient lighting
 ------------------------------------------------------------------------------*/

--- a/menu/skeleton-parts/appearance.js
+++ b/menu/skeleton-parts/appearance.js
@@ -548,6 +548,11 @@ extension.skeleton.main.layers.section.appearance.on.click.hide_detail_button = 
 					component: 'switch',
 					text: 'loop',
 					value: true
+				},
+				below_player_keyscene: {
+					component: 'switch',
+					text: 'keyScene',
+					value: true
 				}
 			},
 			youtubeDetailButtons: {

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -1177,6 +1177,11 @@ extension.skeleton.main.layers.section.player.on.click = {
 				text: 'loop',
 				value: true
 			},
+			below_player_keyscene: {
+				component: 'switch',
+				text: 'keyScene',
+				value: true
+			},
 			copy_video_id: {
 				component: 'switch',
 				text: 'copyVideoId',

--- a/menu/skeleton-parts/shortcuts.js
+++ b/menu/skeleton-parts/shortcuts.js
@@ -206,6 +206,10 @@ extension.skeleton.main.layers.section.shortcuts = {
 						}
 					}
 				},
+				shortcut_jump_to_key_scene: {
+					component: 'shortcut',
+					text: 'jumpToKeyScene'
+				},
 				shortcut_seek_next_chapter: {
 					component: 'shortcut',
 					text: 'seekNextChapter'


### PR DESCRIPTION
This feature is closely related to #1463, adding a button below the player
![image](https://github.com/user-attachments/assets/6e6771aa-18e2-4f73-9c33-f8cc2562ea6c)
That allows us to jump to what I call "Key Scene" but is basically to jump to the "Most viewed" parts on a video, including videos with multiple most viewed moments.

It has one issue, though, because when you click on a video from a sidepanel the Youtube actually don't refresh the page, it will not work, it will try to jump to the timestamp from the previous video, the easy way to "solve" this is basically refreshing the page or opening every new video in a new tab, both have the same effect, which is to force the YouTube to refresh the page, so the feature will work fine in this case.

Tested on Chrome, Edge, and Firefox.

@ImprovedTube, let me know what you think.