### PR TITLE
fix: insert below-player buttons after subscribe renderer loads

### DIFF
--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -137,6 +137,7 @@ ImprovedTube.ytElementsHandler = function (node) {
 		|| (name === 'YTD-BUTTON-RENDERER' && node.classList.contains('ytd-c4-tabbed-header-renderer'))) {
 		ImprovedTube.blocklistChannel(node);
 		ImprovedTube.elements.subscribe_button = node;
+		ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer();
 	} else if (id === 'chat-messages') {
 		this.elements.livechat.button = document.querySelector('[aria-label="Close"]');
 		// console.log(document.querySelector('[aria-label="Close"]'))


### PR DESCRIPTION
## Problem
Below-player buttons can miss YouTube's initial render because the first insertion pass may run before `#subscribe-button` exists. That makes the buttons appear only on some refreshes depending on YouTube's DOM timing.

## Root cause
The existing insertion function is real and already handles the button placement, but it may run before the subscribe button renderer has been added to the page. The existing mutation handler already detects the subscribe renderer later; it just did not re-run the insertion hook at that point.

## Fix
Call the existing `ImprovedTube.improvedtubeYoutubeButtonsUnderPlayer()` hook when the subscribe button renderer is observed.

This keeps the change intentionally small: no retry loop, no timer, and no new timing framework.

## Validation
Ran `node --check js&css/web-accessible/functions.js`.
