### PR TITLE
fix: resolve black font color on Show more/less in YouTube Dark theme

### DIFF
--- a/js&css/extension/www.youtube.com/appearance/comments/comments.css
+++ b/js&css/extension/www.youtube.com/appearance/comments/comments.css
@@ -39,38 +39,20 @@ html[it-comments='collapsed'][data-page-type=video] ytd-comments ytd-comments-he
 	font-family: inherit !important;
 	font-size: 1.6rem !important;
 	font-weight: 400 !important;
-
 	display: flex !important;
-
 	width: 100% !important;
 	height: 48px !important;
 	margin: 16px 0 0 !important;
-
 	color: var(--yt-spec-text-primary) !important;
 	border-bottom: 1px solid var(--yt-spec-10-percent-layer) !important;
-
 	justify-content: center !important;
 	align-items: center !important;
 }
 
-html[it-comments='collapsed'][data-page-type=video] ytd-comments:not([it-activated]) ytd-item-section-renderer>#spinner-container,
-html[it-comments='collapsed'][data-page-type=video] ytd-comments:not([it-activated]) ytd-item-section-renderer>#contents,
-html[it-comments='collapsed'][data-page-type=video] ytd-comments:not([it-activated]) ytd-item-section-renderer>#continuations {
-	visibility: hidden !important;
-	pointer-events: none !important;
-}
-
-@media screen and (min-width: 1599px) {
-	html[data-page-type=video][it-comments-sidebar-simple='true'][it-columns=true] #player {margin-left: -20px !important;}
-	html[data-page-type=video][it-comments-sidebar-simple='true'][it-columns=true] #columns {display:flex !important; max-width:100% !important;}
-	html[data-page-type=video][it-comments-sidebar-simple='true'][it-columns=true] #comments {max-width: min(850px, 19vw) !important; margin-left:-12px;} 
-	html[data-page-type=video][it-comments-sidebar-simple='true'][it-columns=true][it-sidebar-left='true'] #comments {margin-right: -25px  !important;} 
-	html[data-page-type=video][it-comments-sidebar-simple='true'][it-columns=true] #related {margin-right: -22px !important; max-width: max(360px, 18vw) !important;}
-	html[data-page-type=video][it-comments-sidebar-simple='true'][it-columns=true] #secondary {margin-right: -22px !important; max-width: max(360px, 18vw) !important;}
-
-	html[data-page-type=video][it-comments-sidebar-simple='true'][it-columns=true]:not([it-player-size='1080p']):not([it-player-size='1440p']):not([it-player-size='2160p']):not([it-player-size='custom']):not([it-player-size='max_width']) ytd-watch-flexy:not([fullscreen]) #primary {
-		min-width: min(calc(100vw - 1000px), 1260px) !important; max-width: 1260px !important;
-	}
+/* Fix: "Show more/less" font is black on YouTube Dark theme */
+html[dark][it-comments='collapsed'][data-page-type=video] ytd-comments ytd-comments-header-renderer::after,
+html[data-theme='dark'][it-comments='collapsed'][data-page-type=video] ytd-comments ytd-comments-header-renderer::after {
+	color: var(--yt-spec-text-primary, #ffffff) !important;
 }
 
 /* 2 COLS FEATURE */

--- a/js&css/extension/www.youtube.com/appearance/comments/comments.css
+++ b/js&css/extension/www.youtube.com/appearance/comments/comments.css
@@ -70,8 +70,9 @@ html[it-comments='collapsed'][data-page-type=video] ytd-comments:not([it-activat
 }
 /* Fix: "Show more/less" font is black on YouTube Dark theme */
 html[dark][it-comments='collapsed'][data-page-type=video] ytd-comments ytd-comments-header-renderer::after,
-html[data-theme='dark'][it-comments='collapsed'][data-page-type=video] ytd-comments ytd-comments-header-renderer::after {
-	color: var(--yt-spec-text-primary, #ffffff) !important;
+html[data-theme='dark'][it-comments='collapsed'][data-page-type=video] ytd-comments ytd-comments-header-renderer::after,
+html[data-theme='black'][it-comments='collapsed'][data-page-type=video] ytd-comments ytd-comments-header-renderer::after {
+	color: var(--yt-spec-text-primary, #eee) !important;
 }
 
 /* 2 COLS FEATURE */

--- a/js&css/extension/www.youtube.com/appearance/comments/comments.css
+++ b/js&css/extension/www.youtube.com/appearance/comments/comments.css
@@ -67,6 +67,7 @@ html[it-comments='collapsed'][data-page-type=video] ytd-comments:not([it-activat
 	html[data-page-type=video][it-comments-sidebar-simple='true'][it-columns=true]:not([it-player-size='1080p']):not([it-player-size='1440p']):not([it-player-size='2160p']):not([it-player-size='custom']):not([it-player-size='max_width']) ytd-watch-flexy:not([fullscreen]) #primary {
 		min-width: min(calc(100vw - 1000px), 1260px) !important; max-width: 1260px !important;
 	}
+}
 /* Fix: "Show more/less" font is black on YouTube Dark theme */
 html[dark][it-comments='collapsed'][data-page-type=video] ytd-comments ytd-comments-header-renderer::after,
 html[data-theme='dark'][it-comments='collapsed'][data-page-type=video] ytd-comments ytd-comments-header-renderer::after {

--- a/js&css/extension/www.youtube.com/appearance/comments/comments.css
+++ b/js&css/extension/www.youtube.com/appearance/comments/comments.css
@@ -49,6 +49,24 @@ html[it-comments='collapsed'][data-page-type=video] ytd-comments ytd-comments-he
 	align-items: center !important;
 }
 
+html[it-comments='collapsed'][data-page-type=video] ytd-comments:not([it-activated]) ytd-item-section-renderer>#spinner-container,
+html[it-comments='collapsed'][data-page-type=video] ytd-comments:not([it-activated]) ytd-item-section-renderer>#contents,
+html[it-comments='collapsed'][data-page-type=video] ytd-comments:not([it-activated]) ytd-item-section-renderer>#continuations {
+	visibility: hidden !important;
+	pointer-events: none !important;
+}
+
+@media screen and (min-width: 1599px) {
+	html[data-page-type=video][it-comments-sidebar-simple='true'][it-columns=true] #player {margin-left: -20px !important;}
+	html[data-page-type=video][it-comments-sidebar-simple='true'][it-columns=true] #columns {display:flex !important; max-width:100% !important;}
+	html[data-page-type=video][it-comments-sidebar-simple='true'][it-columns=true] #comments {max-width: min(850px, 19vw) !important; margin-left:-12px;} 
+	html[data-page-type=video][it-comments-sidebar-simple='true'][it-columns=true][it-sidebar-left='true'] #comments {margin-right: -25px  !important;} 
+	html[data-page-type=video][it-comments-sidebar-simple='true'][it-columns=true] #related {margin-right: -22px !important; max-width: max(360px, 18vw) !important;}
+	html[data-page-type=video][it-comments-sidebar-simple='true'][it-columns=true] #secondary {margin-right: -22px !important; max-width: max(360px, 18vw) !important;}
+
+	html[data-page-type=video][it-comments-sidebar-simple='true'][it-columns=true]:not([it-player-size='1080p']):not([it-player-size='1440p']):not([it-player-size='2160p']):not([it-player-size='custom']):not([it-player-size='max_width']) ytd-watch-flexy:not([fullscreen]) #primary {
+		min-width: min(calc(100vw - 1000px), 1260px) !important; max-width: 1260px !important;
+	}
 /* Fix: "Show more/less" font is black on YouTube Dark theme */
 html[dark][it-comments='collapsed'][data-page-type=video] ytd-comments ytd-comments-header-renderer::after,
 html[data-theme='dark'][it-comments='collapsed'][data-page-type=video] ytd-comments ytd-comments-header-renderer::after {


### PR DESCRIPTION
Fixes #3828

Problem:
The "Show more" / "Show less" text in collapsed comments 
was appearing in black on the YouTube Dark theme, making 
it unreadable.

Solution:
Added a CSS override targeting html[dark] and 
html[data-theme='dark'] selectors that sets 
color: var(--yt-spec-text-primary, #ffffff) ensuring 
the text is always visible on dark backgrounds while 
keeping the original rule intact for light theme users.

Tested on:
- YouTube Dark theme ✅
- YouTube Light theme ✅
<img width="1920" height="1022" alt="Screenshot 2026-05-03 164828" src="https://github.com/user-attachments/assets/62c6fe63-d23a-4b4c-97e4-1dec092f9557" />
<img width="1920" height="1022" alt="Screenshot 2026-05-03 164927" src="https://github.com/user-attachments/assets/055f578f-beea-412c-8874-dcab5741838f" />