### PR TITLE
feat: Add option to collapse the Transcript panel

### DIFF
--- a/js&css/web-accessible/core.js
+++ b/js&css/web-accessible/core.js
@@ -270,13 +270,26 @@ document.addEventListener('it-message-from-extension', function () {
 					}
 					break
 
-				case 'transcript':
-					if (ImprovedTube.storage.transcript === true) {
-						document.querySelector('*[target-id*=transcript]')?.removeAttribute('visibility');
-					} else if (ImprovedTube.storage.transcript === false) {
-						document.querySelector('*[target-id*=transcript] #visibility-button button')?.click();
+			case 'transcript':
+				if (ImprovedTube.storage.transcript === 'normal' || ImprovedTube.storage.transcript === 'collapsed') {
+					document.querySelector('*[target-id*=transcript]')?.removeAttribute('visibility');
+					
+					// Collapse the transcript if set to 'collapsed'
+					if (ImprovedTube.storage.transcript === 'collapsed') {
+						const transcriptPanel = document.querySelector('*[target-id*=transcript]');
+						if (transcriptPanel) {
+							setTimeout(function() {
+								const collapseButton = transcriptPanel.querySelector('button[aria-label*="collapse"], button[aria-label*="Collaps"]');
+								if (collapseButton) {
+									collapseButton.click();
+								}
+							}, 500);
+						}
 					}
-					break
+				} else if (ImprovedTube.storage.transcript === 'hidden') {
+					document.querySelector('*[target-id*=transcript] #visibility-button button')?.click();
+				}
+				break
 
 				case 'chapters':
 					if (ImprovedTube.storage.chapters === true) {

--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -370,7 +370,7 @@ ImprovedTube.hideTopProgressBar = function () {
 /*----------------------------------------------------------------
  TRANSCRIPT
 --------------------------------------------------------------*/
-ImprovedTube.transcript = function (el) { if (ImprovedTube.storage.transcript === true) {
+ImprovedTube.transcript = function (el) { if (ImprovedTube.storage.transcript === 'collapsed' || ImprovedTube.storage.transcript === 'normal') {
 	const available = el.querySelector('[target-id*=transcript][visibility*=HIDDEN]') || el.querySelector('[target-id*=transcript]')?.clientHeight;
 	if (available) {
 		if (!ImprovedTube.originalFocus) {ImprovedTube.originalFocus = HTMLElement.prototype.focus;}  // Backing up default method. Youtube doesn't use alternatives Element.prototype.scrollIntoView  window.scrollTo  window.scrollBy)
@@ -383,6 +383,19 @@ ImprovedTube.transcript = function (el) { if (ImprovedTube.storage.transcript ==
 		const descriptionTranscript = el.querySelector('ytd-video-description-transcript-section-renderer button[aria-label]');
 		descriptionTranscript ? descriptionTranscript.click() : el.querySelector('[target-id*=transcript]')?.removeAttribute('visibility');
 		if ( yt.config_.EXPERIMENT_FLAGS.kevlar_watch_grid === true ) { available.setAttribute('z-index', '98765') }
+
+		// Collapse the transcript if set to 'collapsed'
+		if (ImprovedTube.storage.transcript === 'collapsed') {
+			setTimeout(function() {
+				const transcriptPanel = el.querySelector('[target-id*=transcript]');
+				if (transcriptPanel) {
+					const collapseButton = transcriptPanel.querySelector('button[aria-label*="collapse"], button[aria-label*="Collaps"]');
+					if (collapseButton) {
+						collapseButton.click();
+					}
+				}
+			}, 500);
+		}
 	}  
 }};
 /*----------------------------------------------------------------
@@ -401,6 +414,19 @@ ImprovedTube.chapters = function (el) { if (ImprovedTube.storage.chapters === tr
 		const modernChapters = el.querySelector('[modern-chapters] #navigation-button button[aria-label]');
 		modernChapters ? modernChapters.click() : el.querySelector('[target-id*=chapters]')?.removeAttribute('visibility');
 		if ( yt.config_.EXPERIMENT_FLAGS.kevlar_watch_grid === true ) { available.setAttribute('z-index', '98765') }
+
+		// Collapse the transcript if set to 'collapsed'
+		if (ImprovedTube.storage.transcript === 'collapsed') {
+			setTimeout(function() {
+				const transcriptPanel = el.querySelector('[target-id*=transcript]');
+				if (transcriptPanel) {
+					const collapseButton = transcriptPanel.querySelector('button[aria-label*="collapse"], button[aria-label*="Collaps"]');
+					if (collapseButton) {
+						collapseButton.click();
+					}
+				}
+			}, 500);
+		}
 	}  
 }};	
 /*------------------------------------------------------------------------------

--- a/menu/skeleton-parts/appearance.js
+++ b/menu/skeleton-parts/appearance.js
@@ -1059,21 +1059,19 @@ extension.skeleton.main.layers.section.appearance.on.click.sidebar = {
 				text: "hideThumbnails"
 			},
 			transcript: {
-				component: 'switch',
+				component: "select",
 				text: 'Transcript',
-				value: false,
-				id: 'transcript',
-				on: {
-					click: function () {
-						setTimeout(() => {
-							if (satus.storage.get('transcript')) {
-								if (satus.storage.get('no_page_margin')) {
-									this.nextSibling.nextSibling.click();
-								}
-							}
-						}, 250);
-					}
-				}
+				options: [{
+					text: 'normal',
+					value: 'normal'
+				}, {
+					text: 'collapsed',
+					value: 'collapsed'
+				}, {
+					text: 'hidden',
+					value: 'hidden'
+				}],
+				storage: 'transcript'
 			},
 			compact_spacing: {
 				component: "switch",


### PR DESCRIPTION
## Description

This PR adds an option to collapse the Transcript panel while keeping it visible, addressing issue #3800.

## Changes

### Menu UI
- Changed the `transcript` setting from a boolean switch to a select dropdown with options:
  - `normal` - Shows and expands the transcript panel
  - `collapsed` - Shows the transcript panel in a collapsed state
  - `hidden` - Hides the transcript panel completely

### Code Changes
- Updated `menu/skeleton-parts/appearance.js` to use select component
- Updated `js&css/web-accessible/www.youtube.com/appearance.js` to handle new states
- Updated `js&css/web-accessible/core.js` to collapse transcript panel when collapsed state is set

### Technical Details
The implementation follows the same pattern as the existing `livechat` setting, which also has a select dropdown with multiple states. When the user selects "collapsed", the transcript panel is shown and then automatically collapsed after a 500ms delay to ensure the panel is fully rendered.

## Testing

Please test by:
1. Opening the extension settings
2. Navigating to Appearance > Transcript
3. Selecting each option and verifying behavior:
   - `normal` - Transcript should be visible and expanded
   - `collapsed` - Transcript should be visible but collapsed
   - `hidden` - Transcript should be hidden

---

**AI Disclosure:** This pull request was partially assisted by AI. The changes implement a user-requested feature to add a collapse option for the YouTube transcript panel.