### PR TITLE
fix: correct Portuguese translations for push/pull sync settings

### DIFF
--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -1149,7 +1149,7 @@
         "message": "Cor primária"
     },
     "pullSyncSettings": {
-        "message": "Puxar"
+        "message": "Receber"
     },
     "purchase": {
         "message": "Comprar"
@@ -1158,7 +1158,7 @@
         "message": "Roxo"
     },
     "pushSyncSettings": {
-        "message": "Pressione"
+        "message": "Enviar"
     },
     "quality": {
         "message": "Qualidade"


### PR DESCRIPTION
-pushSyncSettings: "Pressione" → "Enviar" (was translating "press" instead of "push")
-pullSyncSettings: "Puxar" → "Receber" (more natural in sync context)