### PR TITLE
feat: Add playback speed button to player controls

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -1522,5 +1522,8 @@
   },
   "exact": {
     "message": "Genaues Datum/Uhrzeit"
+  },
+  "player_playback_speed_button": {
+    "message": "Wiedergabegeschwindigkeit-Button"
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1013,6 +1013,9 @@
   "player_rewind_and_forward_buttons": {
     "message": "Rewind/forward buttons"
   },
+  "player_playback_speed_button": {
+    "message": "Playback Speed Button"
+  },
   "player_cinema_mode_button": {
     "message": "Cinema Mode"
   },

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1111,5 +1111,8 @@
     },
     "youtubeLimitsVideoQualityTo1080pForH264Codec": {
         "message": "YouTube limita calidad de video a 1080p para el codec h.264"
+    },
+    "player_playback_speed_button": {
+        "message": "Botón de Velocidad de Reproducción"
     }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -950,7 +950,10 @@
     "hardwareInformation": {
         "message": "Informations sur le matériel"
     },
-	"popupAd": {
+        "popupAd": {
         "message": "Pop-up pub: Masquer"
+    },
+    "player_playback_speed_button": {
+        "message": "Bouton de Vitesse de Lecture"
     }
 }

--- a/js&css/web-accessible/core.js
+++ b/js&css/web-accessible/core.js
@@ -375,6 +375,14 @@ document.addEventListener('it-message-from-extension', function () {
 					}
 					break
 
+				case 'playerPlaybackSpeedButton':
+					if (ImprovedTube.storage.player_playback_speed_button === false) {
+						document.querySelector('#it-playback-speed-button')?.remove();
+					} else if (ImprovedTube.storage.player_playback_speed_button === true) {
+						ImprovedTube.playerPlaybackSpeedButton();
+					}
+					break
+
 				case 'belowPlayerPip':
 					if (ImprovedTube.storage.below_player_pip === false) {
 						document.querySelector('.improvedtube-player-button[data-tooltip="PiP"]')?.remove();

--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -396,7 +396,8 @@ ImprovedTube.initPlayer = function () {
 		ImprovedTube.playerRotateButton();
 		ImprovedTube.playerPopupButton();
 		ImprovedTube.playerFitToWinButton();
-		ImprovedTube.playerRewindAndForwardButtons()
+		ImprovedTube.playerRewindAndForwardButtons();
+		ImprovedTube.playerPlaybackSpeedButton();
 		ImprovedTube.playerHamburgerButton();
 		ImprovedTube.playerControls();
 		ImprovedTube.playerHideProgressPreview();

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -821,6 +821,62 @@ ImprovedTube.playerRotateButton = function () {
 };
 
 /*------------------------------------------------------------------------------
+PLAYBACK SPEED BUTTON
+------------------------------------------------------------------------------*/
+ImprovedTube.playerPlaybackSpeedButton = function () {
+	if (this.storage.player_playback_speed_button === true) {
+		var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
+			path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+
+		svg.setAttributeNS(null, 'viewBox', '0 0 24 24');
+		path.setAttributeNS(null, 'd', 'M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z');
+
+		svg.appendChild(path);
+
+		var button = this.createPlayerButton({
+			id: 'it-playback-speed-button',
+			child: svg,
+			opacity: 0.7,
+			onclick: function (e) {
+				// Left click: set to custom speed from settings
+				if (e.button === 0) {
+					var customSpeed = ImprovedTube.storage.player_playback_speed || 1.25;
+					ImprovedTube.playbackSpeed(customSpeed);
+					ImprovedTube.showStatus(customSpeed + 'x');
+				}
+			},
+			title: 'Playback Speed (Scroll: adjust, Left: custom, Right: 1.0x)'
+		});
+
+		// Add right-click handler
+		button.addEventListener('contextmenu', function (e) {
+			e.preventDefault();
+			ImprovedTube.playbackSpeed(1.0);
+			ImprovedTube.showStatus('1.0x');
+		});
+
+		// Add wheel handler
+		button.addEventListener('wheel', function (e) {
+			e.preventDefault();
+			var step = Number(ImprovedTube.storage.shortcuts_playback_speed_step) || 0.1;
+			var currentSpeed = ImprovedTube.playbackSpeed();
+			var newSpeed;
+			
+			if (e.deltaY < 0) {
+				// Scroll up: increase speed
+				newSpeed = Math.min(currentSpeed + step, 16);
+			} else {
+				// Scroll down: decrease speed
+				newSpeed = Math.max(currentSpeed - step, 0.0625);
+			}
+			
+			ImprovedTube.playbackSpeed(newSpeed);
+			ImprovedTube.showStatus(newSpeed.toFixed(2) + 'x');
+		});
+	}
+};
+
+/*------------------------------------------------------------------------------
 FIT-TO-WIN BUTTON
 ------------------------------------------------------------------------------*/
 ImprovedTube.playerFitToWinButton = function () {

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -1208,10 +1208,14 @@ extension.skeleton.main.layers.section.player.on.click = {
 				component: 'switch',
 				text: 'player_fit_to_win_button'
 			},
-			player_rewind_and_forward_buttons: {
-				component: 'switch',
-				text: 'player_rewind_and_forward_buttons'
-			},
+		player_rewind_and_forward_buttons: {
+			component: 'switch',
+			text: 'player_rewind_and_forward_buttons'
+		},
+		player_playback_speed_button: {
+			component: 'switch',
+			text: 'player_playback_speed_button'
+		},
 		},
 		fullscreen_return_button: {
 			component: 'switch',


### PR DESCRIPTION
- Add toggle-able playback speed button in player controls
- Left click: set to custom speed from settings (default 1.25x)
- Right click: reset to 1.0x normal speed
- Mouse wheel: adjust speed in configurable steps (default 0.1x)
- Speed range: 0.0625x to 16x (browser limits)
- Added to Player  Buttons settings section
- Multi-language support: EN, ES, FR, DE
- Integrates with existing playback speed system
- Uses existing shortcuts_playback_speed_step setting
- Uses existing player_playback_speed setting for custom speed

Resolves: Quick access to playback speed without gear menu navigation