### PR TITLE
fix: add null guards to disableAutoDubbing (fixes #3559)

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -2123,43 +2123,64 @@ ImprovedTube.playerIncreaseDecreaseSpeedButtons = function () {
 # DISABLE AUTO DUBBING
 ------------------------------------------------------------------------------*/
 ImprovedTube.disableAutoDubbing = function () {
-	const player = this.elements.player;
-	const tracks = player?.getAvailableAudioTracks();
-	const originalTrack = tracks ? findOriginalAudioTrack(tracks) : null;
+	try {
+		const player = this.elements.player;
+		if (!player || typeof player.getAvailableAudioTracks !== 'function') return;
+
+		const tracks = player.getAvailableAudioTracks();
+		if (!Array.isArray(tracks) || tracks.length === 0) return;
+
+		const originalTrack = findOriginalAudioTrack(tracks);
 	
-	if (originalTrack) {
-		player.setAudioTrack(originalTrack);
+		if (originalTrack && typeof player.setAudioTrack === 'function') {
+			player.setAudioTrack(originalTrack);
+		}
+	} catch (e) {
+		console.warn('ImprovedTube: disableAutoDubbing error', e);
 	}
 
 	function findOriginalAudioTrack(audioTracks) {
 		// Score tracks based on likely original source
 		for (const track of audioTracks) {
-			if (hasOriginalKeyword(track)) {
+			if (track && hasOriginalKeyword(track)) {
 				return track;
 			}
 		}
 
 		for (const track of audioTracks) {
-			if (hasASR(track)) {
+			if (track && hasASR(track)) {
 				return track;
 			}
 		}
 
 		function hasASR(track) {
-			return Array.isArray(track.captionTracks) && 
-				track.captionTracks.some(ct => ct.kind === 'asr');
+			try {
+				return Array.isArray(track.captionTracks) && 
+					track.captionTracks.some(ct => ct && ct.kind === 'asr');
+			} catch (_) {
+				return false;
+			}
 		}
 
 		function hasOriginalKeyword(track) {
-			var name = track?.getLanguageInfo?.()?.name?.toLowerCase() || '';
-			const localizedOriginalWords = ['original', 'originale', 'originalny', 'originalaudio', 'origineel', 'orijinal']; // Add more if needed
-			
-			return localizedOriginalWords.some(word => name.includes(word));
+			try {
+				const info = typeof track.getLanguageInfo === 'function' ? track.getLanguageInfo() : null;
+				var name = (info && typeof info.name === 'string') ? info.name.toLowerCase() : '';
+				const localizedOriginalWords = ['original', 'originale', 'originalny', 'originalaudio', 'origineel', 'orijinal'];
+				return localizedOriginalWords.some(word => name.includes(word));
+			} catch (_) {
+				return false;
+			}
 		}
 
 		// As a fallback: default or first item
-		const fallback = audioTracks.find(t => t?.getLanguageInfo?.()?.isDefault) || audioTracks[0];
-		console.log(fallback);
+		const fallback = audioTracks.find(function (t) {
+			try {
+				return t && typeof t.getLanguageInfo === 'function' && t.getLanguageInfo()?.isDefault;
+			} catch (_) {
+				return false;
+			}
+		}) || audioTracks[0];
 		return fallback;
 	}
 }


### PR DESCRIPTION
## Fix for #3559 — "Disable auto dubbing" TypeError crash

### Problem
The `disableAutoDubbing` function throws `TypeError: can't access property "name", track.Af is undefined` when YouTube player audio tracks have malformed internal properties. This crashes the entire feature, preventing auto-dubbing from working.

### Solution
Added comprehensive null guards and defensive programming throughout the function chain:

| Function | Fix |
|----------|-----|
| `disableAutoDubbing()` | Wrapped in try-catch; validates player and tracks exist and are the correct types |
| `hasOriginalKeyword()` | Explicit type check on `getLanguageInfo` result before accessing `.name` |
| `hasASR()` | Added try-catch; null-check on caption track entries |
| `findOriginalAudioTrack()` | Null-check on each track before passing to helper functions |
| Fallback finder | Wrapped in try-catch with explicit type checks |

### Additional cleanup
- Removed stray `console.log(fallback)` from production code (was logging track objects to console on every invocation)

### Testing
- No behavior change for the happy path (tracks with valid `getLanguageInfo()`)
- Graceful degradation when tracks are malformed — no crash, feature silently skips invalid tracks
