### PR TITLE
Ignoring the remaining time duration if the video is a live stream

### DIFF
--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -156,6 +156,11 @@ ImprovedTube.formatSecond = function (rTime) {
 };
 
 ImprovedTube.playerRemainingDuration = function () {
+	//If is a live stream, do not show remaining time
+	 const button = document.querySelector('button.ytp-live-badge.ytp-button.ytp-live-badge-is-livehead');
+	if (button) 
+		return;	
+
 	var duration = document.querySelector(".ytp-time-duration").innerText;
 	var current = document.querySelector(".ytp-time-current").innerText;
 	document.querySelector('.ytp-time-contents').style.setProperty('display', 'none', 'important');


### PR DESCRIPTION
This should fix the issue mentioned in #3007 

Tested on Edge, Chrome.