### PR TITLE
Fix: Restore black screen when video ends and endscreen is hidden (#3838)

### DIFF
--- a/js&css/extension/www.youtube.com/appearance/player/player.css
+++ b/js&css/extension/www.youtube.com/appearance/player/player.css
@@ -251,10 +251,6 @@ html[it-player-hide-annotations='true'] .annotation-shape,
 /*--------------------------------------------------------------
 # HIDE ENDSCREEN
 --------------------------------------------------------------*/
-html[it-player-hide-endscreen='true'] .html5-video-player.ended-mode .html5-main-video {
-	visibility: hidden !important;
-}
-
 html[it-player-hide-endscreen='true'] .html5-endscreen,
 html[it-player-hide-endscreen='true'] .ytp-fullscreen-grid-stills-container,
 /*--------------------------------------------------------------
@@ -273,7 +269,9 @@ html[it-player-show-cards-on-mouse-hover='true'] .html5-video-player:not(:hover)
 html[it-player-show-cards-on-mouse-hover='true'] .html5-video-player:not(:hover) .ytp-cards-teaser {
 	display: none !important;
 }
-
+html[it-player-hide-lastframe='true'] .html5-video-player.ended-mode .html5-main-video {
+	visibility: hidden !important;
+}
 html[it-player-show-cards-on-mouse-hover='true'] .html5-video-player:hover .ytp-ce-element,
 html[it-player-show-cards-on-mouse-hover='true'] .html5-video-player:hover .ytp-ce-video,
 html[it-player-show-cards-on-mouse-hover='true'] .html5-video-player:hover .ytp-cards-button,

--- a/js&css/extension/www.youtube.com/appearance/player/player.css
+++ b/js&css/extension/www.youtube.com/appearance/player/player.css
@@ -251,6 +251,10 @@ html[it-player-hide-annotations='true'] .annotation-shape,
 /*--------------------------------------------------------------
 # HIDE ENDSCREEN
 --------------------------------------------------------------*/
+html[it-player-hide-endscreen='true'] .html5-video-player.ended-mode .html5-main-video {
+	visibility: hidden !important;
+}
+
 html[it-player-hide-endscreen='true'] .html5-endscreen,
 html[it-player-hide-endscreen='true'] .ytp-fullscreen-grid-stills-container,
 /*--------------------------------------------------------------


### PR DESCRIPTION
Fixes #3838

### **Changes Made**
Added a CSS rule in appearance/player/player.css to apply visibility: hidden !important; to .html5-main-video when the player receives the .ended-mode class and it-player-hide-endscreen is true.

### **Testing**
Turn on the "Hide endscreen" option in ImprovedTube settings.
Watch a video to the very end.
If Autoplay is enabled, press Escape to cancel the "Up Next" countdown.
Verify that the player background is completely black rather than frozen on the last frame.