### PR TITLE
Fix #4016 - Shorts redirect now works on every navigation

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -2389,6 +2389,8 @@ ImprovedTube.redirectShortsToWatch = function () {
             // in YouTube's SPA without a full page reload, then fire a
             // yt-navigate-finish so YouTube re-renders the standard player.
             const newUrl = `${window.location.origin}/watch?v=${videoId}`;
+											// If there ever are parameters in the URL:
+									  // const newUrl = (() => { const u = new URL("/watch", window.location.origin); const p = new URLSearchParams(window.location.search); p.set("v", videoId); u.search = p.toString(); u.hash = window.location.hash; return u.toString(); })();
             if (window.location.href !== newUrl) {
                 console.log(`ImprovedTube: Redirecting Shorts to Watch: ${window.location.href} -> ${newUrl}`);
                 window.history.replaceState(window.history.state, '', newUrl);
@@ -2396,7 +2398,6 @@ ImprovedTube.redirectShortsToWatch = function () {
             }
         }
     }
-};
 
 // Re-run on every YouTube client-side navigation (Shorts swipe uses pushState)
 if (!window.__itShortsRedirectPatched__) {
@@ -2421,6 +2422,7 @@ if (!window.__itShortsRedirectPatched__) {
     window.addEventListener('popstate', function () {
         ImprovedTube.redirectShortsToWatch();
     });
+}
 }
 /*------------------------------------------------------------------------------
 YOUTUBE RETURN BUTTON IN FULLSCREEN

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -2383,17 +2383,45 @@ ImprovedTube.redirectShortsToWatch = function () {
     }
     const currentPath = window.location.pathname;
     if (currentPath.startsWith('/shorts/')) {
-        const videoId = currentPath.substring('/shorts/'.length); 
+        const videoId = currentPath.substring('/shorts/'.length);
         if (videoId) {
-            const newUrl = `${window.location.origin}/watch?v=${videoId}${window.location.search}`;
+            // Use history.replaceState instead of location.replace so we stay
+            // in YouTube's SPA without a full page reload, then fire a
+            // yt-navigate-finish so YouTube re-renders the standard player.
+            const newUrl = `${window.location.origin}/watch?v=${videoId}`;
             if (window.location.href !== newUrl) {
                 console.log(`ImprovedTube: Redirecting Shorts to Watch: ${window.location.href} -> ${newUrl}`);
-                window.location.replace(newUrl); 
+                window.history.replaceState(window.history.state, '', newUrl);
+                window.dispatchEvent(new PopStateEvent('popstate', { state: window.history.state }));
             }
         }
     }
 };
 
+// Re-run on every YouTube client-side navigation (Shorts swipe uses pushState)
+if (!window.__itShortsRedirectPatched__) {
+    window.__itShortsRedirectPatched__ = true;
+
+    const _push    = history.pushState.bind(history);
+    const _replace = history.replaceState.bind(history);
+
+    history.pushState = function (state, title, url) {
+        _push(state, title, url);
+        ImprovedTube.redirectShortsToWatch();
+    };
+
+    history.replaceState = function (state, title, url) {
+        _replace(state, title, url);
+        // Guard: don't recurse into our own replaceState call above
+        if (url && String(url).indexOf('/shorts/') !== -1) {
+            ImprovedTube.redirectShortsToWatch();
+        }
+    };
+
+    window.addEventListener('popstate', function () {
+        ImprovedTube.redirectShortsToWatch();
+    });
+}
 /*------------------------------------------------------------------------------
 YOUTUBE RETURN BUTTON IN FULLSCREEN
 ------------------------------------------------------------------------------*/

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -2393,8 +2393,12 @@ ImprovedTube.redirectShortsToWatch = function () {
 									  // const newUrl = (() => { const u = new URL("/watch", window.location.origin); const p = new URLSearchParams(window.location.search); p.set("v", videoId); u.search = p.toString(); u.hash = window.location.hash; return u.toString(); })();
             if (window.location.href !== newUrl) {
                 console.log(`ImprovedTube: Redirecting Shorts to Watch: ${window.location.href} -> ${newUrl}`);
-                window.history.replaceState(window.history.state, '', newUrl);
-                window.dispatchEvent(new PopStateEvent('popstate', { state: window.history.state }));
+                try {  
+																	window.history.replaceState(window.history.state, "", newUrl);
+																	window.dispatchEvent(new PopStateEvent("popstate", { state: window.history.state }));
+																} catch { 
+																	window.location.replace(newUrl);  
+																}
             }
         }
     }


### PR DESCRIPTION
## What was the bug?
When "Redirect Shorts to Standard Player" was turned on, 
it only worked on the first Short. Going to the next Short 
would stay in the Shorts player.

## Why did it happen?
The old code used `window.location.replace()` which causes 
a full page reload. YouTube moves between Shorts using 
`history.pushState` internally (no page reload), so the 
function never ran again after the first time.

## What did I fix?
- Changed `window.location.replace()` to `history.replaceState()` 
  so no full page reload happens
- Added patches to `history.pushState` and `history.replaceState` 
  so the redirect runs on every navigation
- Added a `popstate` listener for back/forward buttons

Closes #4016