### PR TITLE
fix: remove unused custom encryption helpers

### DIFF
--- a/menu/satus.js
+++ b/menu/satus.js
@@ -424,54 +424,6 @@ satus.getAnimationDuration = function (element) {
 };
 
 /*--------------------------------------------------------------
-
-# CRYPTION
-
---------------------------------------------------------------*/
-/*--------------------------------------------------------------
-# DECRYPTION
---------------------------------------------------------------*/
-satus.decrypt = async function (text, password) {
-	var iv = text.slice(0, 24).match(/.{2}/g).map(byte => parseInt(byte, 16)),
-		algorithm = {
-			name: 'AES-GCM',
-			iv: new Uint8Array(iv)
-		};
-
-	try {
-		var data = new TextDecoder().decode(await crypto.subtle.decrypt(
-			algorithm,
-			await crypto.subtle.importKey(
-				'raw',
-				await crypto.subtle.digest('SHA-256', new TextEncoder().encode(password)),
-				algorithm,
-				false, ['decrypt']
-			),
-			new Uint8Array(atob(text.slice(24)).match(/[\s\S]/g).map(ch => ch.charCodeAt(0)))
-		));
-	} catch (err) {
-		return false;
-	}
-
-	return data;
-};
-/*--------------------------------------------------------------
-# ENCRYPTION
---------------------------------------------------------------*/
-satus.encrypt = async function (text, password) {
-	var iv = crypto.getRandomValues(new Uint8Array(12)),
-		algorithm = {
-			name: 'AES-GCM',
-			iv: iv
-		};
-
-	return Array.from(iv).map(b => ('00' + b.toString(16)).slice(-2)).join('') + btoa(Array.from(new Uint8Array(await crypto.subtle.encrypt(
-		algorithm,
-		await crypto.subtle.importKey('raw', await crypto.subtle.digest('SHA-256', new TextEncoder().encode(password)), algorithm, false, ['encrypt']),
-		new TextEncoder().encode(text)
-	))).map(byte => String.fromCharCode(byte)).join(''));
-};
-/*--------------------------------------------------------------
 # EVENTS
 
 --------------------------------------------------------------*/


### PR DESCRIPTION
## Problem
`satus` defines AES-GCM encrypt/decrypt helpers that are not referenced anywhere in the extension. Their presence complicates the App Store encryption declaration and international compliance even though the shipped app does not need custom encryption.

## Root cause
The helpers appear to be dead utility code. Keeping unused encryption code in the shipped extension makes the App Store review path harder to explain without adding runtime value.

## Fix
Remove the unused custom encryption helpers instead of documenting encryption that the app does not actually use.

If the project wants to keep these helpers for future use or another browser-specific path, this can be adjusted, but the current extension does not reference them.

## Validation
Searched for references and confirmed AES-GCM is absent from the packaged extension.
