### PR TITLE
Fix themes not covering entire page #3888

### DIFF
--- a/js&css/web-accessible/www.youtube.com/themes.js
+++ b/js&css/web-accessible/www.youtube.com/themes.js
@@ -30,62 +30,62 @@ ImprovedTube.myColors = function () {
 
 		style.className = 'it-theme-editor';
 		style.textContent = 'html[it-theme=custom], html[it-theme=custom] [dark] {' +
-					'--yt-swatch-textbox-bg:rgba(19,19,19,1)!important;' +
-					'--yt-swatch-icon-color:rgba(136,136,136,1)!important;' +
-					'--yt-spec-brand-background-primary:rgba(0,0,0, 0.1) !important;' +
-					'--yt-spec-brand-background-secondary:rgba(0,0,0, 0.1) !important;' +
-					'--yt-spec-badge-chip-background:rgba(0, 0, 0, 0.05) !important;' +
-					'--yt-spec-verified-badge-background:rgba(0, 0, 0, 0.15) !important;' +
-					'--yt-spec-button-chip-background-hover:rgba(0, 0, 0, 0.10) !important;' +
-					'--yt-spec-brand-button-background:rgba(136,136,136,1) !important;' +
-					'--yt-spec-filled-button-focus-outline:rgba(0, 0, 0, 0.60) !important;' +
-					'--yt-spec-call-to-action-button-focus-outline:rgba(0,0,0, 0.30) !important;' +
-					'--yt-spec-brand-text-button-focus-outline:rgba(204, 0, 0, 0.30) !important;' +
-					'--yt-spec-10-percent-layer:rgba(136,136,136,1) !important;' +
-					'--yt-swatch-header-primary:'+ secondary_color + '!important;' +
-					'--ytd-masthead-background:' + secondary_color + '!important;' +
-					'--yt-spec-brand-background:' + secondary_color + '!important;' +
-					'--ytd-topbar-background-color:' + secondary_color + '!important;' +
-					'--ytd-topbar-dark-background-color:' + secondary_color + '!important;' +
-					'--yt-masthead-background:' + secondary_color + '!important;' +
-					'--yt-app-bar-background:' + secondary_color + '!important;' +
-					'--yt-swatch-primary:' + primary_color + '!important;' +
-					'--yt-swatch-primary-darker:' + primary_color + '!important;' +
-					'--yt-spec-brand-background-solid:' + primary_color + '!important;' +
-					'--yt-spec-general-background-a:' + primary_color + '!important;' +
-					'--yt-spec-general-background-b:' + primary_color + '!important;' +
-					'--yt-spec-general-background-c:' + primary_color + '!important;' +
-					'--yt-spec-touch-response:' + primary_color + '!important;' +
-					'--yt-swatch-text: ' + text_color + '!important;' +
-					'--yt-swatch-important-text: ' + text_color + '!important;' +
-					'--yt-swatch-input-text: ' + text_color + '!important;' +
-					'--yt-swatch-logo-override: ' + text_color + '!important;' +
-					'--yt-spec-text-primary:' + text_color + ' !important;' +
-					'--yt-spec-text-primary-inverse:' + primary_color + ' !important;' +
-					'--yt-spec-text-secondary:' + text_color + ' !important;' +
-					'--yt-spec-text-disabled:' + text_color + ' !important;' +
-					'--yt-spec-icon-active-other:' + text_color + ' !important;' +
-					'--yt-spec-icon-inactive:' + text_color + ' !important;' +
-					'--yt-spec-icon-disabled:' + text_color + ' !important;' +
-					'--yt-spec-filled-button-text:' + text_color + ' !important;' +
-					'--yt-spec-call-to-action-inverse:' + text_color + ' !important;' +
-					'--yt-spec-brand-icon-active:' + text_color + ' !important;' +
-					'--yt-spec-brand-icon-inactive:' + text_color + ' !important;' +
-					'--yt-spec-brand-link-text:' + text_color + '!important;' +
-					'--yt-spec-brand-subscribe-button-background:' + text_color + ' !important;' +
-					'--yt-spec-wordmark-text:' + text_color + ' !important;' +
-					'--yt-spec-selected-nav-text:' + text_color + ' !important;' +
-					'--yt-spec-base-background:' + primary_color + '!important;' +
-					'--yt-spec-raised-background:' + primary_color + '!important;' +
-					'--yt-spec-menu-background:' + primary_color + '!important;' +
-					'--yt-spec-inverted-background: #fff;' +
-					'--ytd-searchbox-background:' + primary_color + '!important;' +
-					'--ytd-searchbox-legacy-button-color:' + 'var(--yt-spec-brand-background-primary)' + '!important;' +
-					'--yt-frosted-glass-desktop:' + primary_color + 'cc !important;' +
-					'background-color: var(--yt-spec-base-background)!important;' +
-					'}' +
-					'html[it-theme=custom] ytd-masthead, html[it-theme=custom] #masthead, html[it-theme=custom] ytd-app #masthead { background-color: ' + secondary_color + ' !important; }';
-					//Tested, but still not sure if it's good enough
+				'--yt-swatch-textbox-bg:rgba(19,19,19,1)!important;' +
+				'--yt-swatch-icon-color:rgba(136,136,136,1)!important;' +
+				'--yt-spec-brand-background-primary:rgba(0,0,0, 0.1) !important;' +
+				'--yt-spec-brand-background-secondary:rgba(0,0,0, 0.1) !important;' +
+				'--yt-spec-badge-chip-background:rgba(0, 0, 0, 0.05) !important;' +
+				'--yt-spec-verified-badge-background:rgba(0, 0, 0, 0.15) !important;' +
+				'--yt-spec-button-chip-background-hover:rgba(0, 0, 0, 0.10) !important;' +
+				'--yt-spec-brand-button-background:rgba(136,136,136,1) !important;' +
+				'--yt-spec-filled-button-focus-outline:rgba(0, 0, 0, 0.60) !important;' +
+				'--yt-spec-call-to-action-button-focus-outline:rgba(0,0,0, 0.30) !important;' +
+				'--yt-spec-brand-text-button-focus-outline:rgba(204, 0, 0, 0.30) !important;' +
+				'--yt-spec-10-percent-layer:rgba(136,136,136,1) !important;' +
+				'--yt-swatch-header-primary:'+ secondary_color + '!important;' +
+				'--ytd-masthead-background:' + secondary_color + '!important;' +
+				'--yt-spec-brand-background:' + secondary_color + '!important;' +
+				'--ytd-topbar-background-color:' + secondary_color + '!important;' +
+				'--ytd-topbar-dark-background-color:' + secondary_color + '!important;' +
+				'--yt-masthead-background:' + secondary_color + '!important;' +
+				'--yt-app-bar-background:' + secondary_color + '!important;' +
+				'--yt-swatch-primary:' + primary_color + '!important;' +
+				'--yt-swatch-primary-darker:' + primary_color + '!important;' +
+				'--yt-spec-brand-background-solid:' + primary_color + '!important;' +
+				'--yt-spec-general-background-a:' + primary_color + '!important;' +
+				'--yt-spec-general-background-b:' + primary_color + '!important;' +
+				'--yt-spec-general-background-c:' + primary_color + '!important;' +
+				'--yt-spec-touch-response:' + primary_color + '!important;' +
+				'--yt-swatch-text: ' + text_color + '!important;' +
+				'--yt-swatch-important-text: ' + text_color + '!important;' +
+				'--yt-swatch-input-text: ' + text_color + '!important;' +
+				'--yt-swatch-logo-override: ' + text_color + '!important;' +
+				'--yt-spec-text-primary:' + text_color + ' !important;' +
+				'--yt-spec-text-primary-inverse:' + primary_color + ' !important;' +
+				'--yt-spec-text-secondary:' + text_color + ' !important;' +
+				'--yt-spec-text-disabled:' + text_color + ' !important;' +
+				'--yt-spec-icon-active-other:' + text_color + ' !important;' +
+				'--yt-spec-icon-inactive:' + text_color + ' !important;' +
+				'--yt-spec-icon-disabled:' + text_color + ' !important;' +
+				'--yt-spec-filled-button-text:' + text_color + ' !important;' +
+				'--yt-spec-call-to-action-inverse:' + text_color + ' !important;' +
+				'--yt-spec-brand-icon-active:' + text_color + ' !important;' +
+				'--yt-spec-brand-icon-inactive:' + text_color + ' !important;' +
+				'--yt-spec-brand-link-text:' + text_color + '!important;' +
+				'--yt-spec-brand-subscribe-button-background:' + text_color + ' !important;' +
+				'--yt-spec-wordmark-text:' + text_color + ' !important;' +
+				'--yt-spec-selected-nav-text:' + text_color + ' !important;' +
+				'--yt-spec-base-background:' + primary_color + '!important;' +
+				'--yt-spec-raised-background:' + primary_color + '!important;' +
+				'--yt-spec-menu-background:' + primary_color + '!important;' +
+				'--yt-spec-inverted-background: #fff;' +
+				'--ytd-searchbox-background:' + primary_color + '!important;' +
+				'--ytd-searchbox-legacy-button-color:' + 'var(--yt-spec-brand-background-primary)' + '!important;' +
+				'--yt-frosted-glass-desktop:' + primary_color + 'cc !important;' +
+				'background-color: var(--yt-spec-base-background)!important;' +
+				'}' +
+				'html[it-theme=custom] ytd-masthead, html[it-theme=custom] #masthead, html[it-theme=custom] ytd-app #masthead { background-color: ' + secondary_color + ' !important; }' +
+				'html[it-theme=custom] ytd-app, html[it-theme=custom] ytd-browse-view, html[it-theme=custom] ytd-watch-flexy, html[it-theme=custom] #page, html[it-theme=custom] #content { background-color: var(--yt-spec-base-background) !important; }';
 
 		this.elements.my_colors = style;
 		(document.head || document.documentElement).appendChild(style);


### PR DESCRIPTION
## Fixes  #3888

### Problem
Themes (especially custom themes) were not covering the entire YouTube page - they only covered the top bar/header area. The main content area remained the default YouTube theme/background.

### Root Cause
The CSS selectors in `themes.js` were only applying theme colors to `html[it-theme=custom]` and `html[it-theme=custom] [dark]`, but didn't explicitly target the main content containers:
- `ytd-app` - The root YouTube application container
- `ytd-browse-view` - Browse pages (Home, Subscriptions, etc.)
- `ytd-watch-flexy` - Watch pages
- `#page` and `#content` - Legacy content containers

### Solution
Added an additional CSS rule that explicitly targets all major YouTube containers and ensures the background-color cascades properly through the page hierarchy:

```javascript
'html[it-theme=custom] ytd-app, html[it-theme=custom] ytd-browse-view, html[it-theme=custom] ytd-watch-flexy, html[it-theme=custom] #page, html[it-theme=custom] #content { background-color: var(--yt-spec-base-background) !important; }'
```

### Changes Made
- **File Modified**: `js&css/web-accessible/www.youtube.com/themes.js`
- Added explicit background-color rules for `ytd-app`, `ytd-browse-view`, `ytd-watch-flexy`, `#page`, and `#content`
- Ensures the theme's `--yt-spec-base-background` variable is applied consistently across all main content areas

### Testing
The fix should be tested with:
1. Custom theme enabled with various color combinations
2. Different YouTube pages (home, watch, channel, playlists)
3. Different YouTube layouts (dark mode, light mode)
4. Both browser and desktop YouTube interfaces

### Impact
This fix ensures that when users select a theme (particularly custom themes), the entire page adopts the theme colors instead of just the top bar, providing a consistent and immersive viewing experience.