### PR TITLE
fix: resolve comment sidebar scroll freezing

### DIFF
--- a/js&css/extension/www.youtube.com/appearance/comments/comments.css
+++ b/js&css/extension/www.youtube.com/appearance/comments/comments.css
@@ -132,7 +132,7 @@ html[data-theme='black'][it-comments='collapsed'][data-page-type=video] ytd-comm
 	}
 	
 	html[data-page-type=video][it-comments-sidebar='true'] ytd-watch-flexy:not([theater]):not([fullscreen]) #primary-content {overflow: hidden;}
-	html[data-page-type=video][it-comments-sidebar='true'] ytd-watch-flexy:not([theater]):not([fullscreen]) #columns {justify-content: flex-start !important; overflow-x: scroll;}
+	html[data-page-type=video][it-comments-sidebar='true'] ytd-watch-flexy:not([theater]):not([fullscreen]) #columns {justify-content: flex-start !important; overflow-x: hidden;}
 	
 }
 @media screen and (min-width: 1000px){

--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -362,9 +362,9 @@ ImprovedTube.commentsSidebar = function () { if (ImprovedTube.storage.comments_s
 			if (ImprovedTube.storage.comments_sidebar_scrollbars === true) {
 				const cssRule = `
             #primary, #secondary {
-                overflow: overlay !important;
+                overflow: auto !important;
             }
-            
+
             ::-webkit-scrollbar
             {
                 width: 16px;
@@ -385,8 +385,8 @@ ImprovedTube.commentsSidebar = function () { if (ImprovedTube.storage.comments_s
 			}
 			else {	const cssRule = `
             #primary, #secondary {
-                overflow: overlay !important;
-            }            
+                overflow: auto !important;
+            }
             ::-webkit-scrollbar
             {
                 width: 0px;
@@ -421,8 +421,16 @@ ImprovedTube.commentsSidebar = function () { if (ImprovedTube.storage.comments_s
 			state.layoutObserver.disconnect();
 		}
 		state.layoutObserver = new MutationObserver(function () {
+			// Skip if the sidebar layout is already applied correctly
+			const wideLayout = window.matchMedia("(min-width: 1952px)").matches;
+			const mediumLayout = window.matchMedia("(min-width: 1000px)").matches;
+			if ((wideLayout && state.hasApplied === 1 && isLayoutApplied(true)) ||
+				(!wideLayout && mediumLayout && state.hasApplied === 2 && isLayoutApplied(false)) ||
+				(!mediumLayout && state.hasApplied === 0)) {
+				return;
+			}
 			clearTimeout(state.layoutTimer);
-			state.layoutTimer = setTimeout(sidebar, 50);
+			state.layoutTimer = setTimeout(sidebar, 300);
 		});
 		state.layoutObserver.observe(root, {
 			childList: true,

--- a/tests/unit/comments-sidebar.test.js
+++ b/tests/unit/comments-sidebar.test.js
@@ -197,7 +197,7 @@ describe('comments sidebar', () => {
 
 		document.getElementById('below').appendChild(comments);
 		triggerMutation();
-		jest.advanceTimersByTime(100);
+		jest.advanceTimersByTime(350);
 
 		expect(comments.parentElement.id).toBe('secondary-inner');
 	});


### PR DESCRIPTION
## Summary

Fixes #3918

The comment sidebar scroll freezes intermittently because of three overlapping issues in the current implementation. This PR addresses all three root causes:

1. **Deprecated `overflow: overlay` property** - `overflow: overlay` is non-standard and has been removed in Chromium 114+. Modern browsers either ignore it or handle it unpredictably, which causes scroll to freeze on Edge and newer Chrome. Replaced with `overflow: auto`, which is the standard equivalent.

2. **Overly aggressive MutationObserver** - The layout observer on `#columns` was firing `sidebar()` every 50ms on any DOM change. When a user scrolls through comments and YouTube lazy-loads more content, the resulting DOM mutations would trigger `sidebar()`, which calls `moveNode()` (appendChild). This resets the scroll position and makes scrolling feel "stuck." Added a guard that checks whether the sidebar layout is already in the correct state before scheduling `sidebar()`, and increased the debounce from 50ms to 300ms.

3. **Competing horizontal scroll context** - In the 1000-1951px breakpoint, `#columns` had `overflow-x: scroll`, which created a competing scroll context alongside the vertical scroll on `#primary` and `#secondary`. Changed to `overflow-x: hidden` since there is no horizontal overflow to scroll in this layout.

## Changes

| File | Change |
|------|--------|
| `appearance.js` (line 365, 388) | `overflow: overlay` to `overflow: auto` |
| `appearance.js` (line 423-432) | MutationObserver guard + debounce 50ms to 300ms |
| `comments.css` (line 135) | `overflow-x: scroll` to `overflow-x: hidden` |
| `comments-sidebar.test.js` (line 200) | Updated test timer to match new debounce |

## Test plan

- [x] All existing sidebar tests pass (`npx jest tests/unit/comments-sidebar.test.js`)
- [x] No new test failures introduced (pre-existing failures unchanged)
- [ ] Manual testing: load extension unpacked, enable "comments sidebar" on a YouTube video, scroll through comments and verify no freezing
- [ ] Test across breakpoints: narrow (<1000px), medium (1000-1951px), wide (1952px+)
- [ ] Test in both normal and theater mode