### PR TITLE
feat: Add sticky navigation feature to prevent YouTube sidebar auto-hide

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -674,6 +674,9 @@
     "sidebar": {
         "message": "Seitenleiste"
     },
+    "stickyNavigation": {
+        "message": "Feste Navigation"
+    },
     "spacebar": {
         "message": "Leertaste"
     },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -630,6 +630,9 @@
     "Hide_sidebar": {
         "message": "Hide sidebar "
     },
+    "stickyNavigation": {
+        "message": "Sticky Navigation"
+    },
     "Hide_the_tabs_only": {
         "message": "Hide the tabs only"
     },

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -932,6 +932,9 @@
     "sidebar": {
         "message": "Barra lateral"
     },
+    "stickyNavigation": {
+        "message": "Navegación Fija"
+    },
     "softwareInformation": {
         "message": "Información del Software"
     },

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -605,6 +605,9 @@
     "sidebar": {
         "message": "Barre latérale"
     },
+    "stickyNavigation": {
+        "message": "Navigation Fixe"
+    },
     "spacebar": {
         "message": "Barre d'espace"
     },

--- a/js&css/extension/init.js
+++ b/js&css/extension/init.js
@@ -10,6 +10,7 @@ window.addEventListener('yt-navigate-finish', function () {
 
 	extension.features.trackWatchedVideos();
 	extension.features.thumbnailsQuality();
+	extension.features.stickyNavigation();
 });
 
 extension.messages.create();
@@ -44,6 +45,7 @@ extension.events.on('init', function () {
 	extension.features.disableThumbnailPlayback();
 	extension.features.markWatchedVideos();
 	extension.features.relatedVideos();
+	extension.features.stickyNavigation();
 	extension.features.comments();
 	extension.features.openNewTab();
 	extension.features.removeListParamOnNewTab();	

--- a/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.css
+++ b/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.css
@@ -263,6 +263,53 @@ html[it-thumbnails-right='true'] #related ytd-compact-playlist-renderer ytd-thum
 	order: 5 !important;
 }
 
+/*--------------------------------------------------------------
+# STICKY NAVIGATION
+--------------------------------------------------------------*/
+/* Prevent left navigation from auto-hiding */
+html[it-sticky-navigation='true'] ytd-mini-guide-renderer {
+	transform: translateX(0) !important;
+	transition: none !important;
+}
+
+html[it-sticky-navigation='true'] ytd-mini-guide-renderer[hidden] {
+	display: block !important;
+	transform: translateX(0) !important;
+}
+
+html[it-sticky-navigation='true'] ytd-mini-guide-renderer[aria-hidden="true"] {
+	aria-hidden: false !important;
+	transform: translateX(0) !important;
+}
+
+/* Ensure the guide is always visible */
+html[it-sticky-navigation='true'] ytd-guide-renderer {
+	transform: translateX(0) !important;
+	transition: none !important;
+}
+
+html[it-sticky-navigation='true'] ytd-guide-renderer[hidden] {
+	display: block !important;
+	transform: translateX(0) !important;
+}
+
+html[it-sticky-navigation='true'] ytd-guide-renderer[aria-hidden="true"] {
+	aria-hidden: false !important;
+	transform: translateX(0) !important;
+}
+
+/* Override any auto-hide animations */
+html[it-sticky-navigation='true'] ytd-mini-guide-renderer,
+html[it-sticky-navigation='true'] ytd-guide-renderer {
+	animation: none !important;
+	transition: none !important;
+}
+
+/* Ensure the guide button doesn't hide the navigation */
+html[it-sticky-navigation='true'] ytd-masthead ytd-button-renderer[is="ytd-button-renderer"] {
+	display: none !important;
+}
+
 /* Move thumbnails to the right for playlist suggestions (non-Polymer) */
 html[it-thumbnails-right='true'] #related yt-lockup-view-model .yt-lockup-view-model-wiz {
 	display: flex !important;

--- a/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.js
+++ b/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.js
@@ -2,6 +2,7 @@
 >>> SIDEBAR
 ----------------------------------------------------------------
 # Related videos
+# Sticky navigation
 --------------------------------------------------------------*/
 
 /*--------------------------------------------------------------
@@ -33,6 +34,74 @@ extension.features.relatedVideos = function (anything) {
 			window.addEventListener('click', this.relatedVideos, true);
 		} else {
 			window.removeEventListener('click', this.relatedVideos, true);
+		}
+	}
+};
+
+/*--------------------------------------------------------------
+# STICKY NAVIGATION
+--------------------------------------------------------------*/
+
+extension.features.stickyNavigation = function () {
+	if (extension.storage.get('sticky_navigation') === true) {
+		// Function to ensure navigation stays visible
+		function ensureNavigationVisible() {
+			const miniGuide = document.querySelector('ytd-mini-guide-renderer');
+			const guide = document.querySelector('ytd-guide-renderer');
+			
+			if (miniGuide) {
+				miniGuide.style.transform = 'translateX(0)';
+				miniGuide.style.transition = 'none';
+				miniGuide.removeAttribute('hidden');
+				miniGuide.setAttribute('aria-hidden', 'false');
+			}
+			
+			if (guide) {
+				guide.style.transform = 'translateX(0)';
+				guide.style.transition = 'none';
+				guide.removeAttribute('hidden');
+				guide.setAttribute('aria-hidden', 'false');
+			}
+		}
+
+		// Apply immediately
+		ensureNavigationVisible();
+
+		// Set up observer to watch for navigation changes
+		const observer = new MutationObserver(function(mutations) {
+			mutations.forEach(function(mutation) {
+				if (mutation.type === 'attributes' && 
+					(mutation.attributeName === 'hidden' || mutation.attributeName === 'aria-hidden')) {
+					ensureNavigationVisible();
+				}
+			});
+		});
+
+		// Observe navigation elements
+		const miniGuide = document.querySelector('ytd-mini-guide-renderer');
+		const guide = document.querySelector('ytd-guide-renderer');
+		
+		if (miniGuide) {
+			observer.observe(miniGuide, {
+				attributes: true,
+				attributeFilter: ['hidden', 'aria-hidden']
+			});
+		}
+		
+		if (guide) {
+			observer.observe(guide, {
+				attributes: true,
+				attributeFilter: ['hidden', 'aria-hidden']
+			});
+		}
+
+		// Store observer for cleanup
+		extension.features.stickyNavigationObserver = observer;
+	} else {
+		// Clean up observer if setting is disabled
+		if (extension.features.stickyNavigationObserver) {
+			extension.features.stickyNavigationObserver.disconnect();
+			extension.features.stickyNavigationObserver = null;
 		}
 	}
 };

--- a/menu/skeleton-parts/appearance.js
+++ b/menu/skeleton-parts/appearance.js
@@ -972,6 +972,11 @@ extension.skeleton.main.layers.section.appearance.on.click.sidebar = {
 			hide_sidebar: {
 				component: "switch",
 				text: 'Hide_sidebar'
+			},
+			sticky_navigation: {
+				component: "switch",
+				text: 'stickyNavigation',
+				tags: 'navigation,auto-hide,sidebar'
 			}
 		}
 	}

--- a/tests/unit/sticky-navigation.test.js
+++ b/tests/unit/sticky-navigation.test.js
@@ -1,0 +1,132 @@
+// Mock extension object for sticky navigation tests
+jest.mock('../../js&css/extension/core', () => ({
+	storage: {
+		get: jest.fn(),
+		data: {}
+	},
+	features: {
+		stickyNavigationObserver: null
+	}
+}));
+
+// Set up global extension object before requiring sidebar.js
+global.extension = {
+	storage: {
+		get: jest.fn(),
+		data: {}
+	},
+	features: {
+		stickyNavigationObserver: null
+	}
+};
+
+// Mock DOM elements
+const mockMiniGuide = {
+	style: {},
+	setAttribute: jest.fn(),
+	removeAttribute: jest.fn()
+};
+
+const mockGuide = {
+	style: {},
+	setAttribute: jest.fn(),
+	removeAttribute: jest.fn()
+};
+
+// Mock document.querySelector
+global.document = {
+	querySelector: jest.fn((selector) => {
+		if (selector === 'ytd-mini-guide-renderer') {
+			return mockMiniGuide;
+		}
+		if (selector === 'ytd-guide-renderer') {
+			return mockGuide;
+		}
+		return null;
+	})
+};
+
+// Mock MutationObserver
+global.MutationObserver = jest.fn().mockImplementation(() => ({
+	observe: jest.fn(),
+	disconnect: jest.fn()
+}));
+
+// Import the sticky navigation feature
+require('../../js&css/extension/www.youtube.com/appearance/sidebar/sidebar.js');
+
+describe('Sticky Navigation Feature', () => {
+	beforeEach(() => {
+		// Reset mocks
+		jest.clearAllMocks();
+		global.extension.storage.get.mockReturnValue(false);
+		global.extension.features.stickyNavigationObserver = null;
+	});
+
+	test('should not apply sticky navigation when setting is disabled', () => {
+		global.extension.storage.get.mockReturnValue(false);
+		
+		// Call the sticky navigation function
+		global.extension.features.stickyNavigation();
+		
+		// Verify that no DOM manipulation occurred
+		expect(mockMiniGuide.style.transform).toBeUndefined();
+		expect(mockGuide.style.transform).toBeUndefined();
+		expect(global.extension.features.stickyNavigationObserver).toBeNull();
+	});
+
+	test('should apply sticky navigation when setting is enabled', () => {
+		global.extension.storage.get.mockReturnValue(true);
+		
+		// Call the sticky navigation function
+		global.extension.features.stickyNavigation();
+		
+		// Verify that DOM manipulation occurred
+		expect(mockMiniGuide.style.transform).toBe('translateX(0)');
+		expect(mockMiniGuide.style.transition).toBe('none');
+		expect(mockGuide.style.transform).toBe('translateX(0)');
+		expect(mockGuide.style.transition).toBe('none');
+		
+		// Verify that attributes were set correctly
+		expect(mockMiniGuide.removeAttribute).toHaveBeenCalledWith('hidden');
+		expect(mockMiniGuide.setAttribute).toHaveBeenCalledWith('aria-hidden', 'false');
+		expect(mockGuide.removeAttribute).toHaveBeenCalledWith('hidden');
+		expect(mockGuide.setAttribute).toHaveBeenCalledWith('aria-hidden', 'false');
+		
+		// Verify that observer was created
+		expect(global.extension.features.stickyNavigationObserver).toBeDefined();
+	});
+
+	test('should clean up observer when setting is disabled after being enabled', () => {
+		// First enable the feature
+		global.extension.storage.get.mockReturnValue(true);
+		global.extension.features.stickyNavigation();
+		
+		// Mock the observer
+		const mockObserver = {
+			disconnect: jest.fn()
+		};
+		global.extension.features.stickyNavigationObserver = mockObserver;
+		
+		// Now disable the feature
+		global.extension.storage.get.mockReturnValue(false);
+		global.extension.features.stickyNavigation();
+		
+		// Verify that observer was disconnected
+		expect(mockObserver.disconnect).toHaveBeenCalled();
+		expect(global.extension.features.stickyNavigationObserver).toBeNull();
+	});
+
+	test('should handle missing navigation elements gracefully', () => {
+		global.extension.storage.get.mockReturnValue(true);
+		
+		// Mock document.querySelector to return null
+		global.document.querySelector = jest.fn().mockReturnValue(null);
+		
+		// Call the sticky navigation function
+		global.extension.features.stickyNavigation();
+		
+		// Should not throw an error and should still create an observer
+		expect(global.extension.features.stickyNavigationObserver).toBeDefined();
+	});
+}); 


### PR DESCRIPTION
Implemented a new feature that allows users to disable YouTube's auto-hiding left navigation panel, keeping it visible at all times like YouTube's UI before recent updates.
Workflow:
User enables setting in extension popup → Settings → Appearance → Sidebar → "Sticky Navigation" toggle
Extension injects CSS to override YouTube's auto-hide styles
JavaScript applies DOM manipulation to force navigation visibility
MutationObserver monitors for YouTube's attempts to hide navigation and re-applies styles
Feature persists across page loads and navigation events

Files Modified:
sidebar.js - Core feature logic
sidebar.css - Style overrides
init.js - Integration
appearance.js - UI setting
_locales/*.json - Translations (EN/ES/FR/DE)
sticky-navigation.test.js - Unit tests.

Result: When enabled, YouTube's left navigation stays visible and doesn't auto-hide on scroll/interaction.