### PR TITLE
fix: auto PiP now triggers for playing videos on tab blur (#1352)

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -71,7 +71,11 @@ ImprovedTube.playerAutoPip = function () {
 
 	if (this.storage.player_autoPip && this.storage.player_autoPip_outside && this.focus) {
 		this.enterPip(true);
-	} else if (this.storage.player_autoPip && !this.focus && !video?.paused) {
+	// #1351: Use played_before_blur instead of video.paused because
+	// playerAutopauseWhenSwitchingTabs() runs BEFORE this in pageOnFocus()
+	// and pauses the video, making !video?.paused always false on blur.
+	// played_before_blur captures the pre-pause state correctly.
+	} else if (this.storage.player_autoPip && !this.focus && this.played_before_blur) {
 		this.enterPip();
 	}
 };


### PR DESCRIPTION
## Summary

Fixes **#1352** — Auto PiP only worked when video was paused, not when playing. The logic was inverted due to execution order bug.

### Root Cause

In `pageOnFocus()`, two functions run sequentially:
1. `playerAutopauseWhenSwitchingTabs()` — **pauses** the video, sets `played_before_blur = true`
2. `playerAutoPip()` — checks `!video?.paused` → **always false** (just paused!) → never enters PiP

The auto-PiP feature was dead code for the tab-switching scenario because the check happened after the video was already paused.

### Fix

| Before | After |
|--------|-------|
| `!video?.paused` (real-time pause state) | `this.played_before_blur` (pre-pause state) |

`played_before_blur` is set by `playerAutopauseWhenSwitchingTabs()` **before** it pauses, so it correctly captures whether the user was watching a video when they switched tabs.

### Changes
- **File**: `js&css/web-accessible/www.youtube.com/player.js` (1 file, +5/-1)
- Only changes the condition in `playerAutoPip()`, no behavior changes to other features

### Test Results
```
Test Suites: 16 passed, 1 failed (pre-existing)
Tests:       66 passed, 3 failed (pre-existing)
```
No new test failures introduced.

---
**Bounty claim**: This PR addresses issue #1352 (Bounty label). Requesting review.
