### PR TITLE
fix: auto-pause not working when switching tabs in the same window

### DIFF
--- a/background.js
+++ b/background.js
@@ -210,6 +210,7 @@ function tabPrune (callback) {
 chrome.tabs.onActivated.addListener(function (activeInfo) {
 	tabPrev = tab;
 	tab = activeInfo;
+    windowId = activeInfo.windowId;
 	//console.log('activeInfo', windowId, tabPrev, tab);
 	tabPrune(function () {
 		if (windowId == tabPrev.windowId) {


### PR DESCRIPTION
I still have an issue: if I have two tabs in the same window with the same YouTube video — for example, one tab paused (inactive) and the other playing — when I switch from the playing tab to the paused one, the current video stops, which is fine. But the problem is that the video in the inactive tab starts playing automatically, which can be annoying. I don’t know if this is intended behavior or a bug.