### PR TITLE
Fix visibility of extra buttons in YouTube dark theme: #issue : 3907

### DIFF
--- a/js&css/extension/www.youtube.com/styles.css
+++ b/js&css/extension/www.youtube.com/styles.css
@@ -690,7 +690,15 @@ html:not([data-page-type=channel]) .it-blocklisted-channel:hover ytd-thumbnail {
 	border: none;
 	outline: none;
 	background: none;
-	fill: var(--yt-spec-icon-inactive);
+	fill: var(--yt-spec-icon-active-other, #fff);
+}
+html[dark] .improvedtube-player-button svg,
+html[dark] .improvedtube-player-button svg path {
+	fill: #fff;
+}
+html:not([dark]) .improvedtube-player-button svg,
+html:not([dark]) .improvedtube-player-button svg path {
+	fill: #000;
 }
 
 .improvedtube-player-button:last-of-type {

--- a/js&css/extension/www.youtube.com/styles.css
+++ b/js&css/extension/www.youtube.com/styles.css
@@ -690,17 +690,12 @@ html:not([data-page-type=channel]) .it-blocklisted-channel:hover ytd-thumbnail {
 	border: none;
 	outline: none;
 	background: none;
-	fill: var(--yt-spec-icon-active-other, #fff);
+	fill: var(--yt-spec-icon-inactive);
 }
 html[dark] .improvedtube-player-button svg,
 html[dark] .improvedtube-player-button svg path {
 	fill: #fff;
 }
-html:not([dark]) .improvedtube-player-button svg,
-html:not([dark]) .improvedtube-player-button svg path {
-	fill: #000;
-}
-
 .improvedtube-player-button:last-of-type {
 	margin-right: 24px;
 }

--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -526,7 +526,7 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
 				var button = document.createElement('button'),
 					svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
 					path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-		                var transparentOrOn = .85; if (this.storage.player_always_repeat === true ) { transparentOrOn = 1; }
+		                var transparentOrOn = .5; if (this.storage.player_always_repeat === true ) { transparentOrOn = 1; }
 				button.className = 'improvedtube-player-button';
 				button.id = 'it-below-player-loop';
 				button.dataset.tooltip = 'Loop';
@@ -547,7 +547,7 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
 	            }
 					if (video.hasAttribute('loop')) {
 						video.removeAttribute('loop');
-						matchLoopState('.85')
+						matchLoopState('.5')
 					} else if (!/ad-showing/.test(ImprovedTube.elements.player.className)) {
 						video.setAttribute('loop', '');
 						matchLoopState('1')
@@ -565,7 +565,7 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
 				button.className = 'improvedtube-player-button';
 				button.id = 'it-below-player-pip';
 				button.dataset.tooltip = 'PiP';
-				svg.style.opacity = '1';
+				svg.style.opacity = '.64';
 				svg.setAttributeNS(null, 'viewBox', '0 0 24 24');
 				path.setAttributeNS(null, 'd', 'M19 7h-8v6h8V7zm2-4H3C2 3 1 4 1 5v14c0 1 1 2 2 2h18c1 0 2-1 2-2V5c0-1-1-2-2-2zm0 16H3V5h18v14z');
 
@@ -585,7 +585,7 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
 				button.className = 'improvedtube-player-button';
 				button.id = 'it-below-player-screenshot';
 				button.dataset.tooltip = 'Screenshot';
-				svg.style.opacity = '1';
+				svg.style.opacity = '.55';
 				svg.setAttributeNS(null, 'viewBox', '0 0 24 24');
 				path.setAttributeNS(null, 'd', 'M21 19V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14c0 1.1.9 2 2 2h14a2 2 0 0 0 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z');
 
@@ -605,7 +605,7 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
 				button.id = 'it-below-player-keyscene';
 				button.style.marginRight = '-0.2px';
 				button.dataset.tooltip = 'Key Scene';
-				svg.style.opacity = '1';
+				svg.style.opacity = '.55';
 				svg.setAttributeNS(null, 'viewBox', '0 0 24 24');
 				g.setAttributeNS(null, 'transform', 'translate(5, 0)');				
 				path.setAttributeNS(null, 'd', 'M13 2 L3 14 H10 L8 22 L20 10 H13 L15 2 Z');
@@ -631,7 +631,7 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
 				button.className = 'improvedtube-player-button';
 				button.id = 'it-below-player-copy-video-id';
 				button.dataset.tooltip = 'CopyVideoId';
-				svg.style.opacity = '1';
+				svg.style.opacity = '.5';
 				svg.setAttributeNS(null, 'viewBox', '0 0 24 24');
 				path.setAttributeNS(null, 'd', 'M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2m0 16H8V7h11z');
 				button.onclick = function () {
@@ -646,7 +646,7 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
 					button.dataset.tooltip = 'Copied!';
 					setTimeout(function() {
 						button.dataset.tooltip = 'CopyVideoID';
-						svg.style.opacity = '1';
+						svg.style.opacity = '.5';
 					}, 500);
 				}
 
@@ -662,7 +662,7 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
 				button.className = 'improvedtube-player-button';
 				button.id = 'it-below-player-copy-transcript';
 				button.dataset.tooltip = 'CopyTranscript';
-				svg.style.opacity = '1';
+				svg.style.opacity = '.5';
 				svg.setAttributeNS(null, 'viewBox', '0 0 24 24');
 				path.setAttributeNS(null, 'd', 'M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z');
 

--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -526,7 +526,7 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
 				var button = document.createElement('button'),
 					svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
 					path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
-		                var transparentOrOn = .5; if (this.storage.player_always_repeat === true ) { transparentOrOn = 1; }
+		                var transparentOrOn = .85; if (this.storage.player_always_repeat === true ) { transparentOrOn = 1; }
 				button.className = 'improvedtube-player-button';
 				button.id = 'it-below-player-loop';
 				button.dataset.tooltip = 'Loop';
@@ -547,7 +547,7 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
 	            }
 					if (video.hasAttribute('loop')) {
 						video.removeAttribute('loop');
-						matchLoopState('.5')
+						matchLoopState('.85')
 					} else if (!/ad-showing/.test(ImprovedTube.elements.player.className)) {
 						video.setAttribute('loop', '');
 						matchLoopState('1')
@@ -565,7 +565,7 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
 				button.className = 'improvedtube-player-button';
 				button.id = 'it-below-player-pip';
 				button.dataset.tooltip = 'PiP';
-				svg.style.opacity = '.64';
+				svg.style.opacity = '1';
 				svg.setAttributeNS(null, 'viewBox', '0 0 24 24');
 				path.setAttributeNS(null, 'd', 'M19 7h-8v6h8V7zm2-4H3C2 3 1 4 1 5v14c0 1 1 2 2 2h18c1 0 2-1 2-2V5c0-1-1-2-2-2zm0 16H3V5h18v14z');
 
@@ -585,7 +585,7 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
 				button.className = 'improvedtube-player-button';
 				button.id = 'it-below-player-screenshot';
 				button.dataset.tooltip = 'Screenshot';
-				svg.style.opacity = '.55';
+				svg.style.opacity = '1';
 				svg.setAttributeNS(null, 'viewBox', '0 0 24 24');
 				path.setAttributeNS(null, 'd', 'M21 19V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14c0 1.1.9 2 2 2h14a2 2 0 0 0 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z');
 
@@ -605,7 +605,7 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
 				button.id = 'it-below-player-keyscene';
 				button.style.marginRight = '-0.2px';
 				button.dataset.tooltip = 'Key Scene';
-				svg.style.opacity = '.55';
+				svg.style.opacity = '1';
 				svg.setAttributeNS(null, 'viewBox', '0 0 24 24');
 				g.setAttributeNS(null, 'transform', 'translate(5, 0)');				
 				path.setAttributeNS(null, 'd', 'M13 2 L3 14 H10 L8 22 L20 10 H13 L15 2 Z');
@@ -631,7 +631,7 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
 				button.className = 'improvedtube-player-button';
 				button.id = 'it-below-player-copy-video-id';
 				button.dataset.tooltip = 'CopyVideoId';
-				svg.style.opacity = '.5';
+				svg.style.opacity = '1';
 				svg.setAttributeNS(null, 'viewBox', '0 0 24 24');
 				path.setAttributeNS(null, 'd', 'M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2m0 16H8V7h11z');
 				button.onclick = function () {
@@ -646,7 +646,7 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
 					button.dataset.tooltip = 'Copied!';
 					setTimeout(function() {
 						button.dataset.tooltip = 'CopyVideoID';
-						svg.style.opacity = '.5';
+						svg.style.opacity = '1';
 					}, 500);
 				}
 
@@ -662,7 +662,7 @@ ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer = function () {
 				button.className = 'improvedtube-player-button';
 				button.id = 'it-below-player-copy-transcript';
 				button.dataset.tooltip = 'CopyTranscript';
-				svg.style.opacity = '.5';
+				svg.style.opacity = '1';
 				svg.setAttributeNS(null, 'viewBox', '0 0 24 24');
 				path.setAttributeNS(null, 'd', 'M14 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z');
 


### PR DESCRIPTION
## Description

Fixes #3907

### Problem

The "Extra buttons below the player" became barely visible when YouTube Dark Theme was enabled because the SVG icons were rendered with insufficient contrast against the dark background.

### Changes

* Updated the styling of the extra player buttons.
* Applied the fill color directly to the SVG/path elements to ensure proper icon visibility.
* Verified that the buttons remain visible in both Dark Theme and Light Theme.

### Testing

* Tested on YouTube Dark Theme.
<img width="667" height="129" alt="image" src="https://github.com/user-attachments/assets/f0c7865e-8592-4f0d-8ba2-f21e36758a34" />

* Tested on YouTube Light Theme.
<img width="643" height="127" alt="image" src="https://github.com/user-attachments/assets/732f3e69-e4bf-4292-b067-3af95f9ba607" />

* Verified visibility of all extra buttons below the player.
