### PR TITLE
Fix `TypeError` when creating Fit-to-Window button multiple times

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -1157,24 +1157,17 @@ FIT-TO-WIN BUTTON
 ------------------------------------------------------------------------------*/
 ImprovedTube.playerFitToWinButton = function () {
 	if (this.storage.player_fit_to_win_button === true && (/watch\?/.test(location.href))) {
-	let tempContainer = document.createElement("div");
-	let svg;
-	if (typeof trustedTypes !== 'undefined' && typeof trustedTypes.createPolicy === 'function') {
-		// Create a Trusted Type policy
-		const policy = trustedTypes.createPolicy('default', {
-			createHTML: (string) => string,
-		});
-
-		// Use the policy to set innerHTML
-		tempContainer.innerHTML = policy.createHTML(`
-		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" id="ftw-icon">
-		<path d="M21 3 9 15"/><path d="M12 3H3v18h18v-9"/><path d="M16 3h5v5"/><path d="M14 15H9v-5"/></svg>`);
-
-		// Ensure the SVG element is correctly parsed
-        	svg = tempContainer.querySelector('svg');
-	} else {tempContainer.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" id="ftw-icon">
- 		<path d="M21 3 9 15"/><path d="M12 3H3v18h18v-9"/><path d="M16 3h5v5"/><path d="M14 15H9v-5"/></svg>`;
-		svg = tempContainer.firstChild;}
+		const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+		const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+		svg.setAttribute('width', '24');
+		svg.setAttribute('height', '24');
+		svg.setAttribute('viewBox', '0 0 24 24');
+		svg.setAttribute('fill', 'none');
+		svg.setAttribute('stroke', 'currentColor');
+		svg.setAttribute('stroke-width', '2');
+		svg.setAttribute('id', 'ftw-icon');
+		path.setAttribute('d', 'M21 3 9 15 M12 3H3v18h18v-9 M16 3h5v5 M14 15H9v-5');
+		svg.appendChild(path);
 		this.createPlayerButton({
 			id: 'it-fit-to-win-player-button',
 			child: svg,


### PR DESCRIPTION
close #4014 

# Summary
Fix `TypeError` when creating Fit-to-Window button multiple times.

# Problem
The error occurred because the code attempted to create a Trusted Type policy named `"default"`. Since a `"default"` policy can only be created once per execution context, attempting to redefine it (e.g., during re-initialization) triggers this exception. Because this exception was unhandled, it halted subsequent initialization logic, preventing other feature buttons from being rendered. This results in the following console error:

### Console Error
```log
Uncaught TypeError: TrustedTypePolicyFactory.createPolicy: Tried to create a second default policy
    playerFitToWinButton moz-extension://55c75782-e62e-4c5b-b399-4c54fd1ae1a0/js&css/web-accessible/www.youtube.com/player.js:1164
    initPlayer moz-extension://55c75782-e62e-4c5b-b399-4c54fd1ae1a0/js&css/web-accessible/functions.js:480
    init moz-extension://55c75782-e62e-4c5b-b399-4c54fd1ae1a0/js&css/web-accessible/init.js:205
    <anonymous> moz-extension://55c75782-e62e-4c5b-b399-4c54fd1ae1a0/js&css/web-accessible/core.js line 301 > srcScript:209
```

# Solution
Replaced the `innerHTML`-based SVG creation with direct DOM manipulation using `document.createElementNS`. This change:
- Aligns the implementation with how other feature buttons are constructed in the codebase.
- Avoids creating a `"default"` policy, resolving the error.
- Removes the conditional check for Trusted Type support, resulting in a simpler code structure.
- Minimizes risk by only affecting the button element construction; the core logic of ImprovedTube.toggleFitToWindow() remains unchanged.
 
# Verification
Manual verification confirms that the DOM-generated SVG structure is identical to the previous implementation and functions correctly.
