### PR TITLE
fix: 60fps OFF toggle now takes effect without page reload (#1506)

### DIFF
--- a/js&css/web-accessible/core.js
+++ b/js&css/web-accessible/core.js
@@ -98,8 +98,13 @@ CODEC || 30FPS
 ----------------------------------------------------------------
 	Do not move, needs to be on top of first injected content
 	file to patch HTMLMediaElement before YT player uses it.
+
+	Patches are always installed so that toggling 60fps OFF or
+	codec blocking at runtime takes effect without a reload.
+	The overwrite() function reads localStorage fresh each call,
+	so activation is fully dynamic.
 --------------------------------------------------------------*/
-if (localStorage['it-codec'] || localStorage['it-player30fps']) {
+(function () {
 	function overwrite(self, callback, mime) {
 		if (localStorage['it-codec']) {
 			var re = new RegExp(localStorage['it-codec']);
@@ -123,7 +128,7 @@ if (localStorage['it-codec'] || localStorage['it-player30fps']) {
 	HTMLMediaElement.prototype.canPlayType = function (mime) {
 		return overwrite(this, canPlayType, mime);
 	}
-};
+})();
 
 /*--------------------------------------------------------------
 # MESSAGES


### PR DESCRIPTION
## Problem

**Issue**: #1506 — Allow **60fps: OFF** does not work

Toggling "Allow 60fps" to OFF in the extension settings has no effect.
Videos continue playing at 60 fps even after disabling the option.

## Root Cause

The `MediaSource.isTypeSupported` and `HTMLMediaElement.prototype.canPlayType`
patches (in `js\&css/web-accessible/core.js` lines 102-126) are only installed
when `localStorage` already contains `it-codec` **or** `it-player30fps` at
**page load time**:

```javascript
if (localStorage["it-codec"] || localStorage["it-player30fps"]) {
    // ... patches installed here
}
```

On a fresh install (or when both codec blocking AND 60fps limiting are
disabled), neither key exists in localStorage → **the overwrite hook is never
attached to the DOM APIs**. When the user later toggles 60fps OFF, the
`storage-changed` handler correctly sets `localStorage["it-player30fps"] = true`,
but nobody is listening — the patches were never installed.

## Fix

**Always install the patches** (wrapped in an IIFE to avoid scope pollution).
The `overwrite()` function reads `localStorage` fresh on every invocation, so:

- Codec blocking and 30fps filtering activate **dynamatically** when toggled
- No page reload needed for the setting to take effect
- No behavioral change when both features are disabled (overwrite passes through)

## Changes

| File | Change |
|------|--------|
| `js\&css/web-accessible/core.js` | Removed `if (localStorage[...])` guard; wrapped in IIFE |

## Testing

1. Open YouTube with extension installed (fresh, no prior 60fps/codec settings)
2. Open any 60fps video → should play at 60fps (default: ON)
3. Go to extension settings → Player → toggle **Allow 60fps** to OFF
4. **Before fix**: video continues at 60fps (bug)
5. **After fix**: player drops to ≤30fps on next source switch/reload

Fixes #1506