### PR TITLE
fix: recover keyboard shortcuts after a missed keyup (#3986)

### DIFF
--- a/js&css/web-accessible/www.youtube.com/shortcuts.js
+++ b/js&css/web-accessible/www.youtube.com/shortcuts.js
@@ -49,6 +49,27 @@ ImprovedTube.shortcutsInit = function () {
 				window.addEventListener(name, handler, {passive: false, capture: true});
 			}
 		}
+
+		// Issue #3986: a missed keyup — focus moving to the player/an ad iframe,
+		// an SPA navigation, or a tab switch, all common while the connection is
+		// unstable — leaves a key stuck in input.pressed.keys. Because
+		// shortcutsHandler() requires an EXACT key-set size match, a single stuck
+		// key silently disables EVERY shortcut. The only existing recovery is the
+		// 'improvedtube-blur' event, dispatched from the extension side (core.js)
+		// over the messaging path / MV3 background worker — which the same network
+		// instability can suspend, so shortcuts stay dead until a manual reload.
+		// Bind the same reset to native, in-page events so recovery is immediate
+		// and never depends on the background worker. Clearing an already-empty
+		// set is a harmless no-op, so we bind once and leave it.
+		if (!this.input.recoveryListenersBound) {
+			this.input.recoveryListenersBound = true;
+			const resetPressedKeys = this.shortcutsListeners['improvedtube-blur'];
+			window.addEventListener('blur', resetPressedKeys);
+			document.addEventListener('visibilitychange', function () {
+				if (document.hidden) resetPressedKeys();
+			});
+			document.addEventListener('yt-navigate-start', resetPressedKeys);
+		}
 	} else {
 		// no shortcuts means we dont need 'listeners', uninstall all
 		for (const [name, handler] of Object.entries(this.shortcutsListeners)) {

--- a/tests/unit/shortcuts-stuck-key-recovery.test.js
+++ b/tests/unit/shortcuts-stuck-key-recovery.test.js
@@ -1,0 +1,93 @@
+// Test for Issue #3986: keyboard shortcuts stop working when the internet
+// connection is unstable, and stay broken until the page is reloaded.
+//
+// Root cause: shortcutsHandler() matches a shortcut only on an EXACT key-set
+// size. If a keyup is ever missed — focus jumping to the player / an ad iframe,
+// an SPA navigation, or a tab switch during network churn — the keyCode stays
+// stuck in input.pressed.keys and no shortcut can match again. The only prior
+// recovery ('improvedtube-blur') is dispatched from the extension side and can
+// itself be lost when the same network issue suspends the MV3 service worker.
+//
+// Fix under test: shortcutsInit() also binds the pressed-keys reset to native,
+// in-page events (window 'blur', document 'visibilitychange', 'yt-navigate-start')
+// so a stuck key recovers without a reload and without the background worker.
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const SHORTCUTS_SRC = path.join(
+	__dirname,
+	'../../js&css/web-accessible/www.youtube.com/shortcuts.js'
+);
+
+function makeImprovedTube() {
+	return {
+		// one active shortcut (Space -> play/pause) so shortcutsInit installs listeners
+		storage: { shortcut_play_pause: { keys: { '32': true } } },
+		input: {
+			listening: {},
+			listeners: {},
+			pressed: { keys: new Set(), wheel: 0, alt: false, ctrl: false, shift: false },
+			cancelled: new Set(),
+			ignoreElements: ['EMBED', 'INPUT', 'OBJECT', 'TEXTAREA', 'IFRAME'],
+			modifierKeys: ['AltLeft', 'AltRight', 'ControlLeft', 'ControlRight', 'ShiftLeft', 'ShiftRight']
+		}
+	};
+}
+
+// Load the real shortcuts.js into a sandbox with minimal window/document stand-ins
+// (Node's built-in EventTarget), then run shortcutsInit() to wire the listeners.
+function loadShortcuts() {
+	const improvedTube = makeImprovedTube();
+	const win = new EventTarget();
+	const doc = new EventTarget();
+	doc.hidden = false;
+
+	const sandbox = { ImprovedTube: improvedTube, window: win, document: doc, console };
+	vm.createContext(sandbox);
+	vm.runInContext(fs.readFileSync(SHORTCUTS_SRC, 'utf8'), sandbox);
+
+	improvedTube.shortcutsInit();
+	return { improvedTube, win, doc };
+}
+
+describe('Issue #3986: shortcut stuck-key recovery', () => {
+	test('a missed keyup leaves a key stuck (the failure condition)', () => {
+		const { improvedTube } = loadShortcuts();
+		improvedTube.input.pressed.keys.add(70); // keydown for "f" whose keyup never arrived
+		// shortcutsHandler requires an exact size match, so this stuck key blocks
+		// every shortcut (e.g. Space, size 1) until pressed.keys is cleared.
+		expect(improvedTube.input.pressed.keys.size).toBe(1);
+	});
+
+	test('window blur clears the stuck key (recovery without reload)', () => {
+		const { improvedTube, win } = loadShortcuts();
+		improvedTube.input.pressed.keys.add(70);
+		win.dispatchEvent(new Event('blur'));
+		expect(improvedTube.input.pressed.keys.size).toBe(0);
+	});
+
+	test('tab hide (visibilitychange) clears the stuck key', () => {
+		const { improvedTube, doc } = loadShortcuts();
+		improvedTube.input.pressed.keys.add(70);
+		doc.hidden = true;
+		doc.dispatchEvent(new Event('visibilitychange'));
+		expect(improvedTube.input.pressed.keys.size).toBe(0);
+	});
+
+	test('yt-navigate-start (SPA navigation) clears the stuck key', () => {
+		const { improvedTube, doc } = loadShortcuts();
+		improvedTube.input.pressed.keys.add(70);
+		doc.dispatchEvent(new Event('yt-navigate-start'));
+		expect(improvedTube.input.pressed.keys.size).toBe(0);
+	});
+
+	test('visibilitychange while still visible does NOT clear (only on hide)', () => {
+		const { improvedTube, doc } = loadShortcuts();
+		improvedTube.input.pressed.keys.add(70);
+		doc.hidden = false;
+		doc.dispatchEvent(new Event('visibilitychange'));
+		expect(improvedTube.input.pressed.keys.size).toBe(1);
+	});
+});


### PR DESCRIPTION
Fixes #3986.

## Problem
When the internet connection is unstable, the extension's keyboard shortcuts stop working and stay broken until the page is reloaded.

## Root cause
`shortcutsHandler()` only fires a shortcut when `input.pressed.keys` is an **exact** size match. If a single `keyup` is ever missed — which happens when focus jumps to the player / an ad iframe, on an SPA navigation, or when the MV3 service worker is suspended (all common during network churn) — the released key stays stuck in `input.pressed.keys`. From then on no shortcut can match, so **every** shortcut silently stops working.

The only existing recovery is the `improvedtube-blur` event, but it's dispatched from the extension side (`core.js`) over the same messaging path / background worker that the network issue can break — so recovery may never fire, and shortcuts stay dead until a manual reload.

## Fix
Bind the existing pressed-keys reset to native, in-page events in `shortcutsInit()`:

- `window` `blur`
- `document` `visibilitychange` (when the tab is hidden)
- `yt-navigate-start`

These run entirely in the page, so a stuck key clears immediately on any focus loss / tab switch / navigation, with no dependence on the background service worker. The listeners are bound once, and clearing an already-empty set is a harmless no-op — so it never changes behaviour while shortcuts are working normally.

## Tests
Adds `tests/unit/shortcuts-stuck-key-recovery.test.js` (5 cases). It loads the real `shortcuts.js` in a `vm` sandbox, plants a stuck key, and asserts that `blur`, `visibilitychange` (hidden), and `yt-navigate-start` each recover it — and that `visibilitychange` while still visible does not. All 5 pass.

> The pre-existing `day-of-week` and `hide-sidebar-transcript` suite failures are timezone/environment-dependent and unrelated to this change.
