### PR TITLE
Fix: Add Watch Later button to more thumbnails (#3906)

### DIFF
--- a/js&css/extension/www.youtube.com/general/general.js
+++ b/js&css/extension/www.youtube.com/general/general.js
@@ -349,7 +349,7 @@ extension.features.watchLaterButtons = function (event) {
 				target.href &&
 				(
 					target.id === 'thumbnail' ||
-					(target.className && typeof target.className === 'string' && target.className.indexOf('thumb-link') !== -1)
+					(target.className && typeof target.className === 'string' && (target.className.indexOf('thumb-link') !== -1 || target.className.indexOf('ytLockupViewModelContentImage') !== -1))
 				)
 			) {
 				return target;
@@ -486,7 +486,7 @@ extension.features.watchLaterButtons = function (event) {
 	}
 
 	function addWatchLaterButtons(root) {
-		var thumbnails = (root || document).querySelectorAll ? (root || document).querySelectorAll('a#thumbnail, a.thumb-link') : [];
+		var thumbnails = (root || document).querySelectorAll ? (root || document).querySelectorAll('a#thumbnail, a.thumb-link, a.ytLockupViewModelContentImage') : [];
 
 		for (var i = 0, l = thumbnails.length; i < l; i++) {
 			addWatchLaterButton(thumbnails[i]);


### PR DESCRIPTION
Closes #3906

**Description:**
YouTube recently updated its DOM elements for thumbnails on the Subscriptions page and Related Videos feed. This caused the Watch Later button to stop appearing in these locations because the extension's scanner couldn't identify the new classes. 

This PR adds the new `ytLockupViewModelContentImage` class selector to the `addWatchLaterButtons` and `findThumbnail` functions in `general.js` so the extension correctly identifies these thumbnails again.

**Testing:**
- Loaded the extension locally as unpacked.
- Verified that the Watch Later button now successfully appears on hover over thumbnails in the Related Videos sidebar and the Subscriptions page.