### PR TITLE
Fixed css to address 🐞 #2261 Bug with firefox #3135

### DIFF
--- a/menu/index.html
+++ b/menu/index.html
@@ -1,5 +1,6 @@
 <!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width">
-<title>ImprovedTube</title><style>body{width:320px;max-width:320px; margin:0; min-height:522 !important;height:584px;max-height:584px;}</style>
+<title>ImprovedTube</title>
+<style> body { margin: 0; width: 320px; max-width: 320px; min-height: 522px !important; height: 584px; max-height: 584px; } </style>
 <script src="satus.js"></script>
 <script src="skeleton.js"></script>
 <script src="functions.js"></script>


### PR DESCRIPTION
Fixed body CSS in menu/index.html so that the menu renders properly in about:addons Preferences in Firefox. Corrected code to `min-height: 522px !important` (the "px" was missing before, so Firefox was ignoring this requirement, causing the menu to be collapsed).