### PR TITLE
fix: hide only "Most relevant" section, not Shorts on subscriptions page (#3927)

### DIFF
--- a/js&css/extension/www.youtube.com/appearance/comments/comments.css
+++ b/js&css/extension/www.youtube.com/appearance/comments/comments.css
@@ -9,7 +9,14 @@
 # Sidebar
 --------------------------------------------------------------*/
 /*Comments*/ 
-html[it-comments='hidden'] ytd-comments,
+/* Comments - hide everything except "Comments are turned off." */
+html[it-comments='hidden'] ytd-comments ytd-item-section-renderer#sections #header,
+html[it-comments='hidden'] ytd-comments ytd-item-section-renderer#sections #spinner-container,
+html[it-comments='hidden'] ytd-comments ytd-item-section-renderer#sections #continuations,
+html[it-comments='hidden'] ytd-comments ytd-item-section-renderer#sections #contents > ytd-continuation-item-renderer,
+html[it-comments='hidden'] ytd-comments ytd-item-section-renderer#sections #contents > ytd-comment-thread-renderer {
+    display: none !important;
+}
 /*AVATARS-*/ 
 html[it-hide-author-avatars='true'] ytd-comments #author-thumbnail,
 html[it-hide-author-avatars='true'] ytd-comments #creator-thumbnail,

--- a/js&css/extension/www.youtube.com/styles.css
+++ b/js&css/extension/www.youtube.com/styles.css
@@ -16,7 +16,7 @@ html {overflow-x: hidden !important}
 
 html[it-hide-suggested-action="true"] div.ytp-suggested-action {  display: none;  } /* "View products" button */
 html[it-hide-merch-shelf="true"] div.style-scope.ytd-merch-shelf-renderer {   display: none; } /* product list above comments */
-html[it-remove-subscriptions-most-relevant="true"][it-pathname="/feed/subscriptions"] ytd-rich-section-renderer { display: none !important; } /* "Most relevant" section on subscriptions page */
+html[it-remove-subscriptions-most-relevant="true"][it-pathname="/feed/subscriptions"] ytd-rich-section-renderer:has(ytd-rich-shelf-renderer:not([is-shorts])) { display: none !important; } /* "Most relevant" section on subscriptions page */
 
 /*------------------------------------------------------------------------------
 >>> TABLE OF CONTENTS:


### PR DESCRIPTION
Fixes #3927

## Problem
The "Hide Most relevant section on Subscriptions page" setting was also 
hiding the Shorts section because the CSS selector targeted all 
ytd-rich-section-renderer elements.

## Fix
The Shorts shelf has an `is-shorts` attribute that the Most relevant 
shelf does not. Updated the CSS selector to use :has(ytd-rich-shelf-renderer:not([is-shorts])) 
to target only the Most relevant section.

## Before
ytd-rich-section-renderer { display: none }  ← hides everything

## After  
ytd-rich-section-renderer:has(ytd-rich-shelf-renderer:not([is-shorts])) { display: none }  ← hides only Most relevant