### PR TITLE
fix list layout on Subscriptions page

### DIFF
--- a/js&css/extension/www.youtube.com/styles.css
+++ b/js&css/extension/www.youtube.com/styles.css
@@ -2342,33 +2342,32 @@ html[it-subscriptions-list-layout="true"][it-pathname="/feed/subscriptions"] ytd
 }
 
 /* Each video item: horizontal row */
-html[it-subscriptions-list-layout="true"][it-pathname="/feed/subscriptions"] ytd-rich-item-renderer {
+html[it-subscriptions-list-layout="true"][it-pathname="/feed/subscriptions"] ytd-rich-item-renderer:not([is-shelf-item]) {
     width: 100% !important;
     max-width: 100% !important;
-    margin: 0 !important;
 }
 
-html[it-subscriptions-list-layout="true"][it-pathname="/feed/subscriptions"] ytd-rich-item-renderer #dismissible.ytd-rich-grid-media {
+html[it-subscriptions-list-layout="true"][it-pathname="/feed/subscriptions"] ytd-rich-item-renderer:not([is-shelf-item]) .ytLockupViewModelVertical {
     display: flex !important;
     flex-direction: row !important;
     gap: 16px !important;
 }
 
 /* Thumbnail fixed width on left */
-html[it-subscriptions-list-layout="true"][it-pathname="/feed/subscriptions"] ytd-rich-item-renderer #dismissible.ytd-rich-grid-media ytd-thumbnail {
+html[it-subscriptions-list-layout="true"][it-pathname="/feed/subscriptions"] ytd-rich-item-renderer:not([is-shelf-item]) .ytLockupViewModelVertical .ytLockupViewModelContentImage {
     min-width: 360px !important;
     max-width: 360px !important;
     flex-shrink: 0 !important;
 }
 
 /* Details fill remaining space on right */
-html[it-subscriptions-list-layout="true"][it-pathname="/feed/subscriptions"] ytd-rich-item-renderer #dismissible.ytd-rich-grid-media #details {
+html[it-subscriptions-list-layout="true"][it-pathname="/feed/subscriptions"] ytd-rich-item-renderer:not([is-shelf-item]) .ytLockupViewModelVertical .ytLockupViewModelMetadata {
     flex: 1 !important;
     min-width: 0 !important;
     padding-top: 4px !important;
 }
 
 /* Hide empty items */
-html[it-subscriptions-list-layout="true"][it-pathname="/feed/subscriptions"] ytd-rich-item-renderer[is-empty] {
+html[it-subscriptions-list-layout="true"][it-pathname="/feed/subscriptions"] ytd-rich-item-renderer:not([is-shelf-item])[is-empty] {
     display: none !important;
 }


### PR DESCRIPTION
Youtube seems to have update some elements and classes which broke the option for showing the subscription view in a list view. All videos where displayed way to large.
To test enable the setting `List layout on Subscriptions page`

Before the fix:
<img width="1470" height="777" alt="Screenshot 2026-06-14 at 17 23 09" src="https://github.com/user-attachments/assets/a18f3770-df4b-4c68-9766-59cb8b181aa2" />

After the fix:
<img width="1466" height="767" alt="Screenshot 2026-06-14 at 17 22 47" src="https://github.com/user-attachments/assets/984e03b1-4622-4b18-97fa-5a2df5892622" />
