### PR TITLE
Fix: Hide sidebar thumbnails option not working

### DIFF
--- a/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.css
+++ b/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.css
@@ -142,6 +142,9 @@ html[it-hide-shorts-remixing='true'] #related ytd-reel-shelf-renderer,
 --------------------------------------------------------------*/
 html[it-thumbnails-hide='true'] ytd-watch-next-secondary-results-renderer ytd-thumbnail,
 html[it-thumbnails-hide='true'] ytd-watch-next-secondary-results-renderer ytd-playlist-thumbnail,
+html[it-thumbnails-hide='true'] ytd-watch-next-secondary-results-renderer .yt-lockup-view-model-wiz__content-image {
+    display: none !important;
+}
 /*--------------------------------------------------------------
 # LIVECHAT
 --------------------------------------------------------------*/


### PR DESCRIPTION
Addressing #3114 
This PR updates the CSS rule for hiding thumbnails in the sidebar to more precisely target sidebar thumbnails. 
