### PR TITLE
Fix: Nightmode Without Refreshing (Partial) Issue #3136

### DIFF
--- a/js&css/extension/www.youtube.com/night-mode/night-mode.js
+++ b/js&css/extension/www.youtube.com/night-mode/night-mode.js
@@ -116,7 +116,7 @@ extension.features.schedule = function () {
 		to = Number((extension.storage.get('schedule_time_to') || '00:00').substr(0, 2));
 
 	if (to < from && current > from && current < 24) {
-		times.to += 24;
+		to += 24;
 	} else if (to < from && current < to) {
 		from = 0;
 	}

--- a/menu/skeleton-parts/night-mode.js
+++ b/menu/skeleton-parts/night-mode.js
@@ -51,7 +51,13 @@ extension.skeleton.header.sectionEnd.menu.on.click.nightMode = {
 					}, {
 						text: 'systemPeferenceLight',
 						value: 'system_peference_light'
-					}]
+					}],
+					onchange: function () {
+						setTimeout(() => {
+						extension.features.bluelight();
+						extension.features.dim();
+						}, 100);
+					},
 				},
 				schedule_time_from: {
 					component: 'time',
@@ -59,7 +65,13 @@ extension.skeleton.header.sectionEnd.menu.on.click.nightMode = {
 					variant: 'from',
 					hour12: function () {
 						return satus.storage.get('use_24_hour_format') === false;
-					}
+					},
+					onchange: function () {
+						setTimeout(() => {
+						extension.features.bluelight();
+						extension.features.dim();
+						}, 100);
+					},
 				},
 				schedule_time_to: {
 					component: 'time',
@@ -67,7 +79,13 @@ extension.skeleton.header.sectionEnd.menu.on.click.nightMode = {
 					variant: 'to',
 					hour12: function () {
 						return satus.storage.get('use_24_hour_format') === false;
-					}
+					},
+					onchange: function () {
+						setTimeout(() => {
+						extension.features.bluelight();
+						extension.features.dim();
+						}, 100);
+					},
 				}
 			}
 		}


### PR DESCRIPTION
When the time at the start of the video page is within the schedule time, nightmode no longer needs to refresh when altering with dim and schedule times.

However, nightmode's dim is locked, but not reset to 0 when outside of the schedule time frame. Also, nightmode does not auto-switch into the proper schedule while the video is playing until the page is refreshed as the time is only collected at the start of the webpage.

It's supposed to address Issue #3136.

Tested with Firefox's Temporary Add-ons and Google's Developer Mode on Extensions.