### PR TITLE
Fix: Auto-pause YouTube video on tab switch using visibilitychange

### DIFF
--- a/js&css/extension/functions.js
+++ b/js&css/extension/functions.js
@@ -4,6 +4,19 @@
 # GET URL PARAMETER
 --------------------------------------------------------------*/
 extension.functions.getUrlParameter = function (url, parameter) {
-	var match = url.match(new RegExp('(\\?|\\&)' + parameter + '=[^&]+'));
-	if (match) {return match[0].substr(3);}
+  var match = url.match(new RegExp("(\\?|\\&)" + parameter + "=[^&]+"));
+  if (match) {
+    return match[0].substr(3);
+  }
 };
+
+document.addEventListener("visibilitychange", () => {
+  const videos = document.getElementsByTagName("video");
+  if (document.hidden && videos.length > 0) {
+    const video = videos[0];
+    if (!video.paused) {
+      video.pause();
+      console.log("[YT+]: Video paused (getElementsByTagName fallback)");
+    }
+  }
+});


### PR DESCRIPTION
This pull request adds a fix for the "auto-pause" feature when the user switches away from the YouTube tab.

✅ Listens for the `visibilitychange` event  
✅ Detects and pauses the first video on the page  
✅ Uses `getElementsByTagName("video")` for better reliability  
✅ Logs to console for testing and debugging  
✅ Tested on Microsoft Edge Dev — working as expected

This fixes a core functionality issue where multiple videos play or tab-switching does not pause playback. Let me know if any improvements are needed!