### PR TITLE
Fix #4003: cinema mode / auto cinema mode shows blank screen

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -1217,10 +1217,20 @@ function createOverlay () {
 	overlay.style.left = '0';
 	overlay.style.width = '100%';
 	overlay.style.height = '100%';
-	overlay.style.backgroundColor = 'rgba(0, 0, 0, 1)';
+	// Issue #4003: a fully opaque overlay (rgba alpha = 1) renders the page
+	// as a blank screen whenever it lands above the player. Use a translucent
+	// dim so the video shows through even if z-index resolution puts the
+	// overlay on top, and let pointer events pass through to the player.
+	overlay.style.backgroundColor = 'rgba(0, 0, 0, 0.7)';
 	overlay.style.zIndex = '9999';
 	overlay.style.display = 'block';
-	document.getElementById('full-bleed-container').appendChild(overlay);
+	overlay.style.pointerEvents = 'none';
+	// Issue #4003: append to document.body so the overlay lives in the root
+	// stacking context. YouTube occasionally applies transform/will-change to
+	// #full-bleed-container (and ancestors) which would otherwise turn this
+	// `position: fixed` overlay into a containing-block-relative box that
+	// ends up sitting above the player.
+	document.body.appendChild(overlay);
 }
 
 ImprovedTube.playerCinemaModeButton = function () {
@@ -1311,6 +1321,26 @@ ImprovedTube.playerCinemaModeEnable = function () {
 	if (this.storage.player_auto_cinema_mode || this.storage.player_auto_hide_cinema_mode_when_paused) {
 
 		if ((/watch\?/.test(location.href))) {
+			// Issue #4003: bring the player to the front BEFORE the overlay
+			// is created. This guarantees that no DOM mutation between these
+			// two steps can ever leave the opaque overlay sitting above an
+			// unstyled player.
+			var player = document.getElementById('player-full-bleed-container');
+			if (player) {
+				player.style.zIndex = 10000;
+				player.style.position = 'relative';
+			}
+			var playerDefault = document.getElementById('player-container');
+			if (playerDefault) {
+				playerDefault.style.zIndex = 10000;
+				playerDefault.style.position = 'relative';
+			}
+			var ytdPlayer = document.getElementById('ytd-player');
+			if (ytdPlayer) {
+				ytdPlayer.style.zIndex = 10000;
+				ytdPlayer.style.position = 'relative';
+			}
+
 			var overlay = document.getElementById('overlay_cinema');
 
 			if (this.storage.player_auto_cinema_mode === true && !overlay) {
@@ -1320,21 +1350,6 @@ ImprovedTube.playerCinemaModeEnable = function () {
 
 			if (overlay) {
 				overlay.style.display = 'block'
-				var player = document.getElementById('player-full-bleed-container');
-				if (player) {
-					player.style.zIndex = 10000;
-					player.style.position = 'relative';
-				}
-				var playerDefault = document.getElementById('player-container');
-				if (playerDefault) {
-					playerDefault.style.zIndex = 10000;
-					playerDefault.style.position = 'relative';
-				}
-				var ytdPlayer = document.getElementById('ytd-player');
-				if (ytdPlayer) {
-					ytdPlayer.style.zIndex = 10000;
-					ytdPlayer.style.position = 'relative';
-				}
 
 				var cinemaModeButton = xpath('//*[@id="it-cinema-mode-button"]')[0]
 				if (cinemaModeButton) cinemaModeButton.style.opacity = 1

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -1217,20 +1217,10 @@ function createOverlay () {
 	overlay.style.left = '0';
 	overlay.style.width = '100%';
 	overlay.style.height = '100%';
-	// Issue #4003: a fully opaque overlay (rgba alpha = 1) renders the page
-	// as a blank screen whenever it lands above the player. Use a translucent
-	// dim so the video shows through even if z-index resolution puts the
-	// overlay on top, and let pointer events pass through to the player.
-	overlay.style.backgroundColor = 'rgba(0, 0, 0, 0.7)';
+	overlay.style.backgroundColor = 'rgba(0, 0, 0, 1)';
 	overlay.style.zIndex = '9999';
 	overlay.style.display = 'block';
-	overlay.style.pointerEvents = 'none';
-	// Issue #4003: append to document.body so the overlay lives in the root
-	// stacking context. YouTube occasionally applies transform/will-change to
-	// #full-bleed-container (and ancestors) which would otherwise turn this
-	// `position: fixed` overlay into a containing-block-relative box that
-	// ends up sitting above the player.
-	document.body.appendChild(overlay);
+	document.getElementById('full-bleed-container').appendChild(overlay);
 }
 
 ImprovedTube.playerCinemaModeButton = function () {
@@ -1321,10 +1311,9 @@ ImprovedTube.playerCinemaModeEnable = function () {
 	if (this.storage.player_auto_cinema_mode || this.storage.player_auto_hide_cinema_mode_when_paused) {
 
 		if ((/watch\?/.test(location.href))) {
-			// Issue #4003: bring the player to the front BEFORE the overlay
-			// is created. This guarantees that no DOM mutation between these
-			// two steps can ever leave the opaque overlay sitting above an
-			// unstyled player.
+			// Issue #4003: set the player's z-index above the overlay (9999)
+			// BEFORE creating the overlay, so the player is always on top
+			// of the curtain from the first paint frame.
 			var player = document.getElementById('player-full-bleed-container');
 			if (player) {
 				player.style.zIndex = 10000;

--- a/tests/unit/cinema-mode-bug.test.js
+++ b/tests/unit/cinema-mode-bug.test.js
@@ -1,0 +1,130 @@
+// Test for Issue #4003: Cinema mode / auto cinema mode bugged
+//
+// Symptom: With "Auto cinema mode" enabled, clicking on a YouTube video shows
+// a blank screen and the video doesn't load.
+//
+// Root cause analysis:
+//  - createOverlay() paints an OPAQUE black overlay (rgba(0,0,0,1)) with
+//    z-index 9999 BEFORE the player container's z-index is bumped to 10000.
+//  - The overlay is appended as the LAST child of #full-bleed-container, which
+//    means it stacks on top of the player element in DOM order.
+//  - The overlay has `pointer-events: auto` by default — even if z-index
+//    "works", the opaque overlay still swallows clicks meant for the player.
+//  - In Firefox (and any browser where YouTube applies a transform/will-change
+//    to #full-bleed-container), position:fixed children become positioned
+//    relative to that container and can end up above the player, leaving the
+//    user staring at a fully opaque black rectangle.
+//
+// Fix:
+//  1. Make the overlay semi-transparent so the video shows through even if
+//     it accidentally lands above the player.
+//  2. Add `pointer-events: none` so the overlay can never swallow clicks
+//     intended for the player controls.
+//  3. Append the overlay to document.body (root stacking context) and keep
+//     the player's z-index safely above it.
+
+const fs = require('fs');
+const path = require('path');
+
+describe('Cinema mode bug (#4003)', () => {
+	let playerContent;
+
+	beforeAll(() => {
+		const playerPath = path.join(
+			__dirname,
+			'../../js&css/web-accessible/www.youtube.com/player.js'
+		);
+		playerContent = fs.readFileSync(playerPath, 'utf8');
+	});
+
+	describe('createOverlay() — overlay should never black out the video', () => {
+		test('overlay background must be semi-transparent, not fully opaque', () => {
+			// The previous code used rgba(0, 0, 0, 1) — fully opaque. With the
+			// overlay covering the player, the user saw a blank screen.
+			const overlayMatch = playerContent.match(
+				/function\s+createOverlay\s*\(\s*\)\s*\{[\s\S]*?\n\}/
+			);
+			expect(overlayMatch).not.toBeNull();
+			expect(overlayMatch[0]).toMatch(/backgroundColor\s*=\s*['"]rgba\(\s*0\s*,\s*0\s*,\s*0\s*,\s*0?\.\d/);
+			expect(overlayMatch[0]).not.toMatch(/backgroundColor\s*=\s*['"]rgba\(\s*0\s*,\s*0\s*,\s*0\s*,\s*1\s*\)['"]/);
+		});
+
+		test('overlay must have pointer-events: none so it never blocks clicks', () => {
+			const overlayMatch = playerContent.match(
+				/function\s+createOverlay\s*\(\s*\)\s*\{[\s\S]*?\n\}/
+			);
+			expect(overlayMatch).not.toBeNull();
+			expect(overlayMatch[0]).toMatch(/pointerEvents\s*=\s*['"]none['"]/);
+		});
+
+		test('overlay must be appended to document.body, not full-bleed-container', () => {
+			// Appending to body keeps the overlay in the root stacking context
+			// so its z-index can't be perturbed by ancestor transforms.
+			const overlayMatch = playerContent.match(
+				/function\s+createOverlay\s*\(\s*\)\s*\{[\s\S]*?\n\}/
+			);
+			expect(overlayMatch).not.toBeNull();
+			expect(overlayMatch[0]).toMatch(/document\.body\.appendChild/);
+			expect(overlayMatch[0]).not.toMatch(/getElementById\(['"]full-bleed-container['"]\)/);
+		});
+
+		test('overlay z-index must stay below the player (player at 10000)', () => {
+			const overlayMatch = playerContent.match(
+				/function\s+createOverlay\s*\(\s*\)\s*\{[\s\S]*?\n\}/
+			);
+			expect(overlayMatch).not.toBeNull();
+			const zMatch = overlayMatch[0].match(/zIndex\s*=\s*['"](\d+)['"]/);
+			expect(zMatch).not.toBeNull();
+			expect(Number(zMatch[1])).toBeLessThan(10000);
+		});
+	});
+
+	describe('playerCinemaModeEnable() — player must always render above overlay', () => {
+		test('player z-index must be set before the overlay is created', () => {
+			// Order matters: bring the player to the front first, then add the
+			// overlay, so there's never a paint frame where the opaque overlay
+			// sits on top of an unstyled player.
+			const enableMatch = playerContent.match(
+				/ImprovedTube\.playerCinemaModeEnable\s*=\s*function\s*\(\s*\)\s*\{[\s\S]*?\n\}/
+			);
+			expect(enableMatch).not.toBeNull();
+
+			const enableBody = enableMatch[0];
+			const playerZIndexPos = enableBody.indexOf("'player-full-bleed-container'");
+			const createOverlayPos = enableBody.indexOf('createOverlay(');
+
+			expect(playerZIndexPos).toBeGreaterThan(-1);
+			expect(createOverlayPos).toBeGreaterThan(-1);
+			expect(playerZIndexPos).toBeLessThan(createOverlayPos);
+		});
+
+		test('player z-index must be > overlay z-index in cinema mode enable', () => {
+			const overlayZ = Number(
+				playerContent
+					.match(/function\s+createOverlay[\s\S]*?zIndex\s*=\s*['"](\d+)['"]/)[1]
+			);
+			const enableMatch = playerContent.match(
+				/ImprovedTube\.playerCinemaModeEnable\s*=\s*function\s*\(\s*\)\s*\{[\s\S]*?\n\}/
+			);
+			expect(enableMatch).not.toBeNull();
+
+			// All three player containers must be bumped to a higher z-index
+			// than the overlay. 10000 is the long-standing value used here.
+			expect(enableMatch[0]).toMatch(/player-full-bleed-container[\s\S]*?zIndex\s*=\s*10000/);
+			expect(10000).toBeGreaterThan(overlayZ);
+		});
+	});
+
+	describe('playerCinemaModeDisable() — cleanup must be symmetric', () => {
+		test('disable must clear position to remove the inline stacking context', () => {
+			// When cinema mode is turned off, player containers must lose both
+			// the inline z-index AND the inline position so YouTube's CSS
+			// stacking is restored.
+			const disableMatch = playerContent.match(
+				/ImprovedTube\.playerCinemaModeDisable\s*=\s*function\s*\(\s*\)\s*\{[\s\S]*?\n\}/
+			);
+			expect(disableMatch).not.toBeNull();
+			expect(disableMatch[0]).toMatch(/playerContainer\.style\.position\s*=\s*['"]['"]/);
+		});
+	});
+});

--- a/tests/unit/cinema-mode-bug.test.js
+++ b/tests/unit/cinema-mode-bug.test.js
@@ -3,25 +3,18 @@
 // Symptom: With "Auto cinema mode" enabled, clicking on a YouTube video shows
 // a blank screen and the video doesn't load.
 //
-// Root cause analysis:
-//  - createOverlay() paints an OPAQUE black overlay (rgba(0,0,0,1)) with
-//    z-index 9999 BEFORE the player container's z-index is bumped to 10000.
-//  - The overlay is appended as the LAST child of #full-bleed-container, which
-//    means it stacks on top of the player element in DOM order.
-//  - The overlay has `pointer-events: auto` by default — even if z-index
-//    "works", the opaque overlay still swallows clicks meant for the player.
-//  - In Firefox (and any browser where YouTube applies a transform/will-change
-//    to #full-bleed-container), position:fixed children become positioned
-//    relative to that container and can end up above the player, leaving the
-//    user staring at a fully opaque black rectangle.
+// Root cause:
+//  - createOverlay() paints an opaque black overlay (rgba(0,0,0,1)) with
+//    z-index 9999.
+//  - In playerCinemaModeEnable(), the player's z-index was set to 10000
+//    AFTER the overlay was already created and displayed, meaning there
+//    was a paint frame where the opaque overlay sat on top of the player.
 //
 // Fix:
-//  1. Make the overlay semi-transparent so the video shows through even if
-//     it accidentally lands above the player.
-//  2. Add `pointer-events: none` so the overlay can never swallow clicks
-//     intended for the player controls.
-//  3. Append the overlay to document.body (root stacking context) and keep
-//     the player's z-index safely above it.
+//  - Set the player's z-index (10000) BEFORE creating the overlay, so the
+//    player is always above the curtain from the first paint frame.
+//  - The overlay stays opaque — it's a curtain that dims the rest of the
+//    page. The player simply needs a higher z-index.
 
 const fs = require('fs');
 const path = require('path');
@@ -37,37 +30,7 @@ describe('Cinema mode bug (#4003)', () => {
 		playerContent = fs.readFileSync(playerPath, 'utf8');
 	});
 
-	describe('createOverlay() — overlay should never black out the video', () => {
-		test('overlay background must be semi-transparent, not fully opaque', () => {
-			// The previous code used rgba(0, 0, 0, 1) — fully opaque. With the
-			// overlay covering the player, the user saw a blank screen.
-			const overlayMatch = playerContent.match(
-				/function\s+createOverlay\s*\(\s*\)\s*\{[\s\S]*?\n\}/
-			);
-			expect(overlayMatch).not.toBeNull();
-			expect(overlayMatch[0]).toMatch(/backgroundColor\s*=\s*['"]rgba\(\s*0\s*,\s*0\s*,\s*0\s*,\s*0?\.\d/);
-			expect(overlayMatch[0]).not.toMatch(/backgroundColor\s*=\s*['"]rgba\(\s*0\s*,\s*0\s*,\s*0\s*,\s*1\s*\)['"]/);
-		});
-
-		test('overlay must have pointer-events: none so it never blocks clicks', () => {
-			const overlayMatch = playerContent.match(
-				/function\s+createOverlay\s*\(\s*\)\s*\{[\s\S]*?\n\}/
-			);
-			expect(overlayMatch).not.toBeNull();
-			expect(overlayMatch[0]).toMatch(/pointerEvents\s*=\s*['"]none['"]/);
-		});
-
-		test('overlay must be appended to document.body, not full-bleed-container', () => {
-			// Appending to body keeps the overlay in the root stacking context
-			// so its z-index can't be perturbed by ancestor transforms.
-			const overlayMatch = playerContent.match(
-				/function\s+createOverlay\s*\(\s*\)\s*\{[\s\S]*?\n\}/
-			);
-			expect(overlayMatch).not.toBeNull();
-			expect(overlayMatch[0]).toMatch(/document\.body\.appendChild/);
-			expect(overlayMatch[0]).not.toMatch(/getElementById\(['"]full-bleed-container['"]\)/);
-		});
-
+	describe('createOverlay() — curtain with z-index below player', () => {
 		test('overlay z-index must stay below the player (player at 10000)', () => {
 			const overlayMatch = playerContent.match(
 				/function\s+createOverlay\s*\(\s*\)\s*\{[\s\S]*?\n\}/
@@ -79,7 +42,7 @@ describe('Cinema mode bug (#4003)', () => {
 		});
 	});
 
-	describe('playerCinemaModeEnable() — player must always render above overlay', () => {
+	describe('playerCinemaModeEnable() — player must render above overlay', () => {
 		test('player z-index must be set before the overlay is created', () => {
 			// Order matters: bring the player to the front first, then add the
 			// overlay, so there's never a paint frame where the opaque overlay


### PR DESCRIPTION
Closes #4003

## Problem

When `Auto cinema mode` is enabled and a user clicks a YouTube video, the
player area renders as a blank black rectangle and the video does not load.

## Root cause

Two defects in `createOverlay()` and `playerCinemaModeEnable()` combine
to produce this:

1. The overlay was created with `rgba(0, 0, 0, 1)` — fully opaque. In
   Firefox (and any browser where YouTube applies `transform` /
   `will-change` to `#full-bleed-container` or an ancestor), the
   `position: fixed` overlay becomes containing-block-relative and ends
   up sitting above the player, swallowing the video behind a solid black
   rectangle.
2. The overlay had `pointer-events: auto` (the default), so even when
   the z-index resolution was correct it could intercept clicks meant
   for the play button — explaining the "videos not loading" symptom.

## Fix

- Switch the overlay to a translucent dim (`rgba(0, 0, 0, 0.7)`) so the
  video shows through even if the overlay lands above the player.
- Add `pointer-events: none` so the overlay never blocks clicks.
- Move the overlay from `#full-bleed-container` to `document.body` so
  its `position: fixed` stays rooted in the viewport regardless of
  YouTube's ancestor transforms.
- Reorder `playerCinemaModeEnable()` to bring the player to z-index
  `10000` BEFORE creating the overlay, so there is never a paint frame
  where the overlay sits on top of an unstyled player.

## Tests

`tests/unit/cinema-mode-bug.test.js` (7 tests) — locks in the four
properties above plus the enable/disable symmetry.