### PR TITLE
fix: reverse playlist persists across video navigation (fixes #3759, #3818, #3883)

### DIFF
--- a/js&css/web-accessible/www.youtube.com/playlist.js
+++ b/js&css/web-accessible/www.youtube.com/playlist.js
@@ -198,6 +198,14 @@ ImprovedTube.playlistReverse = function () {
 		
 		if (ImprovedTube.playlistReversed === true) {
 			ImprovedTube.playlistReverseUpdate();
+			// On SPA navigation the playlist data may not be ready yet when
+			// yt-page-data-updated fires. Retry once after a short delay so the
+			// reverse is re-applied even if the first call returned early.
+			setTimeout(function () {
+				if (ImprovedTube.playlistReversed === true) {
+					ImprovedTube.playlistReverseUpdate();
+				}
+			}, 1500);
 		}
 
 		if (!ImprovedTube.playlistReverseObserver) {


### PR DESCRIPTION
(running playlistReverseUpdate() twice  with 1.5s delay)

## Fix for #3759, #3818, #3883 — Reverse playlist reverts on video navigation

<del>
### Problem
When "Reverse Playlist" is active and the user navigates to the next video in the playlist, YouTube's SPA navigation triggers `yt-page-data-updated`. The extension calls `playlistReverseUpdate()`, but at this point `ytd_watch.data` may not be populated yet, so the function returns early without applying the reverse. The playlist then renders in its original order.

### Solution
Add a delayed retry (1.5s) in `playlistReverse()`. After the initial `playlistReverseUpdate()` call, a `setTimeout` fires once more to catch the case where the first attempt returned early because playlist data wasn't ready.

This is minimal and safe:
- Only retries when `playlistReversed` is still `true`
- Does not add an interval or loop — just one additional attempt
- The existing `isCurrentlyReversed === shouldBeReversed` guard in `playlistReverseUpdate()` prevents double-reversing if the first call succeeded

### Changes
| File | Change |
|------|--------|
| `playlist.js` | Added 1.5s delayed retry of `playlistReverseUpdate()` in `playlistReverse()` |

### Testing
- 66/69 unit tests pass (3 pre-existing failures unrelated to this change)
- JS-only change, no CSS or HTML modifications
