### PR TITLE
fix(header): update logo styles for improved visibility and modern ap…

### DIFF
--- a/js&css/extension/www.youtube.com/appearance/header/header.css
+++ b/js&css/extension/www.youtube.com/appearance/header/header.css
@@ -168,11 +168,15 @@ html[it-header-hide-logo='true'] #logo-icon yt-icon-shape,
 html[it-header-hide-logo='true'] #logo-icon .yt-icon-shape {
 	visibility:hidden;
 }
+/* Simple fix: Add modern YouTube logo selectors */
 html[it-header-improve-logo='true'] ytd-topbar-logo-renderer path[fill='#FF0000'],
-html[it-header-improve-logo='true'] ytd-topbar-logo-renderer polygon[fill='#FFFFFF'] {
+html[it-header-improve-logo='true'] ytd-topbar-logo-renderer polygon[fill='#FFFFFF'],
+html[it-header-improve-logo='true'] #logo path[fill='#FF0000'],
+html[it-header-improve-logo='true'] #logo polygon[fill='#FFFFFF'] {
 	fill: rgb(44, 44, 44) !important;
 }
-html[it-header-improve-logo='true'][dark] ytd-topbar-logo-renderer path[fill='#FF0000'] {
+html[it-header-improve-logo='true'][dark] ytd-topbar-logo-renderer path[fill='#FF0000'],
+html[it-header-improve-logo='true'][dark] #logo path[fill='#FF0000'] {
 	fill: rgb(70, 70, 70) !important;
 }
 /*--------------------------------------------------------------


### PR DESCRIPTION
### Concise Description

Fixes an issue where the "Monochrome logo" setting had no effect — the YouTube logo remained bright red even when the monochrome option was enabled.

### Summary

This update adjusts the YouTube header CSS to properly support the modern YouTube logo structure. It expands the CSS selectors so that logo color changes apply correctly to both the old and new logo markup used by YouTube.

### Changes Made

- Added CSS selectors to target modern YouTube logo elements (#logo path and #logo polygon).

- Ensured proper color handling for both light and dark modes.

- Improved consistency for logo color customization across all header variations.

This PR fixes #3225 

