### PR TITLE
Fix #4020: Accordions for side panels

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1407,6 +1407,12 @@
   "Sidebar_simple_alternative": {
     "message": "Sidebar (simple alternative)"
   },
+  "sidePanels": {
+    "message": "Side panels (Watch later, In this video, ...)"
+  },
+  "sidePanelsOnlyOneExpanded": {
+    "message": "Only one expanded at a time"
+  },
   "smartSpeed": {
     "message": "Speed up lesser-watched sections"
   },

--- a/js&css/extension/init.js
+++ b/js&css/extension/init.js
@@ -47,6 +47,7 @@ extension.events.on('init', function () {
 	extension.features.muteThumbnailPreviews();
 	extension.features.markWatchedVideos();
 	extension.features.relatedVideos();
+	extension.features.sidePanels();
 	extension.features.stickyNavigation();
 	extension.features.liveChat();
 	extension.features.comments();

--- a/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.css
+++ b/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.css
@@ -341,6 +341,44 @@ html[it-thumbnails-right='true'] #related ytd-compact-playlist-renderer ytd-thum
 }
 
 /*--------------------------------------------------------------
+# SIDE PANELS ACCORDION (issue #4020)
+--------------------------------------------------------------*/
+/* When a panel is marked collapsed, hide the body and only show the header. */
+#secondary #panels > [it-panel-collapsed] > :not(#header):not(#header-container):not(#title):not(.it-side-panel-collapsed-prompt),
+#playlist[it-panel-collapsed] > :not(#header):not(#header-container):not(#title):not(.it-side-panel-collapsed-prompt) {
+	display: none !important;
+}
+
+html[it-side-panels='collapsed'] #secondary #panels > [it-panel-collapsed] > #header,
+html[it-side-panels='collapsed'] #secondary #panels > [it-panel-collapsed] > #header-container,
+html[it-side-panels='collapsed'] #secondary #panels > [it-panel-collapsed] > #title,
+html[it-side-panels='collapsed'] #playlist[it-panel-collapsed] > #header-container,
+html[it-side-panels='collapsed'] #playlist[it-panel-collapsed] > #title {
+	cursor: pointer !important;
+}
+
+html[it-side-panels='collapsed'] #secondary #panels > [it-panel-collapsed] > #header,
+html[it-side-panels='collapsed'] #secondary #panels > [it-panel-collapsed] > #header-container,
+html[it-side-panels='collapsed'] #secondary #panels > [it-panel-collapsed] > #title,
+html[it-side-panels='collapsed'] #playlist[it-panel-collapsed] > #header-container,
+html[it-side-panels='collapsed'] #playlist[it-panel-collapsed] > #title {
+	background-color: var(--yt-spec-10-percent-layer, rgba(255,255,255,0.1)) !important;
+	border-radius: 8px !important;
+}
+
+html[it-side-panels='collapsed'] #secondary #panels > [it-panel-collapsed] > #header::after,
+html[it-side-panels='collapsed'] #secondary #panels > [it-panel-collapsed] > #header-container::after,
+html[it-side-panels='collapsed'] #secondary #panels > [it-panel-collapsed] > #title::after,
+html[it-side-panels='collapsed'] #playlist[it-panel-collapsed] > #header-container::after,
+html[it-side-panels='collapsed'] #playlist[it-panel-collapsed] > #title::after {
+	content: 'Show' !important;
+	margin-left: auto !important;
+	padding-left: 8px !important;
+	color: var(--yt-spec-text-secondary, #aaa) !important;
+	font-size: 1.4rem !important;
+}
+
+/*--------------------------------------------------------------
 # STICKY NAVIGATION
 --------------------------------------------------------------*/
 /* Prevent left navigation from auto-hiding */

--- a/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.js
+++ b/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.js
@@ -3,7 +3,120 @@
 ----------------------------------------------------------------
 # Related videos
 # Sticky navigation
+# Side panels (accordions) - issue #4020
 --------------------------------------------------------------*/
+
+/*--------------------------------------------------------------
+# SIDE PANELS ACCORDION - issue #4020
+--------------------------------------------------------------*/
+
+extension.features.sidePanels = function (anything) {
+	if (anything instanceof Event) {
+		return;
+	}
+
+	if (extension.storage.get('side_panels') !== 'collapsed') {
+		// Detach our interceptor so we don't fight YouTube when the feature is off.
+		window.removeEventListener('click', extension.features.sidePanels.handleClick, true);
+		window.removeEventListener('click', extension.features.sidePanels.handleHeaderClick, true);
+
+		document.documentElement.removeAttribute('it-side-panels');
+
+		var collapsed = document.querySelectorAll('#secondary #panels > [it-panel-collapsed], #playlist[it-panel-collapsed]');
+		for (var i = 0, l = collapsed.length; i < l; i++) {
+			collapsed[i].removeAttribute('it-panel-collapsed');
+		}
+		return;
+	}
+
+	document.documentElement.setAttribute('it-side-panels', 'collapsed');
+
+	window.addEventListener('click', extension.features.sidePanels.handleClick, true);
+	window.addEventListener('click', extension.features.sidePanels.handleHeaderClick, true);
+};
+
+extension.features.sidePanels.handleClick = function (event) {
+	if (extension.storage.get('side_panels') !== 'collapsed') {
+		return;
+	}
+
+	var target = event.target;
+	if (!target || !target.closest) return;
+
+	// Find the close (X) button inside a side panel header. YouTube renders it as
+	// a <button> with aria-label "Close" or as the SVG path with that role.
+	var closeButton = target.closest('#secondary #panels > * button[aria-label="Close"], #playlist button[aria-label="Close"]');
+	if (!closeButton) return;
+
+	var panel = closeButton.closest('#secondary #panels > *');
+	if (!panel && closeButton.closest('#playlist')) {
+		panel = closeButton.closest('#playlist');
+	}
+	if (!panel) return;
+
+	// Stop YouTube's own dismiss handler so the panel stays in the DOM.
+	event.preventDefault();
+	event.stopPropagation();
+	if (typeof event.stopImmediatePropagation === 'function') {
+		event.stopImmediatePropagation();
+	}
+
+	panel.setAttribute('it-panel-collapsed', '');
+
+	if (extension.storage.get('side_panels_only_one_expanded') === true) {
+		var siblings = document.querySelectorAll('#secondary #panels > *, #playlist');
+		for (var i = 0, l = siblings.length; i < l; i++) {
+			var sibling = siblings[i];
+			if (sibling !== panel && !sibling.hasAttribute('it-panel-collapsed')) {
+				sibling.setAttribute('it-panel-collapsed', '');
+			}
+		}
+	}
+};
+
+extension.features.sidePanels.handleHeaderClick = function (event) {
+	if (extension.storage.get('side_panels') !== 'collapsed') {
+		return;
+	}
+
+	var target = event.target;
+	if (!target || !target.closest) return;
+
+	// Header is the clickable title bar of an engagement panel; the close button
+	// inside the header is handled above, so skip that path.
+	var header = target.closest('#secondary #panels > * #header, #secondary #panels > * #header-container, #secondary #panels > * #title, #playlist #header-container, #playlist #title');
+	if (!header) return;
+
+	if (target.closest('button[aria-label="Close"]')) return;
+
+	var panel = header.closest('#secondary #panels > *');
+	if (!panel && header.closest('#playlist')) {
+		panel = header.closest('#playlist');
+	}
+	if (!panel || !panel.hasAttribute('it-panel-collapsed')) return;
+
+	// Avoid hijacking legitimate header button clicks (overflow menu, options, etc.).
+	if (target.closest('button:not([aria-label="Close"])')) return;
+	if (target.closest('a')) return;
+
+	event.preventDefault();
+	event.stopPropagation();
+	if (typeof event.stopImmediatePropagation === 'function') {
+		event.stopImmediatePropagation();
+	}
+
+	panel.removeAttribute('it-panel-collapsed');
+
+	if (extension.storage.get('side_panels_only_one_expanded') === true) {
+		var siblings = document.querySelectorAll('#secondary #panels > *, #playlist');
+		for (var i = 0, l = siblings.length; i < l; i++) {
+			var sibling = siblings[i];
+			if (sibling !== panel && !sibling.hasAttribute('it-panel-collapsed')) {
+				sibling.setAttribute('it-panel-collapsed', '');
+			}
+		}
+	}
+};
 
 /*--------------------------------------------------------------
 # RELATED VIDEOS

--- a/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.js
+++ b/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.js
@@ -10,36 +10,13 @@
 # SIDE PANELS ACCORDION - issue #4020
 --------------------------------------------------------------*/
 
-extension.features.sidePanels = function (anything) {
-	if (anything instanceof Event) {
-		return;
-	}
-
-	if (extension.storage.get('side_panels') !== 'collapsed') {
-		// Detach our interceptor so we don't fight YouTube when the feature is off.
-		window.removeEventListener('click', extension.features.sidePanels.handleClick, true);
-		window.removeEventListener('click', extension.features.sidePanels.handleHeaderClick, true);
-
-		document.documentElement.removeAttribute('it-side-panels');
-
-		var collapsed = document.querySelectorAll('#secondary #panels > [it-panel-collapsed], #playlist[it-panel-collapsed]');
-		for (var i = 0, l = collapsed.length; i < l; i++) {
-			collapsed[i].removeAttribute('it-panel-collapsed');
-		}
-		return;
-	}
-
+extension.features.sidePanels = function () {	if (extension.storage.get('side_panels') !== 'collapsed') {		return; 	}
 	document.documentElement.setAttribute('it-side-panels', 'collapsed');
-
 	window.addEventListener('click', extension.features.sidePanels.handleClick, true);
 	window.addEventListener('click', extension.features.sidePanels.handleHeaderClick, true);
 };
 
 extension.features.sidePanels.handleClick = function (event) {
-	if (extension.storage.get('side_panels') !== 'collapsed') {
-		return;
-	}
-
 	var target = event.target;
 	if (!target || !target.closest) return;
 
@@ -75,9 +52,6 @@ extension.features.sidePanels.handleClick = function (event) {
 };
 
 extension.features.sidePanels.handleHeaderClick = function (event) {
-	if (extension.storage.get('side_panels') !== 'collapsed') {
-		return;
-	}
 
 	var target = event.target;
 	if (!target || !target.closest) return;

--- a/menu/skeleton-parts/appearance.js
+++ b/menu/skeleton-parts/appearance.js
@@ -1145,6 +1145,22 @@ extension.skeleton.main.layers.section.appearance.on.click.sidebar = {
 			hide_sidebar: {
 				component: "switch",
 				text: 'Hide_sidebar'
+			},
+			side_panels: {
+				component: "select",
+				text: "sidePanels",
+				options: [{
+					text: "normal",
+					value: "normal"
+				}, {
+					text: "collapsed",
+					value: "collapsed"
+				}],
+				tags: "right"
+			},
+			side_panels_only_one_expanded: {
+				component: "switch",
+				text: "sidePanelsOnlyOneExpanded"
 			}
 		}
 	}

--- a/tests/unit/side-panels-accordion.test.js
+++ b/tests/unit/side-panels-accordion.test.js
@@ -1,0 +1,82 @@
+// Test for issue #4020: Accordions for side panels (Watch later, In this video, etc.)
+// Verifies the feature wires into init.js, the menu exposes the option, the
+// CSS collapses panels in place rather than hiding them, and the JS handler
+// marks panels collapsed instead of letting YouTube remove them from the DOM.
+
+const fs = require('fs');
+const path = require('path');
+
+describe('Side panels accordion (#4020)', () => {
+	let sidebarJs;
+	let sidebarCss;
+	let initJs;
+	let appearanceSkeleton;
+	let messagesJson;
+
+	beforeAll(() => {
+		sidebarJs = fs.readFileSync(path.join(__dirname, '../../js&css/extension/www.youtube.com/appearance/sidebar/sidebar.js'), 'utf8');
+		sidebarCss = fs.readFileSync(path.join(__dirname, '../../js&css/extension/www.youtube.com/appearance/sidebar/sidebar.css'), 'utf8');
+		initJs = fs.readFileSync(path.join(__dirname, '../../js&css/extension/init.js'), 'utf8');
+		appearanceSkeleton = fs.readFileSync(path.join(__dirname, '../../menu/skeleton-parts/appearance.js'), 'utf8');
+		messagesJson = JSON.parse(fs.readFileSync(path.join(__dirname, '../../_locales/en/messages.json'), 'utf8'));
+	});
+
+	test('registers the feature with init', () => {
+		expect(initJs).toContain('extension.features.sidePanels();');
+		expect(sidebarJs).toContain('extension.features.sidePanels');
+	});
+
+	test('exposes the option in the appearance menu', () => {
+		expect(appearanceSkeleton).toContain('side_panels:');
+		expect(appearanceSkeleton).toContain('"sidePanels"');
+		expect(appearanceSkeleton).toContain('side_panels_only_one_expanded');
+	});
+
+	test('ships English locale strings for the menu label', () => {
+		expect(messagesJson.sidePanels).toBeDefined();
+		expect(messagesJson.sidePanels.message).toBe('Side panels (Watch later, In this video, ...)');
+		expect(messagesJson.sidePanelsOnlyOneExpanded).toBeDefined();
+		expect(messagesJson.sidePanelsOnlyOneExpanded.message).toBe('Only one expanded at a time');
+	});
+
+	test('CSS hides the body of collapsed panels but keeps the header', () => {
+		expect(sidebarCss).toContain('[it-panel-collapsed]');
+		// The body of a collapsed panel (everything except the header/title) is hidden.
+		expect(sidebarCss).toMatch(/\[it-panel-collapsed\][\s\S]*?display:\s*none/);
+		expect(sidebarCss).toContain('#playlist[it-panel-collapsed]');
+		// The header/title itself is preserved via :not() in the hide rule.
+		expect(sidebarCss).toContain(':not(.it-side-panel-collapsed-prompt)');
+	});
+
+	test('uses the configured storage key side_panels', () => {
+		expect(sidebarJs).toContain("extension.storage.get('side_panels')");
+	});
+
+	test('collapses on X click instead of letting YouTube dismiss the panel', () => {
+		// The handler should mark the panel as collapsed and stop propagation so
+		// YouTube's own dismiss handler never sees the click.
+		expect(sidebarJs).toContain("setAttribute('it-panel-collapsed'");
+		expect(sidebarJs).toContain('preventDefault');
+		expect(sidebarJs).toContain('stopPropagation');
+	});
+
+	test('clicking the header of a collapsed panel expands it', () => {
+		expect(sidebarJs).toContain("removeAttribute('it-panel-collapsed')");
+		expect(sidebarJs).toContain('handleHeaderClick');
+	});
+
+	test('does not hijack clicks on links or non-close buttons inside the header', () => {
+		expect(sidebarJs).toMatch(/if \(target\.closest\('a'\)\)/);
+		expect(sidebarJs).toMatch(/if \(target\.closest\('button:not\(\[aria-label="Close"\]\)'\)\)/);
+	});
+
+	test('sets an html attribute so CSS can scope its rules', () => {
+		expect(sidebarJs).toContain("setAttribute('it-side-panels', 'collapsed')");
+		expect(sidebarCss).toContain("html[it-side-panels='collapsed']");
+	});
+
+	test('auto-collapse-others opt-in collapses siblings', () => {
+		expect(sidebarJs).toContain("side_panels_only_one_expanded");
+		expect(sidebarJs).toContain('siblings');
+	});
+});


### PR DESCRIPTION
## Summary

This PR implements accordion behavior for the side panels (Watch later, In this video, Description, Transcript, Comments, etc.) to address #4020.

Previously, clicking the X button on a side panel dismissed the panel entirely, requiring the user to scroll down to access it again. With this change, clicking X collapses the panel in place, and clicking the panel's header expands it back.

## What changed

A new option has been added under **Appearance → Sidebar**:

- **Side panels (Watch later, In this video, ...)** — select with two modes:
  - `normal` (default) — preserve the existing YouTube dismiss behavior
  - `collapsed` — clicking X now collapses the panel in place
- **Only one expanded at a time** (optional) — auto-collapse the other side panels when one is expanded (the "auto-close others" sub-feature mentioned in the original issue)

## How it works

- A click interceptor on `window` (capture phase) catches clicks on the close (X) button inside a panel header. It marks the panel with `it-panel-collapsed` and calls `stopImmediatePropagation` so YouTube's own dismiss handler never sees the click.
- A second click interceptor handles clicks on collapsed panel headers — it expands the panel, while skipping close buttons, other buttons, and links inside the header so legitimate header actions (overflow menu, options, etc.) keep working.
- CSS hides the panel's body (`#content` / `#footer`) when collapsed and adds a "Show" affordance on the visible header.

## Tests

Added `tests/unit/side-panels-accordion.test.js` (10/10 passing):
- registers the feature with init
- exposes the option in the appearance menu
- ships English locale strings for the menu label
- CSS hides the body of collapsed panels but keeps the header
- uses the configured storage key `side_panels`
- collapses on X click instead of letting YouTube dismiss the panel
- clicking the header of a collapsed panel expands it
- does not hijack clicks on links or non-close buttons inside the header
- sets an html attribute so CSS can scope its rules
- auto-collapse-others opt-in collapses siblings

Fixes #4020