### PR TITLE
fix: stabilize day-of-week date tests

### DIFF
--- a/tests/unit/day-of-week.test.js
+++ b/tests/unit/day-of-week.test.js
@@ -8,28 +8,28 @@ describe('Day of Week indexing', () => {
 
 	test('Sunday (getDay=0) should map to days[0]="Sunday"', () => {
 		// January 19, 2025 is a Sunday
-		const sundayDate = new Date('2025-01-19');
+		const sundayDate = new Date(2025, 0, 19);
 		expect(sundayDate.getDay()).toBe(0);
 		expect(days[sundayDate.getDay()]).toBe('Sunday');
 	});
 
 	test('Monday (getDay=1) should map to days[1]="Monday"', () => {
 		// January 20, 2025 is a Monday
-		const mondayDate = new Date('2025-01-20');
+		const mondayDate = new Date(2025, 0, 20);
 		expect(mondayDate.getDay()).toBe(1);
 		expect(days[mondayDate.getDay()]).toBe('Monday');
 	});
 
 	test('Friday (getDay=5) should map to days[5]="Friday"', () => {
 		// January 16, 2026 is a Friday (from issue #3556)
-		const fridayDate = new Date('2026-01-16');
+		const fridayDate = new Date(2026, 0, 16);
 		expect(fridayDate.getDay()).toBe(5);
 		expect(days[fridayDate.getDay()]).toBe('Friday');
 	});
 
 	test('Saturday (getDay=6) should map to days[6]="Saturday"', () => {
 		// January 17, 2026 is a Saturday
-		const saturdayDate = new Date('2026-01-17');
+		const saturdayDate = new Date(2026, 0, 17);
 		expect(saturdayDate.getDay()).toBe(6);
 		expect(days[saturdayDate.getDay()]).toBe('Saturday');
 	});


### PR DESCRIPTION
## Problem
The day-of-week tests use `YYYY-MM-DD` string parsing, which JavaScript treats as UTC. That can shift the local day and make `getDay()` assertions depend on timezone.

## Root cause
`new Date('2025-01-19')` creates a UTC timestamp, while the assertions read the local day. Timezones west or east of UTC can observe a different local date than the one intended by the test.

## Fix
Switch the test dates to numeric `Date` construction so they are created in local time.

## Validation
Ran `npx jest tests/unit/day-of-week.test.js --runInBand`.
