### PR TITLE
fix: playlist thumbnails move to right when the feature is turned on

### DIFF
--- a/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.css
+++ b/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.css
@@ -255,9 +255,26 @@ html[data-page-type=video][it-sidebar-left='true'] #columns>#secondary>#related 
 /*--------------------------------------------------------------
 # MOVE THUMBNAILS RIGHT
 --------------------------------------------------------------*/
+/* Move thumbnails to the right for video suggestions */
 html[it-thumbnails-right='true'] #related ytd-watch-next-secondary-results-renderer ytd-thumbnail,
 html[it-thumbnails-right='true'] #related .modern-collection-parent,
-html[it-thumbnails-right='true'] #related ytd-watch-next-secondary-results-renderer ytd-playlist-thumbnail {
+html[it-thumbnails-right='true'] #related ytd-watch-next-secondary-results-renderer ytd-playlist-thumbnail,
+html[it-thumbnails-right='true'] #related ytd-compact-playlist-renderer ytd-thumbnail {
 	order: 5 !important;
 }
+
+/* Move thumbnails to the right for playlist suggestions (non-Polymer) */
+html[it-thumbnails-right='true'] #related yt-lockup-view-model .yt-lockup-view-model-wiz {
+	display: flex !important;
+	flex-direction: row-reverse !important;
+	align-items: flex-start !important;
+}
+
+/* Adjust spacing between image and metadata */
+html[it-thumbnails-right='true'] #related yt-lockup-view-model .yt-lockup-view-model-wiz__content-image {
+	margin-left: 12px !important;
+	margin-right: 0 !important;
+}
+
+  
 


### PR DESCRIPTION
Fixes issue #2972

### The Issue:
In **Appearance > Sidebar > Move thumbnails to the right!**, the thumbnails for playlist items remained aligned to the left, unlike regular video suggestions which moved correctly. This broke the visual consistency of the sidebar layout.

### The Fix:
YouTube is now rendering some playlist suggestions using a new layout system.

This PR updates the ImprovedTube stylesheet to handle both layouts:
- Applies `flexbox` to the new container.
- Reverses the direction so that playlist thumbnails appear on the right, matching the behavior for videos.

### Before:
![image](https://github.com/user-attachments/assets/6cf78b93-da23-4a34-89d5-e2c955815c94)  
_Source: from the original issue description_

### After:
<img width="788" alt="image" src="https://github.com/user-attachments/assets/db7c5889-2ed5-4bf9-a7e8-5864b1e8876f" />  
_Source: screenshot from my laptop_

Let me know if any tweaks are needed — happy to iterate!
Thanks,  
Aviral Dewan