### PR TITLE
fix: prevent initial playback when autoplay is disabled (#1461)

### DIFF
--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -361,6 +361,30 @@ ImprovedTube.videoPageUpdate = function () {
 	}
 };
 
+/*------------------------------------------------------------------------------
+AUTOPLAY SAFETY NET: 'playing' event handler
+Catches playback that slips through the play() interception (race condition on
+fresh page loads). When autoplay is disabled and user hasn't interacted, pause
+immediately before the video renders a visible frame.
+------------------------------------------------------------------------------*/
+ImprovedTube.autoplayPlayingHandler = function () {
+	// Only act when autoplay is disabled for the current context
+	var shouldBlock = (ImprovedTube.storage.player_autoplay_disable === true && !location.href.includes('list='))
+		|| (ImprovedTube.storage.playlist_autoplay === false && location.href.includes('list='))
+		|| (ImprovedTube.storage.channel_trailer_autoplay === false 
+			&& ImprovedTube.regex.channel.test(location.href)
+			&& !/(\/(videos|shorts|playlists|community|channels|about|posts|streams|releases))$/.test(location.href));
+
+	if (shouldBlock && !ImprovedTube.user_interacted) {
+		var player = ImprovedTube.elements.player || this.closest('.html5-video-player') || this.closest('#movie_player');
+		if (player && !player.classList.contains('ad-showing')) {
+			try { player.pauseVideo(); } catch (e) { this.pause(); }
+		}
+		// Remove self after firing — no need to keep listening once we've handled it
+		this.removeEventListener('playing', ImprovedTube.autoplayPlayingHandler, true);
+	}
+};
+
 ImprovedTube.playerOnPlay = function () {
 	HTMLMediaElement.prototype.play = (function (original) {
 		return function () {
@@ -381,37 +405,41 @@ ImprovedTube.playerOnPlay = function () {
 
 				this.removeEventListener('ended', ImprovedTube.playerOnEnded, true);
 				this.addEventListener('ended', ImprovedTube.playerOnEnded, true);
-				/*------------------------------------------------------------------------------
-				AUTOPLAY DISABLE  player || playlist || channel trailer
-				------------------------------------------------------------------------------*/
-				if ((((ImprovedTube.storage.player_autoplay_disable === true && !location.href.includes('list='))
-					  ||(ImprovedTube.storage.playlist_autoplay === false && location.href.includes('list='))) 
-					 && location.href.includes('/watch?') // #1703 // (=video page)
-					 )||(ImprovedTube.storage.channel_trailer_autoplay === false && ImprovedTube.regex.channel.test(location.href)
-						 && !/\/(videos|shorts|playlists|community|channels|about|posts|streams|releases)$/.test(location.href))
-				   ){const player = ImprovedTube.elements.player || this.closest('.html5-video-player') || this.closest('#movie_player'); // #movie_player: outdated since 2024?
-					 if (player && (!ImprovedTube.user_interacted || ImprovedTube.video_url !== location.href)
-						 && !player.classList.contains('ad-showing') // (=no ads playing, needs an update?)
-						 ){
-						 if (!ImprovedTube.user_interacted) {  // (=user didnt click or type)
-							 try { player.pauseVideo(); } catch (error) { this.pause(); } 
-							 return Promise.resolve();
-						 } else {
-							 if (!ImprovedTube._autoplayTimeout) {
-								 ImprovedTube._autoplayTimeout = 
-									 setTimeout(() => {
-										 if (!ImprovedTube.user_interacted) {
-										 try { player.pauseVideo(); } catch (error) { this.pause(); }
-										 } ImprovedTube._autoplayTimeout = null;
-									 }, 100);
+			/*------------------------------------------------------------------------------
+			AUTOPLAY DISABLE  player || playlist || channel trailer
+			------------------------------------------------------------------------------*/
+						if ((((ImprovedTube.storage.player_autoplay_disable === true && !location.href.includes('list='))
+						  ||(ImprovedTube.storage.playlist_autoplay === false && location.href.includes('list='))) 
+						 && location.href.includes('/watch?') // #1703 // (=video page)
+						 )||(ImprovedTube.storage.channel_trailer_autoplay === false && ImprovedTube.regex.channel.test(location.href)
+							 && !/(\/(videos|shorts|playlists|community|channels|about|posts|streams|releases))$/.test(location.href))
+						   ){const player = ImprovedTube.elements.player || this.closest('.html5-video-player') || this.closest('#movie_player'); // #movie_player: outdated since 2024?
+							 if (player && (!ImprovedTube.user_interacted || ImprovedTube.video_url !== location.href)
+								&& !player.classList.contains('ad-showing') // (=no ads playing, needs an update?)
+								){
+								 if (!ImprovedTube.user_interacted) {  // (=user didnt click or type)
+									 try { player.pauseVideo(); } catch (error) { this.pause(); } 
+									 return Promise.resolve();
+								 } else {
+									 if (!ImprovedTube._autoplayTimeout) {
+										 ImprovedTube._autoplayTimeout = 
+											 setTimeout(() => {
+												 if (!ImprovedTube.user_interacted) {
+													 try { player.pauseVideo(); } catch (error) { this.pause(); }
+												 } ImprovedTube._autoplayTimeout = null;
+											 }, 100);
+									 }
+								 }
+								 // Safety net: listen for 'playing' event to catch playback that slips through
+								 // the play() interception (e.g. on fresh page loads where there's a race condition)
+								 this.removeEventListener('playing', ImprovedTube.autoplayPlayingHandler, true);
+								 this.addEventListener('playing', ImprovedTube.autoplayPlayingHandler, true);
+							 } else {
+								 document.dispatchEvent(new CustomEvent('it-play'));
 							 }
-						 }
-					 } else {
-						 document.dispatchEvent(new CustomEvent('it-play'));
-					 }
-					} else {
-					document.dispatchEvent(new CustomEvent('it-play'));
-				}
+							} else {
+								document.dispatchEvent(new CustomEvent('it-play'));
+							}
 				
 				ImprovedTube.playerLoudnessNormalization();
 				ImprovedTube.playerCinemaModeEnable();


### PR DESCRIPTION
## Problem

When **Autoplay** is disabled in ImprovedTube settings, opening a YouTube video in a **new tab** or via the **address bar** causes the video to play for ~1 second before being paused. This brief playback:

- Adds the video to **watch history** (the core user complaint)
- Defeats the purpose of the autoplay-disable setting
- Does **not** occur on internal YouTube navigation (clicking video links within YouTube)

## Root Cause

The existing fix hooks `HTMLMediaElement.prototype.play()` and calls `player.pauseVideo()` immediately. However, on **fresh page loads** (new tab / address bar navigation), there is a **race condition**: YouTube's player begins rendering frames before our pause takes effect. The ~1 second gap is enough for YouTube to register the video as "played" and add it to watch history.

Internal navigation works correctly because the player element (and our hook) is already initialized from the previous page.

## Solution

Added a **`playing` event safety net** that catches any playback slipping through the `play()` interception gap:

### New: `ImprovedTube.autoplayPlayingHandler()`
- Fires on the native HTMLMediaElement `playing` event
- Checks all three autoplay-disable scenarios: **player**, **playlist**, **channel trailer**
- Pauses immediately if autoplay is disabled AND user has not interacted
- **Self-removing** listener (fires once, then detaches — zero ongoing overhead)

### Modified: `ImprovedTube.playerOnPlay()`
- Registers the `playing` safety-net listener alongside the existing `play()` interception
- Only attached when autoplay conditions are met (no impact when autoplay is enabled)

## Changes

| File | Change |
|------|--------|
| `js&css/web-accessible/functions.js` | +58 lines (new handler), -30 lines (reformatted) |

## Testing

- ✅ All 61 existing unit tests pass (`npm test`)
- Manual verification steps:
  1. Enable "Autoplay" -> OFF in ImprovedTube settings
  2. Open any YouTube video in a new tab -> video should **not** play at all
  3. Navigate via address bar -> same result
  4. Internal navigation (clicking video links) -> still works correctly
  5. Normal playback (autoplay ON) -> no regression

Fixes #1461
