### PR TITLE
Fix forced Theater Mode after refresh

### DIFF
--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -65,15 +65,21 @@ ImprovedTube.playerSize = function () {
 /*------------------------------------------------------------------------------
  FORCED THEATER MODE
 ------------------------------------------------------------------------------*/
-ImprovedTube.forcedTheaterMode = function () {
+ImprovedTube.forcedTheaterMode = function (attempt) {
 	if (ImprovedTube.storage.forced_theater_mode === true && ImprovedTube.elements.ytd_watch && ImprovedTube.elements.player) {
 		var button = ImprovedTube.elements.player.querySelector("button.ytp-size-button");
-		if (button && ImprovedTube.elements.ytd_watch.theater === false) {
-			document.cookie = "wide=1;domain=.youtube.com";
+		var theater = ImprovedTube.elements.ytd_watch.theater === true || ImprovedTube.elements.ytd_watch.hasAttribute('theater');
+
+		if (button && theater === false) {
+			document.cookie = "wide=1;domain=.youtube.com;path=/";
 			//     ImprovedTube.elements.ytd_watch.theater = true;
 			setTimeout(function () {
 				button.click();
 			}, 100);
+		} else if (theater === false && (attempt || 0) < 10) {
+			setTimeout(function () {
+				ImprovedTube.forcedTheaterMode((attempt || 0) + 1);
+			}, 250);
 		}
 	}
 };


### PR DESCRIPTION
## Summary

- retry forced Theater Mode while YouTube's player controls are still settling
- treat either the `theater` property or the `theater` attribute as already enabled
- write the `wide=1` cookie with `path=/` so it applies across YouTube watch navigations

## Verification

- `npm run lint -- --quiet` passed
- `node --check "js&css/web-accessible/www.youtube.com/appearance.js"` passed
- `npm test -- --runInBand` currently has an unrelated existing failure in `tests/unit/hide-sidebar-transcript.test.js`

Fixes #3933

## AI Assistance

This PR was prepared with AI assistance in Codex. I used it to inspect the issue, locate the forced Theater Mode code path, make the small retry/cookie-path change, and run local checks.