### PR TITLE
fix: prepare Safari App Store packaging

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -47,6 +47,36 @@ def _sanitize_name_for_store(name, store):
 		sanitized = sanitized.replace("'", "*")
 	return sanitized
 
+def _short_app_store_locale_text(text, max_bytes=112):
+	text = re.sub(r'\s+', ' ', text or '').strip()
+
+	if len(text.encode('utf8')) <= max_bytes:
+		return text
+
+	words = text.split(' ')
+	shortened = ''
+
+	for word in words:
+		next_text = word if not shortened else shortened + ' ' + word
+
+		if len(next_text.encode('utf8')) > max_bytes:
+			break
+
+		shortened = next_text
+
+	if shortened:
+		return shortened
+
+	shortened = ''
+
+	for char in text:
+		if len((shortened + char).encode('utf8')) > max_bytes:
+			break
+
+		shortened += char
+
+	return shortened
+
 #---------------------------------------------------------------
 # 2.0 CHROMIUM
 #---------------------------------------------------------------
@@ -203,6 +233,41 @@ def safari():
 	)
 
 	os.chdir(temporary_path)
+
+	for root, dirs, files in os.walk('_locales'):
+		if 'messages.json' not in files:
+			continue
+
+		path = os.path.join(root, 'messages.json')
+
+		with open(path, 'r+', encoding='utf8') as json_file:
+			data = json.load(json_file)
+			changed = False
+
+			for key, value in data.items():
+				if isinstance(value, dict):
+					message = value.get('message')
+					short_message = _short_app_store_locale_text(message)
+
+					if key == 'description_ext' and message != short_message:
+						value['message'] = short_message
+						changed = True
+
+					description = value.get('description')
+					short_description = _short_app_store_locale_text(description or short_message or key)
+
+					if description != short_description:
+						value['description'] = short_description
+						changed = True
+
+					if value.get('placeholders') == {}:
+						del value['placeholders']
+						changed = True
+
+			if changed:
+				json_file.seek(0)
+				json.dump(data, json_file, indent=4, sort_keys=True, ensure_ascii=False)
+				json_file.truncate()
 
 	with open('manifest.json', 'r+', encoding='utf8') as json_file:
 		data = json.load(json_file)

--- a/build/build.py
+++ b/build/build.py
@@ -27,6 +27,10 @@ import re
 #---------------------------------------------------------------
 
 EXCLUDE_TOP_LEVEL = {
+	'.editorconfig',
+	'.idea',
+	'build',
+	'node_modules',
 	'tests',
 	'jest.config.js',
 	'package-lock.json',
@@ -205,6 +209,8 @@ def safari():
 
 		version = data['version']
 		permissions = data.get('permissions', [])
+
+		data['name'] = 'Improve YouTube! for YouTube & Videos'
 
 		if 'scripting' not in permissions:
 			permissions.append('scripting')

--- a/manifest.json
+++ b/manifest.json
@@ -72,7 +72,6 @@
         "js&css/web-accessible/www.youtube.com/themes.js",
         "js&css/web-accessible/www.youtube.com/playlist.js",
         "js&css/web-accessible/www.youtube.com/playlist-complete-playlist.js",
-        "js&css/web-accessible/www.youtube.com/playlist-cleaner.js",
         "js&css/web-accessible/www.youtube.com/channel.js",
         "js&css/web-accessible/www.youtube.com/shortcuts.js",
         "js&css/web-accessible/www.youtube.com/blocklist.js",


### PR DESCRIPTION
## Problem
Safari App Store packaging needs a store-safe extension name and the `scripting` permission, but those should only apply to the Safari build. The packaged extension also included local/dev artifacts, the shared manifest referenced a missing web_accessible_resources file, and App Store Connect rejects Safari extension locale files when message entries are missing valid short metadata.

## Root cause
The existing Safari target already lives in `build/build.py -safari`, but the App Store-specific adjustments were not applied there. That made it easy for Safari-only requirements to leak into the shared extension metadata, or for packaging work to bypass the existing Safari build path.

App Store Connect also validates the generated `_locales/*/messages.json` entries more strictly than browser runtimes do. It reports those failures as generic description-field errors, but the affected locales also had localized `description_ext` messages that exceeded the App Store limit.

## Fix
Keep the existing `python3 build/build.py -safari` flow and apply the App Store packaging changes inside that Safari target:

- Use the App Store-safe extension name only for Safari packaging.
- Add the Safari-only `scripting` permission only during Safari packaging.
- Exclude local/dev artifacts from packaged builds.
- Remove the missing `playlist-cleaner.js` web_accessible_resources entry from the shared manifest.
- Normalize packaged Safari locale message metadata so every generated message entry has a valid App Store `description` string.
- Preserve localized message text whenever it fits the App Store limit, and shorten over-limit `description_ext` values from that locale’s own text instead of replacing them with English.

## Validation
Built the Safari package, checked that every web_accessible_resources path exists, and validated that packaged locale message descriptions and `description_ext` messages are present strings with UTF-8 length <= 112 bytes.
