### PR TITLE
added option to hide sponsored videos on YouTube home page #3073

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,32 +1,49 @@
-{ 
-  "ShortsForceTheStandardPlayer": { "message": "Shorts: Force to use the standard player" },
-  "hideTopLoadingBar": { "message": "Hide Top Loading Bar" },
-	  "withoutVideos": { "message": "'Empty', without video previews" },
-	  "hideBannerAds": { "message": "Hide Banner Ads (YouTube might deny)" },
-		   "keyScene": { "message": "⚡Jump to the Most Replayed Scene/s" },
-	  "hideAISummary": { "message": "Hide AI Summaries" },
-    "requirePassword": { "message": "Require password to change ImprovedTube settings" },
-    "passwordOptions": { "message": "Password options"},
-      "enterPassword": { "message": "Please enter your 4-digit code."},
-    
-    "qualityWhenRunningOnBattery":{
+{
+    "ShortsForceTheStandardPlayer": {
+        "message": "Shorts: Force to use the standard player"
+    },
+    "hideTopLoadingBar": {
+        "message": "Hide Top Loading Bar"
+    },
+    "withoutVideos": {
+        "message": "'Empty', without video previews"
+    },
+    "hideBannerAds": {
+        "message": "Hide Banner Ads (YouTube might deny)"
+    },
+    "keyScene": {
+        "message": "⚡Jump to the Most Replayed Scene/s"
+    },
+    "hideAISummary": {
+        "message": "Hide AI Summaries"
+    },
+    "requirePassword": {
+        "message": "Require password to change ImprovedTube settings"
+    },
+    "passwordOptions": {
+        "message": "Password options"
+    },
+    "enterPassword": {
+        "message": "Please enter your 4-digit code."
+    },
+    "qualityWhenRunningOnBattery": {
         "message": "Quality, when running on battery"
     },
-    "pauseWhileIUnplugTheCharger":{
-        "message": "Pause when I unplug the charger" 
+    "pauseWhileIUnplugTheCharger": {
+        "message": "Pause when I unplug the charger"
     },
-    "whenBatteryIslowDecreaseQuality":{
+    "whenBatteryIslowDecreaseQuality": {
         "message": "Low battery: Decrease the quality"
     },
     "analytics": {
         "message": "Analytics"
-    }, 
+    },
     "purchase": {
         "message": "Purchase"
-    },    
+    },
     "join": {
         "message": "Join"
-    },  
+    },
     "improvedTubeSidePanel": {
         "message": "ImprovedTube: Browser Sidepanel"
     },
@@ -36,10 +53,10 @@
     "youtubesLight": {
         "message": "YouTube's Light"
     },
-	"popupAd": {
+    "popupAd": {
         "message": "Pop-up ad: Hide"
-    },	
-	"hideWatchedVideos": {
+    },
+    "hideWatchedVideos": {
         "message": "Hide watched videos"
     },
     "ambientLighting": {
@@ -186,7 +203,7 @@
     "autoplayDisable": {
         "message": "Force Autoplay Off"
     },
-    "preventShortVideoAutoloop":{
+    "preventShortVideoAutoloop": {
         "message": "Prevent short videos from auto-looping"
     },
     "avoidAv1": {
@@ -504,7 +521,7 @@
     "extraButtonsBelowThePlayer": {
         "message": "Extra buttons below the player"
     },
-    "extraRightControlButtons":{
+    "extraRightControlButtons": {
         "message": "Extra buttons inside the player"
     },
     "Feature_not_yet_available": {
@@ -707,6 +724,9 @@
     },
     "hideSkipOverlay": {
         "message": "Hide 5 second skip animation"
+    },
+    "hideSponsoredVideosOnHome": {
+        "message": "Hide sponsored videos on Home page"
     },
     "hideThumbnailOverlay": {
         "message": "Hide buttons on thumbnails"
@@ -993,7 +1013,7 @@
     "player_fit_to_win_button": {
         "message": "Fit to window"
     },
-    "player_rewind_and_forward_buttons":{
+    "player_rewind_and_forward_buttons": {
         "message": "Rewind/forward buttons"
     },
     "player_cinema_mode_button": {
@@ -1099,7 +1119,7 @@
         "message": "Remove names"
     },
     "removePlaylistParam": {
-	    "message": "Skip playlist when opening videos in new tab"
+        "message": "Skip playlist when opening videos in new tab"
     },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,49 +1,33 @@
-{
-    "ShortsForceTheStandardPlayer": {
-        "message": "Shorts: Force to use the standard player"
-    },
-    "hideTopLoadingBar": {
-        "message": "Hide Top Loading Bar"
-    },
-    "withoutVideos": {
-        "message": "'Empty', without video previews"
-    },
-    "hideBannerAds": {
-        "message": "Hide Banner Ads (YouTube might deny)"
-    },
-    "keyScene": {
-        "message": "⚡Jump to the Most Replayed Scene/s"
-    },
-    "hideAISummary": {
-        "message": "Hide AI Summaries"
-    },
-    "requirePassword": {
-        "message": "Require password to change ImprovedTube settings"
-    },
-    "passwordOptions": {
-        "message": "Password options"
-    },
-    "enterPassword": {
-        "message": "Please enter your 4-digit code."
-    },
-    "qualityWhenRunningOnBattery": {
+{   
+     "hideSponsoredVideosOnHome": { "message": "Hide sponsored videos on Home page"},
+  "ShortsForceTheStandardPlayer": { "message": "Shorts: Force to use the standard player" },
+  "hideTopLoadingBar": { "message": "Hide Top Loading Bar" },
+	  "withoutVideos": { "message": "'Empty', without video previews" },
+	  "hideBannerAds": { "message": "Hide Banner Ads (YouTube might deny)" },
+		   "keyScene": { "message": "⚡Jump to the Most Replayed Scene/s" },
+	  "hideAISummary": { "message": "Hide AI Summaries" },
+    "requirePassword": { "message": "Require password to change ImprovedTube settings" },
+    "passwordOptions": { "message": "Password options"},
+      "enterPassword": { "message": "Please enter your 4-digit code."},
+    
+    "qualityWhenRunningOnBattery":{
         "message": "Quality, when running on battery"
     },
-    "pauseWhileIUnplugTheCharger": {
-        "message": "Pause when I unplug the charger"
+    "pauseWhileIUnplugTheCharger":{
+        "message": "Pause when I unplug the charger" 
     },
-    "whenBatteryIslowDecreaseQuality": {
+    "whenBatteryIslowDecreaseQuality":{
         "message": "Low battery: Decrease the quality"
     },
     "analytics": {
         "message": "Analytics"
-    },
+    }, 
     "purchase": {
         "message": "Purchase"
-    },
+    },    
     "join": {
         "message": "Join"
-    },
+    },  
     "improvedTubeSidePanel": {
         "message": "ImprovedTube: Browser Sidepanel"
     },
@@ -53,10 +37,10 @@
     "youtubesLight": {
         "message": "YouTube's Light"
     },
-    "popupAd": {
+	"popupAd": {
         "message": "Pop-up ad: Hide"
-    },
-    "hideWatchedVideos": {
+    },	
+	"hideWatchedVideos": {
         "message": "Hide watched videos"
     },
     "ambientLighting": {
@@ -203,7 +187,7 @@
     "autoplayDisable": {
         "message": "Force Autoplay Off"
     },
-    "preventShortVideoAutoloop": {
+    "preventShortVideoAutoloop":{
         "message": "Prevent short videos from auto-looping"
     },
     "avoidAv1": {
@@ -521,7 +505,7 @@
     "extraButtonsBelowThePlayer": {
         "message": "Extra buttons below the player"
     },
-    "extraRightControlButtons": {
+    "extraRightControlButtons":{
         "message": "Extra buttons inside the player"
     },
     "Feature_not_yet_available": {
@@ -724,9 +708,6 @@
     },
     "hideSkipOverlay": {
         "message": "Hide 5 second skip animation"
-    },
-    "hideSponsoredVideosOnHome": {
-        "message": "Hide sponsored videos on Home page"
     },
     "hideThumbnailOverlay": {
         "message": "Hide buttons on thumbnails"
@@ -1013,7 +994,7 @@
     "player_fit_to_win_button": {
         "message": "Fit to window"
     },
-    "player_rewind_and_forward_buttons": {
+    "player_rewind_and_forward_buttons":{
         "message": "Rewind/forward buttons"
     },
     "player_cinema_mode_button": {
@@ -1119,7 +1100,7 @@
         "message": "Remove names"
     },
     "removePlaylistParam": {
-        "message": "Skip playlist when opening videos in new tab"
+	    "message": "Skip playlist when opening videos in new tab"
     },
     "removeRelatedSearchResults": {
         "message": "Remove related search results"

--- a/js&css/extension/core.js
+++ b/js&css/extension/core.js
@@ -315,7 +315,7 @@ extension.storage.load = function (callback) {
 			action: 'storage-loaded',
 			storage: items
 		});
-		
+
 		if (callback) {
 			callback(extension.storage.data);
 		}

--- a/js&css/extension/core.js
+++ b/js&css/extension/core.js
@@ -101,7 +101,7 @@ extension.events.trigger = async function (type, data) {
 			var listener = listeners[i];
 
 			if (typeof listener === 'function') {
-				if (listener instanceof (async function () { }).constructor === true) {
+				if (listener instanceof(async function () {}).constructor === true) {
 					await listener(data);
 				} else {
 					listener(data);
@@ -295,27 +295,17 @@ extension.storage.listener = function () {
 /*--------------------------------------------------------------
 # LOAD
 --------------------------------------------------------------*/
-// Default feature settings
-// extension.storage.defaults = {
-// 	hide_sponsored_videos_home: true
-// };
+
 
 extension.storage.load = function (callback) {
 	chrome.storage.local.get(function (items) {
 		extension.storage.data = items;
 
-		// Add fallback default
-		// if (typeof items.hide_sponsored_videos_home === 'undefined') {
-		// 	items.hide_sponsored_videos_home = true;
-		// 	extension.storage.data['hide_sponsored_videos_home'] = true;
-		// 	chrome.storage.local.set({ hide_sponsored_videos_home: true });
-		// }
-
 
 		// initialize theme in case YT is in Dark cookie mode
 		if (!extension.storage.data['theme'] && document.documentElement.hasAttribute('dark')) {
 			extension.storage.data['theme'] = 'dark';
-			chrome.storage.local.set({ theme: 'dark' });
+			chrome.storage.local.set({theme: 'dark'});
 		}
 
 		for (const key in items) {
@@ -328,10 +318,6 @@ extension.storage.load = function (callback) {
 			storage: items
 		});
 
-		// // Call your feature manually (or inside a map of features)
-		// if (typeof extension.features.hideSponsoredVideosOnHome === 'function') {
-		// 	extension.features.hideSponsoredVideosOnHome();
-		// }
 
 		if (callback) {
 			callback(extension.storage.data);

--- a/js&css/extension/core.js
+++ b/js&css/extension/core.js
@@ -101,7 +101,7 @@ extension.events.trigger = async function (type, data) {
 			var listener = listeners[i];
 
 			if (typeof listener === 'function') {
-				if (listener instanceof(async function () {}).constructor === true) {
+				if (listener instanceof (async function () { }).constructor === true) {
 					await listener(data);
 				} else {
 					listener(data);
@@ -295,15 +295,28 @@ extension.storage.listener = function () {
 /*--------------------------------------------------------------
 # LOAD
 --------------------------------------------------------------*/
+// Default feature settings
+extension.storage.defaults = {
+	// Add your new feature here 👇
+	hide_sponsored_videos_home: true
+};
 
 extension.storage.load = function (callback) {
 	chrome.storage.local.get(function (items) {
 		extension.storage.data = items;
 
+		// ✅ Add fallback default
+		if (typeof items.hide_sponsored_videos_home === 'undefined') {
+			items.hide_sponsored_videos_home = true;
+			extension.storage.data['hide_sponsored_videos_home'] = true;
+			chrome.storage.local.set({ hide_sponsored_videos_home: true });
+		}
+
+
 		// initialize theme in case YT is in Dark cookie mode
 		if (!extension.storage.data['theme'] && document.documentElement.hasAttribute('dark')) {
 			extension.storage.data['theme'] = 'dark';
-			chrome.storage.local.set({theme: 'dark'});
+			chrome.storage.local.set({ theme: 'dark' });
 		}
 
 		for (const key in items) {
@@ -315,6 +328,11 @@ extension.storage.load = function (callback) {
 			action: 'storage-loaded',
 			storage: items
 		});
+
+		// 👇 Call your feature manually (or inside a map of features)
+		if (typeof extension.features.hideSponsoredVideosOnHome === 'function') {
+			extension.features.hideSponsoredVideosOnHome();
+		}
 
 		if (callback) {
 			callback(extension.storage.data);

--- a/js&css/extension/core.js
+++ b/js&css/extension/core.js
@@ -296,21 +296,20 @@ extension.storage.listener = function () {
 # LOAD
 --------------------------------------------------------------*/
 // Default feature settings
-extension.storage.defaults = {
-	// Add your new feature here 👇
-	hide_sponsored_videos_home: true
-};
+// extension.storage.defaults = {
+// 	hide_sponsored_videos_home: true
+// };
 
 extension.storage.load = function (callback) {
 	chrome.storage.local.get(function (items) {
 		extension.storage.data = items;
 
-		// ✅ Add fallback default
-		if (typeof items.hide_sponsored_videos_home === 'undefined') {
-			items.hide_sponsored_videos_home = true;
-			extension.storage.data['hide_sponsored_videos_home'] = true;
-			chrome.storage.local.set({ hide_sponsored_videos_home: true });
-		}
+		// Add fallback default
+		// if (typeof items.hide_sponsored_videos_home === 'undefined') {
+		// 	items.hide_sponsored_videos_home = true;
+		// 	extension.storage.data['hide_sponsored_videos_home'] = true;
+		// 	chrome.storage.local.set({ hide_sponsored_videos_home: true });
+		// }
 
 
 		// initialize theme in case YT is in Dark cookie mode
@@ -329,10 +328,10 @@ extension.storage.load = function (callback) {
 			storage: items
 		});
 
-		// 👇 Call your feature manually (or inside a map of features)
-		if (typeof extension.features.hideSponsoredVideosOnHome === 'function') {
-			extension.features.hideSponsoredVideosOnHome();
-		}
+		// // Call your feature manually (or inside a map of features)
+		// if (typeof extension.features.hideSponsoredVideosOnHome === 'function') {
+		// 	extension.features.hideSponsoredVideosOnHome();
+		// }
 
 		if (callback) {
 			callback(extension.storage.data);

--- a/js&css/extension/core.js
+++ b/js&css/extension/core.js
@@ -296,11 +296,9 @@ extension.storage.listener = function () {
 # LOAD
 --------------------------------------------------------------*/
 
-
 extension.storage.load = function (callback) {
 	chrome.storage.local.get(function (items) {
 		extension.storage.data = items;
-
 
 		// initialize theme in case YT is in Dark cookie mode
 		if (!extension.storage.data['theme'] && document.documentElement.hasAttribute('dark')) {
@@ -317,8 +315,7 @@ extension.storage.load = function (callback) {
 			action: 'storage-loaded',
 			storage: items
 		});
-
-
+		
 		if (callback) {
 			callback(extension.storage.data);
 		}

--- a/js&css/extension/init.js
+++ b/js&css/extension/init.js
@@ -49,7 +49,7 @@ extension.events.on('init', function () {
 	extension.features.comments();
 	extension.features.openNewTab();
 	extension.features.removeListParamOnNewTab();
-	extension.features.hideSponsoredVideosOnHome?.();	
+	// extension.features.hideSponsoredVideosOnHome?.();	
 	bodyReady();
 });
 

--- a/js&css/extension/init.js
+++ b/js&css/extension/init.js
@@ -10,6 +10,8 @@ window.addEventListener('yt-navigate-finish', function () {
 
 	extension.features.trackWatchedVideos();
 	extension.features.thumbnailsQuality();
+
+	extension.features.hideSponsoredVideosOnHome?.();
 });
 
 extension.messages.create();
@@ -46,7 +48,8 @@ extension.events.on('init', function () {
 	extension.features.relatedVideos();
 	extension.features.comments();
 	extension.features.openNewTab();
-	extension.features.removeListParamOnNewTab();	
+	extension.features.removeListParamOnNewTab();
+	extension.features.hideSponsoredVideosOnHome?.();	
 	bodyReady();
 });
 

--- a/js&css/extension/www.youtube.com/general/general.css
+++ b/js&css/extension/www.youtube.com/general/general.css
@@ -87,6 +87,13 @@ html[it-hide-thumbnail-dots="true"] button.yt-spec-button-shape-next[aria-label=
     display: none;
 }
 /*--------------------------------------------------------------
+/*--------------------------------------------------------------
+# HIDE SPONSORED VIDEOS ON HOME PAGE
+--------------------------------------------------------------*/
+html[it-hide-sponsored-videos-home='true'] ytd-rich-item-renderer:has(ytd-badge-supported-renderer:has(span:matches-css-text("Sponsored"))) {
+  display: none !important;
+}
+/*--------------------------------------------------------------
 # EMBEDDED VIDEOS
  --------------------------------------------------------------*/
 html[it-embeddedHidePauseOverlay='true'] .ytp-pause-overlay,

--- a/js&css/extension/www.youtube.com/general/general.css
+++ b/js&css/extension/www.youtube.com/general/general.css
@@ -90,9 +90,10 @@ html[it-hide-thumbnail-dots="true"] button.yt-spec-button-shape-next[aria-label=
 /*--------------------------------------------------------------
 # HIDE SPONSORED VIDEOS ON HOME PAGE
 --------------------------------------------------------------*/
-html[it-hide-sponsored-videos-home='true'] ytd-rich-item-renderer:has(ytd-badge-supported-renderer:has(span:matches-css-text("Sponsored"))) {
+html[it-pathname='/'][it-hide-sponsored-videos-home="true"] ytd-rich-item-renderer:has(a[href^="https://www.googleadservices.com/pagead/aclk"]) {
   display: none !important;
 }
+
 /*--------------------------------------------------------------
 # EMBEDDED VIDEOS
  --------------------------------------------------------------*/

--- a/js&css/extension/www.youtube.com/general/general.css
+++ b/js&css/extension/www.youtube.com/general/general.css
@@ -87,7 +87,7 @@ html[it-hide-thumbnail-dots="true"] button.yt-spec-button-shape-next[aria-label=
     display: none;
 }
 /*--------------------------------------------------------------
-/*--------------------------------------------------------------
+/*------------------------------------------------------------------
 # HIDE SPONSORED VIDEOS ON HOME PAGE
 --------------------------------------------------------------*/
 html[it-pathname='/'][it-hide-sponsored-videos-home="true"] ytd-rich-item-renderer:has(a[href^="https://www.googleadservices.com/pagead/aclk"]) {

--- a/js&css/extension/www.youtube.com/general/general.js
+++ b/js&css/extension/www.youtube.com/general/general.js
@@ -689,3 +689,35 @@ extension.features.changeThumbnailsPerRow = async function () {
 	const observer = new MutationObserver(applyGridLayout);
 	observer.observe(document.body, { childList: true, subtree: true });
 };
+
+/*--------------------------------------------------------------
+# HIDE SPONSORED VIDEOS ON HOME PAGE
+--------------------------------------------------------------*/
+
+extension.features.hideSponsoredVideosOnHome = function () {
+	console.log('[ImprovedTube] Hiding sponsored videos on Home is working!!')
+	if (!extension.storage.data.hide_sponsored_videos_home) return;
+
+	console.log('[ImprovedTube] Hiding sponsored videos on Home');
+
+	const hideSponsored = () => {
+		document.querySelectorAll('ytd-rich-item-renderer, ytd-video-renderer').forEach((el) => {
+			const text = el.innerText || '';
+			if (/sponsored/i.test(text)) {
+				el.style.display = 'none';
+			}
+		});
+	};
+
+	hideSponsored(); // Initial run
+
+	const observer = new MutationObserver(hideSponsored);
+	const pageManager = document.querySelector('ytd-page-manager') || document.body;
+
+	if (pageManager) {
+		observer.observe(pageManager, {
+			childList: true,
+			subtree: true
+		});
+	}
+};

--- a/js&css/extension/www.youtube.com/general/general.js
+++ b/js&css/extension/www.youtube.com/general/general.js
@@ -695,11 +695,8 @@ extension.features.changeThumbnailsPerRow = async function () {
 --------------------------------------------------------------*/
 
 // extension.features.hideSponsoredVideosOnHome = function () {
-// 	console.log('[ImprovedTube] Hiding sponsored videos on Home is working!!')
-// 	if (!extension.storage.data.hide_sponsored_videos_home) return;
-
+// 	if (!extension.storage.get('hide_sponsored_videos_home')) return;
 // 	console.log('[ImprovedTube] Hiding sponsored videos on Home');
-
 // 	const hideSponsored = () => {
 // 		document.querySelectorAll('ytd-rich-item-renderer, ytd-video-renderer').forEach((el) => {
 // 			const text = el.innerText || '';
@@ -708,12 +705,9 @@ extension.features.changeThumbnailsPerRow = async function () {
 // 			}
 // 		});
 // 	};
-
 // 	hideSponsored(); // Initial run
-
 // 	const observer = new MutationObserver(hideSponsored);
 // 	const pageManager = document.querySelector('ytd-page-manager') || document.body;
-
 // 	if (pageManager) {
 // 		observer.observe(pageManager, {
 // 			childList: true,

--- a/js&css/extension/www.youtube.com/general/general.js
+++ b/js&css/extension/www.youtube.com/general/general.js
@@ -694,30 +694,30 @@ extension.features.changeThumbnailsPerRow = async function () {
 # HIDE SPONSORED VIDEOS ON HOME PAGE
 --------------------------------------------------------------*/
 
-extension.features.hideSponsoredVideosOnHome = function () {
-	console.log('[ImprovedTube] Hiding sponsored videos on Home is working!!')
-	if (!extension.storage.data.hide_sponsored_videos_home) return;
+// extension.features.hideSponsoredVideosOnHome = function () {
+// 	console.log('[ImprovedTube] Hiding sponsored videos on Home is working!!')
+// 	if (!extension.storage.data.hide_sponsored_videos_home) return;
 
-	console.log('[ImprovedTube] Hiding sponsored videos on Home');
+// 	console.log('[ImprovedTube] Hiding sponsored videos on Home');
 
-	const hideSponsored = () => {
-		document.querySelectorAll('ytd-rich-item-renderer, ytd-video-renderer').forEach((el) => {
-			const text = el.innerText || '';
-			if (/sponsored/i.test(text)) {
-				el.style.display = 'none';
-			}
-		});
-	};
+// 	const hideSponsored = () => {
+// 		document.querySelectorAll('ytd-rich-item-renderer, ytd-video-renderer').forEach((el) => {
+// 			const text = el.innerText || '';
+// 			if (/sponsored/i.test(text)) {
+// 				el.style.display = 'none';
+// 			}
+// 		});
+// 	};
 
-	hideSponsored(); // Initial run
+// 	hideSponsored(); // Initial run
 
-	const observer = new MutationObserver(hideSponsored);
-	const pageManager = document.querySelector('ytd-page-manager') || document.body;
+// 	const observer = new MutationObserver(hideSponsored);
+// 	const pageManager = document.querySelector('ytd-page-manager') || document.body;
 
-	if (pageManager) {
-		observer.observe(pageManager, {
-			childList: true,
-			subtree: true
-		});
-	}
-};
+// 	if (pageManager) {
+// 		observer.observe(pageManager, {
+// 			childList: true,
+// 			subtree: true
+// 		});
+// 	}
+// };

--- a/menu/skeleton-parts/general.js
+++ b/menu/skeleton-parts/general.js
@@ -174,9 +174,7 @@ extension.skeleton.main.layers.section.general = {
 				},
 				hide_sponsored_videos_home: {
 					component: 'switch',
-					variant: 'checkbox',
-					text: 'hideSponsoredVideosOnHome',
-					id: 'hide_sponsored_videos_home'
+					text: 'hideSponsoredVideosOnHome'
 				}
 			},
 			embed: {

--- a/menu/skeleton-parts/general.js
+++ b/menu/skeleton-parts/general.js
@@ -171,7 +171,13 @@ extension.skeleton.main.layers.section.general = {
 				hide_banner_ads: {
 					component: 'switch',
 					text: 'hideBannerAds'
-				} 
+				},
+				hide_sponsored_videos_home: {
+					component: 'switch',
+					variant: 'checkbox',
+					text: 'hideSponsoredVideosOnHome',
+					id: 'hide_sponsored_videos_home'
+				}
 			},
 			embed: {
 				component: 'section',


### PR DESCRIPTION
| Category     | Details                                                                 |
|--------------|-------------------------------------------------------------------------|
| Problem      | No way to remove sponsored videos on home page                          |
| Solution     | Added toggle to hide them cleanly without leaving gaps                  |
| Alternatives | Used scripts before, but they left empty space or broke layout          |
| Scope        | Improves experience for users who dislike sponsored content             |
| Side effects | None – feature is isolated and optional                                 |
| Context      | fixed Issue [#3073](https://github.com/code4charity/YouTube-Extension/issues/3073) |

**🎥 Demo Video:** [Watch here](https://www.loom.com/share/3714d5a1c3bf4aeeaccc1499f6bb4303?sid=10969f3f-3b46-445e-add9-74fa61123c58)

