### PR TITLE
fix: avoid Safari DOM fallback for page-world injection

### DIFF
--- a/js&css/extension/init.js
+++ b/js&css/extension/init.js
@@ -104,8 +104,8 @@ if ((navigator.userAgent.indexOf('Safari') !== -1
 		if (response && response.ok) {
 			finishPageWorldInit();
 		} else {
-			console.warn('Falling back to DOM injection for page-world scripts', chrome.runtime.lastError?.message || response?.error);
-			extension.inject(pageWorldFiles.slice(), finishPageWorldInit);
+			console.warn('[ImprovedTube] Safari MAIN-world injection failed:', chrome.runtime.lastError?.message || response?.error);
+			finishPageWorldInit();
 		}
 	});
 } else {


### PR DESCRIPTION
## Problem
Safari page-world scripts should be injected through the extension API path. When that path fails, the current code falls back to DOM script injection, which is not reliable in Safari and leaves startup in the wrong state.

## Root cause
The fallback assumes a DOM-injected page script can stand in for Safari MAIN-world extension injection. In the production Safari build, that path does not behave like the local extension API injection path and can make the extension appear partially initialized.

## Fix
Remove the Safari-only DOM fallback. If extension API injection fails, log the Safari injection failure and continue extension init instead of attempting the unsupported fallback.

The successful injection path still requires the Safari-only `scripting` permission from #3989.

## Validation
Ran `node --check js&css/extension/init.js`.
