### PR TITLE
feat(player): add playback speed control button and settings

### DIFF
--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -332,6 +332,7 @@ ImprovedTube.videoPageUpdate = function () {
 		ImprovedTube.playerAutofullscreen();
 		ImprovedTube.playerSize();
 		if (this.storage.player_always_repeat === true) { ImprovedTube.playerRepeat(); };
+		ImprovedTube.playerPlaybackSpeedButton();
 		ImprovedTube.playerScreenshotButton();
 		ImprovedTube.addYouTubeReturnButton();
 		ImprovedTube.playerRepeatButton();
@@ -391,6 +392,7 @@ ImprovedTube.initPlayer = function () {
 		ImprovedTube.playerVolume();
 		if (this.storage.player_always_repeat === true) { ImprovedTube.playerRepeat(); }
 
+		ImprovedTube.playerPlaybackSpeedButton();
 		ImprovedTube.playerScreenshotButton();
 		ImprovedTube.playerRepeatButton();
 		ImprovedTube.playerRotateButton();

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -625,6 +625,82 @@ ImprovedTube.playerLoudnessNormalization = function () {
 		} catch (err) {}
 	}
 };
+ImprovedTube.playerPlaybackSpeedButton = function () {
+  if (this.storage.player_playback_speed_button === true) {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    const text = document.createElementNS("http://www.w3.org/2000/svg", "text");
+
+    svg.setAttribute("viewBox", "0 0 36 36");
+    svg.style.width = "100%";
+    svg.style.height = "100%";
+
+    // Simple speedometer icon
+    path.setAttribute(
+      "d",
+      "M25.9,13.1A8.2,8.2,0,0,0,18,10a8.2,8.2,0,0,0-7.9,3.1L8,12.2V22h9.8l-1-2H10v-2h3.3l1.1-2.2a6.1,6.1,0,0,1,11.2,0L26.7,18H30v2H21.8l-1-2h4.1A8.2,8.2,0,0,0,25.9,13.1Z"
+    );
+    path.setAttribute("fill", "#fff");
+
+    // Text element to show current speed
+    text.setAttribute("x", "18");
+    text.setAttribute("y", "23");
+    text.setAttribute("font-size", "8px");
+    text.setAttribute("font-weight", "bold");
+    text.setAttribute("text-anchor", "middle");
+    text.setAttribute("fill", "#fff");
+    text.setAttribute("class", "it-speed-text");
+    text.textContent = (this.elements.video?.playbackRate || 1.0).toFixed(2);
+
+    svg.appendChild(path);
+    svg.appendChild(text);
+
+    const button = this.createPlayerButton({
+      id: "it-playback-speed-button",
+      child: svg,
+      opacity: 0.85,
+      title: "Playback Speed Control",
+    });
+
+    const updateSpeedText = () => {
+      const currentSpeed = (this.elements.video?.playbackRate || 1.0).toFixed(
+        2
+      );
+      if (button) {
+        const textElement = button.querySelector(".it-speed-text");
+        if (textElement) textElement.textContent = currentSpeed;
+      }
+    };
+
+    // --- Event Listeners ---
+    button.onclick = () => {
+      const customSpeed = this.storage.player_custom_playback_speed || 1.25;
+      this.playbackSpeed(customSpeed);
+    };
+
+    button.oncontextmenu = (e) => {
+      e.preventDefault();
+      this.playbackSpeed(1.0);
+      return false;
+    };
+
+    button.onwheel = (e) => {
+      e.preventDefault();
+      const currentSpeed = this.playbackSpeed();
+      const direction = e.deltaY < 0 ? 1 : -1;
+      let newSpeed = Math.round((currentSpeed + direction * 0.05) * 100) / 100;
+
+      if (newSpeed > 4) newSpeed = 4;
+      if (newSpeed < 0.1) newSpeed = 0.1;
+
+      this.playbackSpeed(newSpeed);
+    };
+
+    this.elements.video.addEventListener("ratechange", updateSpeedText);
+    updateSpeedText(); // Set initial value
+  }
+};
+
 /*------------------------------------------------------------------------------
 SCREENSHOT
 ------------------------------------------------------------------------------*/

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -1121,6 +1121,24 @@ extension.skeleton.main.layers.section.player.on.click = {
 				return options;
 			}
 		},
+
+		player_playback_speed_button: {
+			component: 'switch',
+			text: 'playbackSpeedButton',
+			storage: 'player_playback_speed_button',
+			id: 'player_playback_speed_button',
+			children: [{
+				id: 'player_custom_playback_speed',
+				storage: 'player_custom_playback_speed',
+				component: 'slider',
+				text: 'preferredSpeed',
+				min: 0.25,
+				max: 4,
+				step: 0.05,
+				text: true,
+				value: 1.25
+			}]
+		},
 	
 		player_cinema_mode_button: {
 			component: 'switch',


### PR DESCRIPTION
# feat(player): Add dedicated playback speed button

## Summary

This pull request introduces a dedicated, toggle-able button on the YouTube player's control bar for adjusting playback speed. This resolves the inconvenience of accessing the speed controls, which were previously located deep inside the settings menu. The new button provides immediate access to speed adjustments via left-click, right-click, and mouse scroll.

## Root Cause

The YouTube player interface lacks a first-class control for playback speed, forcing users through multiple clicks for a common action. This feature was missing from the extension, requiring a new UI element in both the settings and the player itself.

## Changes

-   **`menu/skeleton-parts/player.js`**: Added a new `switch` and nested `slider` to the settings UI, allowing users to enable the button and configure a preferred speed.
-   **`js&css/web-accessible/www.youtube.com/player.js`**: Added the `playerPlaybackSpeedButton` function, which creates the button's SVG icon and text, and attaches all event listeners (`click`, `contextmenu`, `wheel`).
-   **`js&css/web-accessible/functions.js`**: Integrated the new feature by calling `playerPlaybackSpeedButton()` from the `videoPageUpdate` and `initPlayer` functions, ensuring it loads correctly.

## Screenshots

### New Setting in Menu

This shows the new toggle switch and preferred speed slider in the "Player" settings.

![WhatsApp Image 2025-09-28 at 10 11 05_5fc764b5](https://github.com/user-attachments/assets/bd3a9a18-f23f-4b46-8df5-e84450e968d9)


### Player Controls - Before

This shows the player controls before the change, without the new button.

![WhatsApp Image 2025-09-28 at 10 29 01_408e8582](https://github.com/user-attachments/assets/100978ef-ad83-413f-a700-27bcf21b2eaf)


### Player Controls - After

This shows the player controls with the new playback speed button visible and active.

![WhatsApp Image 2025-09-28 at 10 30 05_1fcaceda](https://github.com/user-attachments/assets/175d614e-3e50-48f0-85f3-ea3bd034320a)
## Testing

-   Ran local checks: `npm run lint` and `npm run test` both passed.
-   Performed manual testing on a live YouTube video page:
    -    Enabled the feature in the extension settings.
    -    Verified the button appears correctly on the player control bar.
    -    Confirmed left-click sets the speed to the preferred value from settings.
    -    Confirmed right-click resets the speed to 1.0x.
    -    Confirmed mouse scrolling over the button correctly increments/decrements the speed.
    -    Verified the speed value displayed on the button updates in real-time.
    -    Disabled the feature and verified the button disappears.

## Risk & Rollback

-   **Risk**: Low. The changes are self-contained within new functions and respect a user-controlled setting. It doesn't modify existing core logic.
-   **Rollback**: This change can be safely reverted with `git revert <commit_hash>`.

## Related

-   Closes #3200