### PR TITLE
fix: Safari page-world injection on YouTube

### DIFF
--- a/background.js
+++ b/background.js
@@ -248,9 +248,15 @@ chrome.windows.onFocusChanged.addListener(function (wId) {
 /*--------------------------------------------------------------
 # EXTENSION API SCRIPT INJECTION (for Safari)
 --------------------------------------------------------------*/
-async function injectFilesInMainWorld(tabId, files) {
+async function injectFilesInMainWorld(tabId, frameId, files) {
 	if (!chrome.scripting?.insertCSS || !chrome.scripting?.executeScript) {
 		throw new Error('chrome.scripting main-world injection failed');
+	}
+
+	const target = { tabId };
+
+	if (typeof frameId === 'number') {
+		target.frameIds = [frameId];
 	}
 
 	for (const originalFile of files) {
@@ -258,12 +264,12 @@ async function injectFilesInMainWorld(tabId, files) {
 
 		if (file.endsWith('.css')) {
 			await chrome.scripting.insertCSS({
-				target: { tabId },
+				target,
 				files: [file]
 			});
 		} else {
 			await chrome.scripting.executeScript({
-				target: { tabId },
+				target,
 				files: [file],
 				world: 'MAIN'
 			});
@@ -312,7 +318,7 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
 				break
 			}
 
-			injectFilesInMainWorld(sender.tab.id, message.files)
+			injectFilesInMainWorld(sender.tab.id, sender.frameId, message.files)
 				.then(function () {
 					sendResponse({ ok: true });
 				})

--- a/background.js
+++ b/background.js
@@ -304,10 +304,10 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
 			break
 
 		case 'inject-main-world':
-			if (!sender.tab?.id || sender.frameId !== 0 || !Array.isArray(message.files)) {
+			if (!sender.tab?.id || !Array.isArray(message.files)) {
 				sendResponse({
 					ok: false,
-					error: 'Missing top-frame tab context or file list'
+					error: 'Missing tab context or file list'
 				});
 				break
 			}

--- a/background.js
+++ b/background.js
@@ -193,6 +193,10 @@ let tabConnected = {},
 	windowId;
 
 async function injectFilesInMainWorld(tabId, files) {
+	if (!chrome.scripting?.insertCSS || !chrome.scripting?.executeScript) {
+		throw new Error('chrome.scripting is unavailable');
+	}
+
 	for (const originalFile of files) {
 		const file = originalFile.replace(/^\//, '');
 

--- a/background.js
+++ b/background.js
@@ -192,29 +192,6 @@ let tabConnected = {},
 	tabPrev = {},
 	windowId;
 
-async function injectFilesInMainWorld(tabId, files) {
-	if (!chrome.scripting?.insertCSS || !chrome.scripting?.executeScript) {
-		throw new Error('chrome.scripting is unavailable');
-	}
-
-	for (const originalFile of files) {
-		const file = originalFile.replace(/^\//, '');
-
-		if (file.endsWith('.css')) {
-			await chrome.scripting.insertCSS({
-				target: { tabId },
-				files: [file]
-			});
-		} else {
-			await chrome.scripting.executeScript({
-				target: { tabId },
-				files: [file],
-				world: 'MAIN'
-			});
-		}
-	}
-}
-
 function tabPrune (callback) {
 	chrome.tabs.query({ url: 'https://www.youtube.com/*' }).then(function (tabs) {
 		let tabIds = [];
@@ -269,6 +246,32 @@ chrome.windows.onFocusChanged.addListener(function (wId) {
 	});
 });
 /*--------------------------------------------------------------
+# EXTENSION API SCRIPT INJECTION (for Safari)
+--------------------------------------------------------------*/
+async function injectFilesInMainWorld(tabId, files) {
+	if (!chrome.scripting?.insertCSS || !chrome.scripting?.executeScript) {
+		throw new Error('chrome.scripting main-world injection failed');
+	}
+
+	for (const originalFile of files) {
+		const file = originalFile.replace(/^\//, '');
+
+		if (file.endsWith('.css')) {
+			await chrome.scripting.insertCSS({
+				target: { tabId },
+				files: [file]
+			});
+		} else {
+			await chrome.scripting.executeScript({
+				target: { tabId },
+				files: [file],
+				world: 'MAIN'
+			});
+		}
+	}
+}
+
+/*--------------------------------------------------------------
 # MESSAGE LISTENER
 --------------------------------------------------------------*/
 chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
@@ -301,10 +304,10 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
 			break
 
 		case 'inject-main-world':
-			if (!sender.tab?.id || !Array.isArray(message.files)) {
+			if (!sender.tab?.id || sender.frameId !== 0 || !Array.isArray(message.files)) {
 				sendResponse({
 					ok: false,
-					error: 'Missing tab context or file list'
+					error: 'Missing top-frame tab context or file list'
 				});
 				break
 			}
@@ -314,10 +317,11 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
 					sendResponse({ ok: true });
 				})
 				.catch(function (error) {
-					console.error('MAIN world injection failed', error);
+					const message = error?.message || 'Safari main-world injection failed';
+					console.error(message, error);
 					sendResponse({
 						ok: false,
-						error: String(error)
+						error: message
 					});
 				});
 

--- a/background.js
+++ b/background.js
@@ -192,6 +192,25 @@ let tabConnected = {},
 	tabPrev = {},
 	windowId;
 
+async function injectFilesInMainWorld(tabId, files) {
+	for (const originalFile of files) {
+		const file = originalFile.replace(/^\//, '');
+
+		if (file.endsWith('.css')) {
+			await chrome.scripting.insertCSS({
+				target: { tabId },
+				files: [file]
+			});
+		} else {
+			await chrome.scripting.executeScript({
+				target: { tabId },
+				files: [file],
+				world: 'MAIN'
+			});
+		}
+	}
+}
+
 function tabPrune (callback) {
 	chrome.tabs.query({ url: 'https://www.youtube.com/*' }).then(function (tabs) {
 		let tabIds = [];
@@ -276,6 +295,29 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
 				tabId: sender.tab.id
 			});
 			break
+
+		case 'inject-main-world':
+			if (!sender.tab?.id || !Array.isArray(message.files)) {
+				sendResponse({
+					ok: false,
+					error: 'Missing tab context or file list'
+				});
+				break
+			}
+
+			injectFilesInMainWorld(sender.tab.id, message.files)
+				.then(function () {
+					sendResponse({ ok: true });
+				})
+				.catch(function (error) {
+					console.error('MAIN world injection failed', error);
+					sendResponse({
+						ok: false,
+						error: String(error)
+					});
+				});
+
+			return true;
 
 		case 'fixPopup':
 			//~ get the current focused tab and convert it to a URL-less popup (with same state and size)

--- a/build/build.py
+++ b/build/build.py
@@ -173,6 +173,57 @@ def firefox():
     os.chdir('..')
     shutil.rmtree(temporary_path)
 
+def safari():
+    temporary_path = os.path.abspath('../cached-safari')
+
+    if os.path.isdir(temporary_path):
+        shutil.rmtree(temporary_path, ignore_errors=True)
+
+    shutil.copytree(
+        '..',
+        temporary_path,
+        ignore=shutil.ignore_patterns(
+            '.git',
+            '.github',
+            'cached',
+            'cached-safari',
+            'previews',
+            'py',
+            'wiki',
+            '*.zip',
+            *EXCLUDE_TOP_LEVEL
+        )
+    )
+
+    os.chdir(temporary_path)
+
+    with open('manifest.json', 'r+', encoding='utf8') as json_file:
+        data = json.load(json_file)
+
+        version = data['version']
+        permissions = data.get('permissions', [])
+
+        if 'scripting' not in permissions:
+            permissions.append('scripting')
+
+        data['permissions'] = permissions
+
+        json_file.seek(0)
+        json.dump(data, json_file, indent=4, sort_keys=True)
+        json_file.truncate()
+
+    archive = zipfile.ZipFile('../safari-' + version + '.zip', 'w', zipfile.ZIP_DEFLATED)
+
+    for root, dirs, files in os.walk('.'):
+        for file in files:
+            archive.write(os.path.join(root, file),
+                          os.path.relpath(os.path.join(root, file),
+                                          os.path.join('.', '.')))
+
+    archive.close()
+    os.chdir('..')
+    shutil.rmtree(temporary_path)
+
 
 #---------------------------------------------------------------
 # 4.0 INITIALIZATION
@@ -189,3 +240,5 @@ for arg in sys.argv:
         chromium('whale')
     elif arg == '-firefox':
         firefox()
+    elif arg == '-safari':
+        safari()

--- a/js&css/extension/init.js
+++ b/js&css/extension/init.js
@@ -65,35 +65,36 @@ chrome.runtime.sendMessage({
 	}
 });
 
-const pageWorldFiles = [
-	'/js&css/web-accessible/core.js',
-	'/js&css/web-accessible/functions.js',
-	'/js&css/web-accessible/www.youtube.com/appearance.js',
-	'/js&css/web-accessible/www.youtube.com/themes.js',
-	'/js&css/web-accessible/www.youtube.com/player.js',
-	'/js&css/web-accessible/www.youtube.com/playlist.js',
-	'/js&css/web-accessible/www.youtube.com/playlist-complete-playlist.js',
-	'/js&css/web-accessible/www.youtube.com/channel.js',
-	'/js&css/web-accessible/www.youtube.com/shortcuts.js',
-	'/js&css/web-accessible/www.youtube.com/blocklist.js',
-	'/js&css/web-accessible/www.youtube.com/settings.js',
-	'/js&css/web-accessible/www.youtube.com/last-watched-overlay.js', // Neue Zeile hinzufügen
-	'/js&css/web-accessible/www.youtube.com/return-youtube-dislike.js',
-	'/js&css/web-accessible/www.youtube.com/return-youtube-dislike.css',
-	'/js&css/web-accessible/init.js'
-];
-
 function finishPageWorldInit() {
 	extension.ready = true;
 
 	extension.events.trigger('init');
 }
 
-function useBackgroundMainWorldInjection() {
-	return /Safari/.test(navigator.userAgent) && !/Chrom(e|ium)/.test(navigator.userAgent);
-}
+if ((navigator.userAgent.indexOf('Safari') !== -1
+	|| (typeof browser !== 'undefined' && browser.runtime?.getURL('')?.startsWith('safari-')))
+	&& (!/Chrom|Android|Windows|Linux/.test(navigator.userAgent)
+		|| /iPhone|iPad/.test(navigator.userAgent)
+	)
+) {
+	const pageWorldFiles = [
+		'/js&css/web-accessible/core.js',
+		'/js&css/web-accessible/functions.js',
+		'/js&css/web-accessible/www.youtube.com/appearance.js',
+		'/js&css/web-accessible/www.youtube.com/themes.js',
+		'/js&css/web-accessible/www.youtube.com/player.js',
+		'/js&css/web-accessible/www.youtube.com/playlist.js',
+		'/js&css/web-accessible/www.youtube.com/playlist-complete-playlist.js',
+		'/js&css/web-accessible/www.youtube.com/channel.js',
+		'/js&css/web-accessible/www.youtube.com/shortcuts.js',
+		'/js&css/web-accessible/www.youtube.com/blocklist.js',
+		'/js&css/web-accessible/www.youtube.com/settings.js',
+		'/js&css/web-accessible/www.youtube.com/last-watched-overlay.js', // Neue Zeile hinzufügen
+		'/js&css/web-accessible/www.youtube.com/return-youtube-dislike.js',
+		'/js&css/web-accessible/www.youtube.com/return-youtube-dislike.css',
+		'/js&css/web-accessible/init.js'
+	];
 
-if (useBackgroundMainWorldInjection()) {
 	chrome.runtime.sendMessage({
 		action: 'inject-main-world',
 		files: pageWorldFiles
@@ -106,7 +107,23 @@ if (useBackgroundMainWorldInjection()) {
 		}
 	});
 } else {
-	extension.inject(pageWorldFiles.slice(), finishPageWorldInit);
+	extension.inject([
+		'/js&css/web-accessible/core.js',
+		'/js&css/web-accessible/functions.js',
+		'/js&css/web-accessible/www.youtube.com/appearance.js',
+		'/js&css/web-accessible/www.youtube.com/themes.js',
+		'/js&css/web-accessible/www.youtube.com/player.js',
+		'/js&css/web-accessible/www.youtube.com/playlist.js',
+		'/js&css/web-accessible/www.youtube.com/playlist-complete-playlist.js',
+		'/js&css/web-accessible/www.youtube.com/channel.js',
+		'/js&css/web-accessible/www.youtube.com/shortcuts.js',
+		'/js&css/web-accessible/www.youtube.com/blocklist.js',
+		'/js&css/web-accessible/www.youtube.com/settings.js',
+		'/js&css/web-accessible/www.youtube.com/last-watched-overlay.js', // Neue Zeile hinzufügen
+		'/js&css/web-accessible/www.youtube.com/return-youtube-dislike.js',
+		'/js&css/web-accessible/www.youtube.com/return-youtube-dislike.css',
+		'/js&css/web-accessible/init.js'
+	], finishPageWorldInit);
 }
 
 document.addEventListener('DOMContentLoaded', function () {

--- a/js&css/extension/init.js
+++ b/js&css/extension/init.js
@@ -71,61 +71,45 @@ function finishPageWorldInit() {
 	extension.events.trigger('init');
 }
 
-if ((navigator.userAgent.indexOf('Safari') !== -1
+const pageWorldFiles = [
+	'/js&css/web-accessible/core.js',
+	'/js&css/web-accessible/functions.js',
+	'/js&css/web-accessible/www.youtube.com/appearance.js',
+	'/js&css/web-accessible/www.youtube.com/themes.js',
+	'/js&css/web-accessible/www.youtube.com/player.js',
+	'/js&css/web-accessible/www.youtube.com/playlist.js',
+	'/js&css/web-accessible/www.youtube.com/playlist-complete-playlist.js',
+	'/js&css/web-accessible/www.youtube.com/channel.js',
+	'/js&css/web-accessible/www.youtube.com/shortcuts.js',
+	'/js&css/web-accessible/www.youtube.com/blocklist.js',
+	'/js&css/web-accessible/www.youtube.com/settings.js',
+	'/js&css/web-accessible/www.youtube.com/last-watched-overlay.js', // Neue Zeile hinzufügen
+	'/js&css/web-accessible/www.youtube.com/return-youtube-dislike.js',
+	'/js&css/web-accessible/www.youtube.com/return-youtube-dislike.css',
+	'/js&css/web-accessible/init.js'
+];
+
+if (window === window.top
+	&& (navigator.userAgent.indexOf('Safari') !== -1
 	|| (typeof browser !== 'undefined' && browser.runtime?.getURL('')?.startsWith('safari-')))
 	&& (!/Chrom|Android|Windows|Linux/.test(navigator.userAgent)
 		|| /iPhone|iPad/.test(navigator.userAgent)
 	)
 ) {
-	const pageWorldFiles = [
-		'/js&css/web-accessible/core.js',
-		'/js&css/web-accessible/functions.js',
-		'/js&css/web-accessible/www.youtube.com/appearance.js',
-		'/js&css/web-accessible/www.youtube.com/themes.js',
-		'/js&css/web-accessible/www.youtube.com/player.js',
-		'/js&css/web-accessible/www.youtube.com/playlist.js',
-		'/js&css/web-accessible/www.youtube.com/playlist-complete-playlist.js',
-		'/js&css/web-accessible/www.youtube.com/channel.js',
-		'/js&css/web-accessible/www.youtube.com/shortcuts.js',
-		'/js&css/web-accessible/www.youtube.com/blocklist.js',
-		'/js&css/web-accessible/www.youtube.com/settings.js',
-		'/js&css/web-accessible/www.youtube.com/last-watched-overlay.js', // Neue Zeile hinzufügen
-		'/js&css/web-accessible/www.youtube.com/return-youtube-dislike.js',
-		'/js&css/web-accessible/www.youtube.com/return-youtube-dislike.css',
-		'/js&css/web-accessible/init.js'
-	];
 
 	chrome.runtime.sendMessage({
 		action: 'inject-main-world',
 		files: pageWorldFiles
 	}, function (response) {
-		var error = chrome.runtime.lastError?.message || response?.error;
-
 		if (response && response.ok) {
 			finishPageWorldInit();
 		} else {
-			console.warn('Falling back to DOM injection for page-world scripts', error);
+			console.warn('Falling back to DOM injection for page-world scripts', chrome.runtime.lastError?.message || response?.error);
 			extension.inject(pageWorldFiles.slice(), finishPageWorldInit);
 		}
 	});
 } else {
-	extension.inject([
-		'/js&css/web-accessible/core.js',
-		'/js&css/web-accessible/functions.js',
-		'/js&css/web-accessible/www.youtube.com/appearance.js',
-		'/js&css/web-accessible/www.youtube.com/themes.js',
-		'/js&css/web-accessible/www.youtube.com/player.js',
-		'/js&css/web-accessible/www.youtube.com/playlist.js',
-		'/js&css/web-accessible/www.youtube.com/playlist-complete-playlist.js',
-		'/js&css/web-accessible/www.youtube.com/channel.js',
-		'/js&css/web-accessible/www.youtube.com/shortcuts.js',
-		'/js&css/web-accessible/www.youtube.com/blocklist.js',
-		'/js&css/web-accessible/www.youtube.com/settings.js',
-		'/js&css/web-accessible/www.youtube.com/last-watched-overlay.js', // Neue Zeile hinzufügen
-		'/js&css/web-accessible/www.youtube.com/return-youtube-dislike.js',
-		'/js&css/web-accessible/www.youtube.com/return-youtube-dislike.css',
-		'/js&css/web-accessible/init.js'
-	], finishPageWorldInit);
+	extension.inject(pageWorldFiles.slice(), finishPageWorldInit);
 }
 
 document.addEventListener('DOMContentLoaded', function () {

--- a/js&css/extension/init.js
+++ b/js&css/extension/init.js
@@ -89,8 +89,7 @@ const pageWorldFiles = [
 	'/js&css/web-accessible/init.js'
 ];
 
-if (window === window.top
-	&& (navigator.userAgent.indexOf('Safari') !== -1
+if ((navigator.userAgent.indexOf('Safari') !== -1
 	|| (typeof browser !== 'undefined' && browser.runtime?.getURL('')?.startsWith('safari-')))
 	&& (!/Chrom|Android|Windows|Linux/.test(navigator.userAgent)
 		|| /iPhone|iPad/.test(navigator.userAgent)

--- a/js&css/extension/init.js
+++ b/js&css/extension/init.js
@@ -65,7 +65,7 @@ chrome.runtime.sendMessage({
 	}
 });
 
-extension.inject([
+const pageWorldFiles = [
 	'/js&css/web-accessible/core.js',
 	'/js&css/web-accessible/functions.js',
 	'/js&css/web-accessible/www.youtube.com/appearance.js',
@@ -81,11 +81,33 @@ extension.inject([
 	'/js&css/web-accessible/www.youtube.com/return-youtube-dislike.js',
 	'/js&css/web-accessible/www.youtube.com/return-youtube-dislike.css',
 	'/js&css/web-accessible/init.js'
-], function () {
+];
+
+function finishPageWorldInit() {
 	extension.ready = true;
 
 	extension.events.trigger('init');
-});
+}
+
+function useBackgroundMainWorldInjection() {
+	return /Safari/.test(navigator.userAgent) && !/Chrom(e|ium)/.test(navigator.userAgent);
+}
+
+if (useBackgroundMainWorldInjection()) {
+	chrome.runtime.sendMessage({
+		action: 'inject-main-world',
+		files: pageWorldFiles
+	}, function (response) {
+		if (response && response.ok) {
+			finishPageWorldInit();
+		} else {
+			console.warn('Falling back to DOM injection for page-world scripts', response?.error);
+			extension.inject(pageWorldFiles.slice(), finishPageWorldInit);
+		}
+	});
+} else {
+	extension.inject(pageWorldFiles.slice(), finishPageWorldInit);
+}
 
 document.addEventListener('DOMContentLoaded', function () {
 	extension.domReady = true;

--- a/js&css/extension/init.js
+++ b/js&css/extension/init.js
@@ -99,10 +99,12 @@ if ((navigator.userAgent.indexOf('Safari') !== -1
 		action: 'inject-main-world',
 		files: pageWorldFiles
 	}, function (response) {
+		var error = chrome.runtime.lastError?.message || response?.error;
+
 		if (response && response.ok) {
 			finishPageWorldInit();
 		} else {
-			console.warn('Falling back to DOM injection for page-world scripts', response?.error);
+			console.warn('Falling back to DOM injection for page-world scripts', error);
 			extension.inject(pageWorldFiles.slice(), finishPageWorldInit);
 		}
 	});

--- a/manifest.json
+++ b/manifest.json
@@ -60,7 +60,7 @@
   "host_permissions": ["https://www.youtube.com/*"],
   "optional_host_permissions": ["https://returnyoutubedislikeapi.com/*"],
   "optional_permissions": ["downloads"],
-  "permissions": ["contextMenus", "storage", "unlimitedStorage"],
+  "permissions": ["contextMenus", "storage", "unlimitedStorage", "scripting"],
   "web_accessible_resources": [
     {
       "resources": [

--- a/manifest.json
+++ b/manifest.json
@@ -60,7 +60,7 @@
   "host_permissions": ["https://www.youtube.com/*"],
   "optional_host_permissions": ["https://returnyoutubedislikeapi.com/*"],
   "optional_permissions": ["downloads"],
-  "permissions": ["contextMenus", "storage", "unlimitedStorage", "scripting"],
+  "permissions": ["contextMenus", "storage", "unlimitedStorage"],
   "web_accessible_resources": [
     {
       "resources": [


### PR DESCRIPTION
fixes #3773

## Summary

- add `scripting` permission for Safari-compatible page-world injection
- inject `js&css/web-accessible/*` through the background script on Safari
- keep the existing DOM injection path for non-Safari browsers

## Why

On Safari, YouTube CSP can block `safari-web-extension://...` script tags appended from the content script, so the page-world bootstrap files never initialize even when the extension is installed and enabled.

This keeps the current behavior for other browsers and only switches Safari to a background-driven injection path.

## Testing

- built and ran the Safari app locally
- confirmed the extension registers in Safari
- confirmed YouTube starts responding after switching Safari away from DOM `<script src="safari-web-extension://...">` injection
