### PR TITLE
Fix the build script for Firefox

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -19,7 +19,8 @@ import sys
 import json
 import os
 import zipfile
-
+#import pathlib
+#import re
 
 #---------------------------------------------------------------
 # 2.0 CHROMIUM


### PR DESCRIPTION
This PR fixes the build.py script so that it generates a zip-file which can be used in Firefox's Load Temporary Add-on. 