### PR TITLE
feat: add separate quality setting for playlist videos (#3924)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -584,6 +584,9 @@
   "fullScreenQuality": {
     "message": "Fullscreen quality"
   },
+  "playlistQuality": {
+    "message": "Playlist quality"
+  },
   "fullscreenReturn": {
     "message": "Fullscreen return"
   },

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -441,7 +441,16 @@ ImprovedTube.playerAutofullscreen = function () {
 QUALITY
 ------------------------------------------------------------------------------*/
 ImprovedTube.playerQuality = function (quality = this.storage.player_quality) {
-	let player = this.elements.player;
+  var playlistQ = this.storage.player_quality_playlist;
+  var isPlaylist = !!(
+    new URLSearchParams(location.search).has('list') ||
+    document.querySelector('ytd-playlist-panel-renderer')
+  );
+  if (isPlaylist && playlistQ && playlistQ !== 'disabled') {
+    quality = playlistQ;
+  }
+
+  let player = this.elements.player;
 	if (quality && quality !== 'disabled'
 		&& player && player.getAvailableQualityLevels
 		&& (!player.dataset.defaultQuality || player.dataset.defaultQuality != quality)) {
@@ -519,10 +528,14 @@ ImprovedTube.playerQualityFullScreen = function () {
      document.mozFullScreen
    );
 
-   var fsq=ImprovedTube.storage.full_screen_quality;
-   var target = isFs ? fsq : ImprovedTube.storage.player_quality;
-
-
+   var fsq = ImprovedTube.storage.full_screen_quality;
+	 var playlistQ = ImprovedTube.storage.player_quality_playlist;
+	 var isPlaylist = !!(
+    new URLSearchParams(location.search).has('list') ||
+    document.querySelector('ytd-playlist-panel-renderer') ||
+    document.querySelector('#playlist')
+		);
+	 var target = isFs ? fsq : (isPlaylist && playlistQ && playlistQ !== 'disabled') ? playlistQ : ImprovedTube.storage.player_quality;
 
    var map = {
      '144p':'tiny','240p':'small','360p':'medium','480p':'large',
@@ -533,21 +546,29 @@ ImprovedTube.playerQualityFullScreen = function () {
    var desired = map[target] || target;
 
    function applyQuality(){
-		 var player = ImprovedTube.elements && ImprovedTube.elements.player;
-   		if (!player) return;
+    var isPlaylist = !!(
+        new URLSearchParams(location.search).has('list') ||
+        document.querySelector('ytd-playlist-panel-renderer')
+    );
+    var finalTarget = isFs ? fsq
+        : (isPlaylist && playlistQ && playlistQ !== 'disabled') ? playlistQ
+        : ImprovedTube.storage.player_quality;
+    var desired = map[finalTarget] || finalTarget;
 
-   		if (typeof ImprovedTube.playerQuality === 'function') {
-     	ImprovedTube.playerQuality(desired);
-
-     	return;
-		
-   }
-   try { if (typeof player.setPlaybackQualityRange === 'function') player.setPlaybackQualityRange(desired, desired); } catch(e) {console.log(e)}
-   try { if (typeof player.setPlaybackQuality === 'function') player.setPlaybackQuality(desired); } catch(e) {console.log(e)}
- }
+    var player = ImprovedTube.elements && ImprovedTube.elements.player;
+    if (!player) return;
+    if (typeof ImprovedTube.playerQuality === 'function') {
+        ImprovedTube.playerQuality(desired);
+        return;
+    }
+    try { if (typeof player.setPlaybackQualityRange === 'function') player.setPlaybackQualityRange(desired, desired); } catch(e) {console.log(e)}
+    try { if (typeof player.setPlaybackQuality === 'function') player.setPlaybackQuality(desired); } catch(e) {console.log(e)}
+}
 
   setTimeout(applyQuality, 300);
-  setTimeout(applyQuality, 800);
+	setTimeout(applyQuality, 800);
+	setTimeout(applyQuality, 1500);
+	setTimeout(applyQuality, 3000);
    }
 
   

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -1330,7 +1330,7 @@ extension.skeleton.main.layers.section.player.on.click = {
 			}
 		},
 		full_screen_quality: {
-			component: 'select',
+		  component: 'select',
 			text: 'fullScreenQuality',
 			id: 'full_screen_quality',
 			options: function () {
@@ -1341,6 +1341,19 @@ extension.skeleton.main.layers.section.player.on.click = {
 					extension.skeleton.main.layers.section.player.on.click.section_1.player_quality.on.render.call(this)
 				}
 			}
+		},
+		player_quality_playlist: {
+      component: 'select',
+      text: 'playlistQuality',
+      id: 'player_quality_playlist',
+      options: function () {
+      	return extension.skeleton.main.layers.section.player.on.click.section_1.player_quality.options;
+      },
+      on: {
+        render: function () {
+					extension.skeleton.main.layers.section.player.on.click.section_1.player_quality.on.render.call(this)
+        }
+      }
 		},
 		/*
 	qualityWhenRunningOnBattery: {
@@ -1513,7 +1526,8 @@ extension.skeleton.main.layers.section.player.on.click = {
 						document.getElementById('player_codecs').dispatchEvent(new CustomEvent('render'));
 						document.getElementById('optimize_codec_for_hardware_acceleration').dispatchEvent(new CustomEvent('render'));
 						document.getElementById('player_quality_without_focus').dispatchEvent(new CustomEvent('render'));
-						document.getElementById('full_screen_quality')?.dispatchEvent(new CustomEvent('render'))
+						document.getElementById('full_screen_quality')?.dispatchEvent(new CustomEvent('render'));
+						document.getElementById('player_quality_playlist')?.dispatchEvent(new CustomEvent('render'))
 						//document.getElementById('quality_when_low_battery').dispatchEvent(new CustomEvent('render'));
 					}
 					if (this.dataset.value === 'false') {


### PR DESCRIPTION
Closes #3924

## What this does
Adds a "Playlist quality" dropdown in Player settings so users can set a different video quality for playlist videos vs regular videos.

## How it works
- Detects playlist via `&list=` in URL or `ytd-playlist-panel-renderer` in DOM
- Intercepts `playerQuality` to apply playlist-specific quality
- Follows the same pattern as the existing `full_screen_quality` feature

## Files changed
- `menu/skeleton-parts/player.js` — added dropdown UI
- `_locales/en/messages.json` — added label
- `js&css/web-accessible/www.youtube.com/player.js` — added logic

Note: 3 pre-existing test failures in `hide-sidebar-transcript.test.js` are unrelated to this change.