### PR TITLE
fix: resolve player initialization issues with fallback observer

### DIFF
--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -181,21 +181,21 @@ ImprovedTube.ytElementsHandler = function (node) {
 			ImprovedTube.playerSize();
 			if (typeof this.storage.ads !== 'undefined' && this.storage.ads !== "all_videos") {
 				new MutationObserver(function (mutationList) {
-					for (var i = 0, l = mutationList.length; i < l; i++) {
-						var mutation = mutationList[i];
+					for (let i = 0, l = mutationList.length; i < l; i++) {
+						const mutation = mutationList[i];
 
 						if (mutation.type === 'childList') {
-							for (var j = 0, k = mutation.addedNodes.length; j < k; j++) {
-								var node = mutation.addedNodes[j];
+							for (let j = 0, k = mutation.addedNodes.length; j < k; j++) {
+								const addedNode = mutation.addedNodes[j];
 
-								if (node instanceof Element
-									&& node.querySelector('ytp-ad-player-overlay, .ytp-ad-text, .ytp-ad-overlay-close-container, ytd-button-renderer#dismiss-button, *[id^="ad-text"], *[id^="skip-button"], .ytp-ad-skip-button.ytp-button, .ytp-ad-skip-button-modern.ytp-button') !== null) {
-									ImprovedTube.playerAds(node);
+								if (addedNode instanceof Element
+									&& addedNode.querySelector('ytp-ad-player-overlay, .ytp-ad-text, .ytp-ad-overlay-close-container, ytd-button-renderer#dismiss-button, *[id^="ad-text"], *[id^="skip-button"], .ytp-ad-skip-button.ytp-button, .ytp-ad-skip-button-modern.ytp-button') !== null) {
+									ImprovedTube.playerAds(addedNode);
 								}
 							}
 						}
 						if (mutation.type === 'attributes' && mutation.attributeName === 'id' && mutation.target.querySelector('*[id^="ad-text"], *[id^="skip-button"], .ytp-ad-skip-button-modern.ytp-button',)) {
-							ImprovedTube.playerAds(node);
+							ImprovedTube.playerAds(addedNode);
 						}
 					}
 				}).observe(node, {
@@ -204,21 +204,52 @@ ImprovedTube.ytElementsHandler = function (node) {
 				});
 			}
 
-			new MutationObserver(function (mutationList) {
-				for (var i = 0, l = mutationList.length; i < l; i++) {
-					var mutation = mutationList[i];
-
-					if (mutation.type === 'attributes') {
-						if (mutation.attributeName === 'style') {
+			// Watches the thumbnail element for style changes (used for HD thumbnail swap)
+			const observePlayerThumbnail = (thumbnailEl) => {
+				new MutationObserver((mutationList) => {
+					for (const mutation of mutationList) {
+						if (mutation.type === 'attributes' && mutation.attributeName === 'style') {
 							ImprovedTube.playerHdThumbnail();
 						}
 					}
+				}).observe(thumbnailEl, {
+					attributes: true,
+					attributeFilter: ['style'],
+				});
+			}
+
+			// Retrieves the specified class element from the node or its descendants.
+			const resolveNode = (node, cls) => {
+				return node.classList.contains(cls) ? node : node.querySelector('.' + cls);
+			}
+
+			// Fallback observer to capture elements that might not have been available during the initial querySelector.
+			let thumbnailObserverAttached = false;
+			const observer = new MutationObserver((mutationList) => {
+				const els = ImprovedTube.elements;
+				for (const mutation of mutationList) {
+					if (mutation.type !== 'childList') continue;
+					for (const addedNode of mutation.addedNodes) {
+						if (!(addedNode instanceof Element)) continue;
+						els.player_left_controls ??= resolveNode(addedNode, 'ytp-left-controls');
+						els.player_right_controls ??= resolveNode(addedNode, 'ytp-right-controls')
+						els.player_thumbnail ??= resolveNode(addedNode, 'ytp-cued-thumbnail-overlay-image');
+						els.player_subtitles_button ??= resolveNode(addedNode, 'ytp-subtitles-button');
+					}
 				}
-			}).observe(ImprovedTube.elements.player_thumbnail, {
-				attributes: true,
-				attributeFilter: ['style'],
-				childList: false,
-				subtree: false
+				// Attach the thumbnail observer only once
+				if (!thumbnailObserverAttached && els.player_thumbnail) {
+					thumbnailObserverAttached = true;
+					observePlayerThumbnail(els.player_thumbnail);
+				}
+				// Stop observing once all elements have been found
+				if (els.player_left_controls && els.player_right_controls && els.player_thumbnail && els.player_subtitles_button) {
+					observer.disconnect();
+				}
+			});
+			observer.observe(node, {
+				childList: true,
+				subtree: true
 			});
 		}
 	} else if (name === 'YTD-WATCH-FLEXY') {


### PR DESCRIPTION
closes #3982 
closes #4007
closes #4011
closes #4014

# Summary

Fixes initialization bugs that caused buttons and UI elements to disappear under certain conditions. Added a fallback observer to capture elements that might not have been available during the initial querySelector.

# Description

In the initialization process when the `MutationObserver` in `function.js` finds `#movie_player`, it attempts to retrieve child nodes. However, likely due to a specification change on YouTube's end, this process could occasionally fail.



Specifically, elements other than `player` and `video` were becoming `null` in the following snippet, which triggered subsequent errors:

```javascript
ImprovedTube.elements.player = node;
ImprovedTube.elements.video = node.querySelector('video');
ImprovedTube.elements.player_left_controls = node.querySelector('.ytp-left-controls');
ImprovedTube.elements.player_right_controls = node.querySelector('.ytp-right-controls');
ImprovedTube.elements.player_thumbnail = node.querySelector('.ytp-cued-thumbnail-overlay-image');
ImprovedTube.elements.player_subtitles_button = node.querySelector('.ytp-subtitles-button');
```

To resolve this, I have added a mechanism using a MutationObserver to populate these values as soon as each node is generated.

## Steps to Reproduce

1. Access the YouTube Home or History page via a direct link (the error in function.js will occur at this point).
```
Uncaught TypeError: MutationObserver.observe: Argument 1 is not an object.
    ytElementsHandler moz-extension://6b523f39-dd5d-4710-83ed-aeaf198a3892/js&css/web-accessible/functions.js:216
    childHandler moz-extension://6b523f39-dd5d-4710-83ed-aeaf198a3892/js&css/web-accessible/functions.js:10
    observer moz-extension://6b523f39-dd5d-4710-83ed-aeaf198a3892/js&css/web-accessible/init.js:13
    insertBefore https://www.youtube.com/s/_/ytmainappweb/_/js/k=ytmainappweb.kevlar_base.en_US.lMdjITFD_rE.es5.O/am=AAAAABAADAHA/d=1/br=1/rs=AGKMywFoJp3d4Ti6f9yvwK-t-zUbJ25o3A/m=kevlar_base_module,kevlar_main_module,kevlar_base_sync_mod_chunk:3607
    O8 https://www.youtube.com/s/player/5b27766f/player_es6.vflset/en_US/base.js:301
    kv https://www.youtube.com/s/player/5b27766f/player_es6.vflset/en_US/base.js:5474
    gJi https://www.youtube.com/s/player/5b27766f/player_es6.vflset/en_US/base.js:5463
    <anonymous> https://www.youtube.com/s/player/5b27766f/player_es6.vflset/en_US/base.js:8406
```
2. From that state, navigate to any regular video or Shorts video.
3. The reported issue is highly likely to manifest.
  - #3982
  - #4007
  - #4011
  - #4014

# Environment
Browser: Firefox Developer Edition 153 / Firefox 152
Extension: ImprovedTube 4.2028 (No other extensions installed)
OS: macOS 15.7