### PR TITLE
feat: automatically resume video when internet connection is restored…

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1687,5 +1687,8 @@
   },
   "smartSpeedWhitelisted": {
     "message": "Channel Whitelisted for Smart Speed!"
+  },
+  "autoVideoRecovery": {
+  "message": "Auto video recovery"
   }
 }

--- a/js&css/extension/www.youtube.com/general/general.js
+++ b/js&css/extension/www.youtube.com/general/general.js
@@ -1216,3 +1216,106 @@ extension.features.hideWatchLater = function () {
 
 // Start the check
 extension.features.hideWatchLater();
+
+/*--------------------------------------------------------------
+# AUTO VIDEO RECOVERY
+--------------------------------------------------------------*/
+
+extension.features.autoVideoRecovery = function () {
+    if (this.autoVideoRecovery.recoveryInterval) {
+        clearInterval(this.autoVideoRecovery.recoveryInterval);
+        this.autoVideoRecovery.recoveryInterval = null;
+    }
+
+    if (extension.storage.get('auto_video_recovery') !== true) {
+        return;
+    }
+
+    var stoppedByNetwork = false;
+    var recoveryInterval = null;
+
+    function getVideo() {
+        return document.querySelector('video');
+    }
+
+    function hasSufficientBandwidth() {
+        var conn = navigator.connection;
+        if (!conn) return true; 
+        return conn.downlink > 0.3; 
+    }
+
+    function attemptRecovery() {
+        if (!navigator.onLine || !hasSufficientBandwidth()) return;
+
+        clearInterval(recoveryInterval);
+        recoveryInterval = null;
+        extension.features.autoVideoRecovery.recoveryInterval = null;
+
+        var video = getVideo();
+
+        if (video && stoppedByNetwork) {
+            stoppedByNetwork = false;
+
+            video.play().catch(function () {
+                video.load();
+                video.play().catch(function (err) {
+                    console.warn('[ImprovedTube] Auto recovery failed:', err);
+                });
+            });
+        }
+    }
+
+    function startRecoveryMonitor() {
+        if (recoveryInterval) return; // ya está corriendo
+
+        recoveryInterval = setInterval(attemptRecovery, 1000);
+        extension.features.autoVideoRecovery.recoveryInterval = recoveryInterval;
+    }
+
+    function onVideoStalled() {
+        var video = getVideo();
+        if (!video || video.paused === false) return;
+
+        stoppedByNetwork = true;
+        startRecoveryMonitor();
+    }
+
+    function onManualPause() {
+        if (navigator.onLine) {
+            stoppedByNetwork = false;
+            clearInterval(recoveryInterval);
+            recoveryInterval = null;
+            extension.features.autoVideoRecovery.recoveryInterval = null;
+        }
+    }
+
+    function attachVideoListeners(video) {
+        if (!video || video._itAutoRecovery) return;
+        video._itAutoRecovery = true;
+
+        video.addEventListener('waiting', onVideoStalled);
+        video.addEventListener('stalled', onVideoStalled);
+        video.addEventListener('pause',   onManualPause);
+    }
+
+    window.addEventListener('online', function () {
+        if (stoppedByNetwork) {
+            setTimeout(attemptRecovery, 500)
+        }
+    });
+
+    var video = getVideo();
+    if (video) {
+        attachVideoListeners(video);
+    }
+
+    this.autoVideoRecovery.observer = new MutationObserver(function () {
+        var v = getVideo();
+        if (v) attachVideoListeners(v);
+    });
+
+    this.autoVideoRecovery.observer.observe(document.documentElement, {
+        childList: true,
+        subtree: true
+    });
+};

--- a/menu/skeleton-parts/general.js
+++ b/menu/skeleton-parts/general.js
@@ -622,6 +622,11 @@ extension.skeleton.main.layers.section.general = {
 				category_refresh_button: {
 					component: 'switch',
 					text: 'categoryRefreshButton'
+				},
+				auto_video_recovery: {
+					component: 'switch',
+					text: 'autoVideoRecovery',
+					tags: 'network reconnect resume playback internet connection unstable'
 				}
 			}
 		}


### PR DESCRIPTION
**Resolves #3922**

### Description

Implemented the `autoVideoRecovery` feature to automatically resume video playback when the internet connection is restored after a dropout, ensuring uninterrupted user experience.

### Technical Implementation

* **Interruption Detection:** Binds to the `waiting` and `stalled` events on the `<video>` element to accurately flag network-induced playback halts (`stoppedByNetwork`).
* **User Intent Preservation:** Hooks into the `pause` event to clear the recovery flag. If the user manually pauses the video while the network is active, the auto-recovery is aborted to avoid overriding manual interactions.
* **Network & Bandwidth Validation:** Evaluates both `navigator.onLine` and the Network Information API (`navigator.connection.downlink`). Recovery is only attempted if the connection is restored and the downlink speed is greater than `0.3 Mbps`.
* **Resumption Mechanism:** Listens to the window's `online` event (with a 500ms debounce/delay) and falls back to a polling monitor (`setInterval`) to ensure recovery. The logic attempts `video.play()` and includes a `video.load()` fallback if the initial promise is rejected.
* **SPA Compatibility:** Implements a `MutationObserver` on `document.documentElement` to ensure the event listeners are attached to new `<video>` elements dynamically injected into the DOM during YouTube's SPA navigation.
* **State & Memory Management:** Properly clears intervals (`clearInterval`) upon feature re-initialization, manual pauses, or successful recoveries to prevent memory leaks and redundant polling.