### PR TITLE
Keep comments sidebar applied after refresh

### DIFF
--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -225,56 +225,62 @@ ImprovedTube.commentsSidebarSimple = function () { if (ImprovedTube.storage.comm
  Comments Sidebar
 ------------------------------------------------------------------------------*/
 ImprovedTube.commentsSidebar = function () { if (ImprovedTube.storage.comments_sidebar === true) {
-	const video = document.querySelector("#player .ytp-chrome-bottom") || document.querySelector("#container .ytp-chrome-bottom");
-	let hasApplied = 0;
+	const state = ImprovedTube.commentsSidebarState || (ImprovedTube.commentsSidebarState = {
+		hasApplied: 0,
+		initialized: false
+	});
 	if (/watch\?/.test(location.href)) {
 		sidebar();
 		styleScrollbars();
 		setGrid();
 		applyObserver();
-		window.addEventListener("resize", sidebar);
-		// Listen for fullscreen changes to properly recalculate player size
-		document.addEventListener("fullscreenchange", function() {
-			// Delay to let YouTube update its attributes first
-			setTimeout(sidebar, 100);
-		});
+		observeLayoutChanges();
+		if (!state.initialized) {
+			window.addEventListener("resize", sidebar);
+			// Listen for fullscreen changes to properly recalculate player size
+			document.addEventListener("fullscreenchange", function() {
+				// Delay to let YouTube update its attributes first
+				setTimeout(sidebar, 100);
+			});
+			state.initialized = true;
+		}
 	}
 
 	function sidebar () {
 		resizePlayer();
 		if (window.matchMedia("(min-width: 1952px)").matches) {
 
-			if (!hasApplied) {
+			if (!state.hasApplied || !isLayoutApplied(true)) {
 				initialSetup()
-				setTimeout(() => {document.getElementById("columns").appendChild(document.getElementById("related"))})
+				setTimeout(() => {moveNode(document.getElementById("columns"), document.getElementById("related"))})
 			}
-			else if (hasApplied == 2) { //from medium to big size
-				setTimeout(() => {document.getElementById("columns").appendChild(document.getElementById("related"))})
+			else if (state.hasApplied == 2) { //from medium to big size
+				setTimeout(() => {moveNode(document.getElementById("columns"), document.getElementById("related"))})
 			}
-			hasApplied = 1
+			state.hasApplied = 1
 		}
 		else if (window.matchMedia("(min-width: 1000px)").matches) {
-			if (!hasApplied) {
+			if (!state.hasApplied || !isLayoutApplied(false)) {
 				initialSetup();
 			}
-			else if (hasApplied == 1) { //from big to medium
-				document.getElementById("primary-inner").appendChild(document.getElementById("related"));
+			else if (state.hasApplied == 1) { //from big to medium
+				moveNode(document.getElementById("primary-inner"), document.getElementById("related"));
 			}
-			hasApplied = 2
+			state.hasApplied = 2
 		}
 		else { /// <1000
-			if (hasApplied == 1) {
-				document.getElementById("primary-inner").appendChild(document.getElementById("related"));
+			if (state.hasApplied == 1) {
+				moveNode(document.getElementById("primary-inner"), document.getElementById("related"));
 				let comments = document.querySelector("#comments");
 				let below = document.getElementById("below");
-				below.appendChild(comments);
+				moveNode(below, comments);
 			}
-			else if (hasApplied == 2) {
+			else if (state.hasApplied == 2) {
 				let comments = document.querySelector("#comments");
 				let below = document.getElementById("below");
-				below.appendChild(comments);
+				moveNode(below, comments);
 			}
-			hasApplied = 0;
+			state.hasApplied = 0;
 		}
 	}
 	function setGrid () {
@@ -289,18 +295,44 @@ ImprovedTube.commentsSidebar = function () { if (ImprovedTube.storage.comments_s
 		}, 250);
 	}
 	function initialSetup () {
-		let secondaryInner = document.getElementById("secondary-inner");
-		let primaryInner = document.getElementById("primary-inner");
-		let comments = document.querySelector("#comments");
+		if (!document.getElementById("secondary-inner") || !document.getElementById("primary-inner") || !document.querySelector("#comments")) {
+			scheduleSidebar();
+			return;
+		}
 		setTimeout(() => {
-			primaryInner.appendChild(document.getElementById("panels"));
-			primaryInner.appendChild(document.getElementById("related"))
-			secondaryInner.appendChild(document.getElementById("chat-template"));
-			secondaryInner.appendChild(comments);
+			let secondaryInner = document.getElementById("secondary-inner");
+			let primaryInner = document.getElementById("primary-inner");
+			let comments = document.querySelector("#comments");
+			if (!secondaryInner || !primaryInner || !comments) {
+				scheduleSidebar();
+				return;
+			}
+			moveNode(primaryInner, document.getElementById("panels"));
+			moveNode(primaryInner, document.getElementById("related"))
+			moveNode(secondaryInner, document.getElementById("chat-template"));
+			moveNode(secondaryInner, comments);
 		})
+	}
+	function moveNode (parent, child) {
+		if (parent && child && child.parentElement !== parent) {
+			parent.appendChild(child);
+		}
+	}
+	function isLayoutApplied (wideLayout) {
+		const secondaryInner = document.getElementById("secondary-inner");
+		const comments = document.querySelector("#comments");
+		const related = document.getElementById("related");
+		const relatedParent = wideLayout ? document.getElementById("columns") : document.getElementById("primary-inner");
+
+		return comments && comments.parentElement === secondaryInner && related && related.parentElement === relatedParent;
+	}
+	function scheduleSidebar () {
+		clearTimeout(state.sidebarRetryTimer);
+		state.sidebarRetryTimer = setTimeout(sidebar, 250);
 	}
 	function resizePlayer () {
 		const player = document.querySelector("#player.style-scope.ytd-watch-flexy");
+		const video = document.querySelector("#player .ytp-chrome-bottom") || document.querySelector("#container .ytp-chrome-bottom");
 		const watchFlexy = document.querySelector("ytd-watch-flexy");
 		const primary = document.getElementById("primary");
 
@@ -312,7 +344,7 @@ ImprovedTube.commentsSidebar = function () { if (ImprovedTube.storage.comments_s
 			return;
 		}
 
-		const width = video.offsetWidth + 24;
+		const width = video ? video.offsetWidth + 24 : 24;
 		if (width != 24 && primary && player) {
 			primary.style.width = `${width}px`;
 			player.style.width = `${width}px`;
@@ -321,10 +353,12 @@ ImprovedTube.commentsSidebar = function () { if (ImprovedTube.storage.comments_s
 	function styleScrollbars () {
 		if (!navigator.userAgent.toLowerCase().includes("mac")) {
 			let color, colorHover
-			const isDarkMode = getComputedStyle(document.querySelector('ytd-app')).getPropertyValue('--yt-spec-base-background') == "#0f0f0f";
+			const isDarkMode = getComputedStyle(document.querySelector('ytd-app') || document.documentElement).getPropertyValue('--yt-spec-base-background') == "#0f0f0f";
 			if (isDarkMode) [color, colorHover] = ["#616161", "#909090"];
 			else [color, colorHover] = ["#aaaaaa", "#717171"];
-			const style = document.createElement("style");
+			const style = document.getElementById("it-comments-sidebar-scrollbars") || document.createElement("style");
+			style.id = "it-comments-sidebar-scrollbars";
+			style.textContent = "";
 			if (ImprovedTube.storage.comments_sidebar_scrollbars === true) {
 				const cssRule = `
             #primary, #secondary {
@@ -360,13 +394,41 @@ ImprovedTube.commentsSidebar = function () { if (ImprovedTube.storage.comments_s
             }`;
 			style.appendChild(document.createTextNode(cssRule));
 			}
-			document.head.appendChild(style);
+			if (!style.parentNode) {
+				document.head.appendChild(style);
+			}
 		}
 	}
 	function applyObserver () {
+		const video = document.querySelector("#player .ytp-chrome-bottom") || document.querySelector("#container .ytp-chrome-bottom");
+		if (!video || typeof ResizeObserver === "undefined" || state.observedVideo === video) {
+			return;
+		}
+		if (state.resizeObserver) {
+			state.resizeObserver.disconnect();
+		}
 		const debouncedResizePlayer = debounce(resizePlayer, 200);
-		const resizeObserver = new ResizeObserver(debouncedResizePlayer);
-		resizeObserver.observe(video);
+		state.resizeObserver = new ResizeObserver(debouncedResizePlayer);
+		state.resizeObserver.observe(video);
+		state.observedVideo = video;
+	}
+	function observeLayoutChanges () {
+		const root = document.getElementById("columns") || document.body || document.documentElement;
+		if (!root || typeof MutationObserver === "undefined" || state.observedLayoutRoot === root) {
+			return;
+		}
+		if (state.layoutObserver) {
+			state.layoutObserver.disconnect();
+		}
+		state.layoutObserver = new MutationObserver(function () {
+			clearTimeout(state.layoutTimer);
+			state.layoutTimer = setTimeout(sidebar, 50);
+		});
+		state.layoutObserver.observe(root, {
+			childList: true,
+			subtree: true
+		});
+		state.observedLayoutRoot = root;
 	}
 	function debounce (callback, delay) {
 		let timerId;

--- a/tests/unit/comments-sidebar.test.js
+++ b/tests/unit/comments-sidebar.test.js
@@ -1,0 +1,217 @@
+class FakeElement {
+	constructor(tagName, id = '', className = '') {
+		this.tagName = tagName.toUpperCase();
+		this.nodeName = this.tagName;
+		this.id = id;
+		this.className = className;
+		this.children = [];
+		this.parentElement = null;
+		this.parentNode = null;
+		this.style = {};
+		this.attributes = {};
+		this.textContent = '';
+		this.offsetWidth = 800;
+	}
+
+	appendChild(child) {
+		if (!child) return child;
+		if (child.parentElement) {
+			child.parentElement.children = child.parentElement.children.filter((node) => node !== child);
+		}
+		this.children.push(child);
+		child.parentElement = this;
+		child.parentNode = this;
+		return child;
+	}
+
+	hasAttribute(name) {
+		return Object.prototype.hasOwnProperty.call(this.attributes, name);
+	}
+
+	setAttribute(name, value) {
+		this.attributes[name] = String(value);
+	}
+
+	removeAttribute(name) {
+		delete this.attributes[name];
+	}
+}
+
+function descendants(node) {
+	return node.children.flatMap((child) => [child, ...descendants(child)]);
+}
+
+function createDocument(includeComments = true) {
+	const elements = {};
+
+	function el(tagName, id = '', className = '') {
+		const node = new FakeElement(tagName, id, className);
+		if (id) elements[id] = node;
+		return node;
+	}
+
+	const documentElement = el('html');
+	const head = el('head');
+	const body = el('body');
+	const app = el('ytd-app');
+	const watch = el('ytd-watch-flexy');
+	const columns = el('div', 'columns');
+	const primary = el('div', 'primary');
+	const player = el('div', 'player', 'style-scope ytd-watch-flexy');
+	const chrome = el('div', '', 'ytp-chrome-bottom');
+	const primaryInner = el('div', 'primary-inner');
+	const below = el('div', 'below');
+	const panels = el('div', 'panels');
+	const related = el('div', 'related');
+	const relatedContent = el('div');
+	const compactVideo = el('ytd-compact-video-renderer', '', 'style-scope');
+	const secondary = el('div', 'secondary');
+	const secondaryInner = el('div', 'secondary-inner');
+	const chatTemplate = el('div', 'chat-template');
+
+	documentElement.appendChild(head);
+	documentElement.appendChild(body);
+	body.appendChild(app);
+	app.appendChild(watch);
+	watch.appendChild(columns);
+	columns.appendChild(primary);
+	columns.appendChild(secondary);
+	primary.appendChild(player);
+	player.appendChild(chrome);
+	primary.appendChild(primaryInner);
+	primaryInner.appendChild(below);
+	primaryInner.appendChild(panels);
+	primaryInner.appendChild(related);
+	related.appendChild(relatedContent);
+	relatedContent.appendChild(compactVideo);
+	secondary.appendChild(secondaryInner);
+	secondaryInner.appendChild(chatTemplate);
+
+	if (includeComments) {
+		below.appendChild(el('div', 'comments'));
+	}
+
+	function findById(id) {
+		return elements[id] || null;
+	}
+
+	function querySelector(selector) {
+		if (selector === '#comments') return findById('comments');
+		if (selector === '#player .ytp-chrome-bottom') return chrome;
+		if (selector === '#container .ytp-chrome-bottom') return null;
+		if (selector === '#player.style-scope.ytd-watch-flexy') return player;
+		if (selector === 'ytd-watch-flexy') return watch;
+		if (selector === 'ytd-app') return app;
+		if (selector === '#related ytd-compact-video-renderer.style-scope') return compactVideo;
+		if (selector.startsWith('#')) return findById(selector.slice(1));
+		return descendants(documentElement).find((node) => node.tagName.toLowerCase() === selector) || null;
+	}
+
+	return {
+		documentElement,
+		head,
+		body,
+		createElement: (tagName) => el(tagName),
+		createTextNode: (text) => {
+			const node = el('#text');
+			node.textContent = text;
+			return node;
+		},
+		getElementById: findById,
+		querySelector,
+		addEventListener: jest.fn(),
+		_createElementWithId: el
+	};
+}
+
+function installBrowserStubs(includeComments = true) {
+	const observers = [];
+	const document = createDocument(includeComments);
+
+	global.document = document;
+	global.location = { href: 'https://www.youtube.com/watch?v=abcdefghijk' };
+	global.navigator = { userAgent: 'Macintosh' };
+	global.window = {
+		addEventListener: jest.fn(),
+		matchMedia: jest.fn((query) => ({
+			matches: query.includes('1000px') && !query.includes('1952px'),
+			addListener: jest.fn(),
+			removeListener: jest.fn()
+		}))
+	};
+	global.ResizeObserver = jest.fn().mockImplementation(() => ({
+		observe: jest.fn(),
+		disconnect: jest.fn()
+	}));
+	global.MutationObserver = jest.fn().mockImplementation((callback) => {
+		const observer = {
+			observe: jest.fn(() => observers.push(callback)),
+			disconnect: jest.fn()
+		};
+		return observer;
+	});
+
+	return {
+		document,
+		triggerMutation: () => observers.forEach((callback) => callback([{ type: 'childList' }]))
+	};
+}
+
+function loadAppearance() {
+	jest.resetModules();
+	global.ImprovedTube = {
+		storage: {
+			comments_sidebar: true,
+			comments_sidebar_scrollbars: false
+		},
+		elements: {}
+	};
+	require('../../js&css/web-accessible/www.youtube.com/appearance.js');
+}
+
+describe('comments sidebar', () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+		delete global.document;
+		delete global.location;
+		delete global.navigator;
+		delete global.window;
+		delete global.ResizeObserver;
+		delete global.MutationObserver;
+		delete global.ImprovedTube;
+	});
+
+	test('moves comments back to the sidebar when YouTube restores the default layout', () => {
+		const { document, triggerMutation } = installBrowserStubs(true);
+		loadAppearance();
+
+		ImprovedTube.commentsSidebar();
+		jest.advanceTimersByTime(300);
+
+		const comments = document.getElementById('comments');
+		expect(comments.parentElement.id).toBe('secondary-inner');
+
+		document.getElementById('below').appendChild(comments);
+		triggerMutation();
+		jest.advanceTimersByTime(100);
+
+		expect(comments.parentElement.id).toBe('secondary-inner');
+	});
+
+	test('waits for late-loading comments instead of failing during initial setup', () => {
+		const { document } = installBrowserStubs(false);
+		loadAppearance();
+
+		expect(() => ImprovedTube.commentsSidebar()).not.toThrow();
+
+		const comments = document._createElementWithId('div', 'comments');
+		document.getElementById('below').appendChild(comments);
+		jest.advanceTimersByTime(300);
+
+		expect(comments.parentElement.id).toBe('secondary-inner');
+	});
+});


### PR DESCRIPTION
Fixes #3880

## Summary
- reapply the comments sidebar layout when YouTube rebuilds the watch page DOM
- guard the sidebar setup while comments/related/sidebar nodes are still loading
- avoid stacking duplicate scrollbar styles and resize observers
- add a regression test for refresh/default-layout restoration and late-loading comments

## Tests
- npm_config_cache=$PWD/.npm-cache npx jest tests/unit/comments-sidebar.test.js --runInBand
- npm_config_cache=$PWD/.npm-cache npm test -- --runInBand
- npm_config_cache=$PWD/.npm-cache npx jest --runInBand
- npm_config_cache=$PWD/.npm-cache npm run lint
- git diff --check