### PR TITLE
Move contextMenus.onClicked listener out of updateContextMenu to the …

### DIFF
--- a/background.js
+++ b/background.js
@@ -164,17 +164,18 @@ function updateContextMenu (language) {
 				// contexts: ['browser_action'] //manifest2
 			});
 		}
-		chrome.contextMenus.onClicked.addListener(function (info) {
-			const links = [
-				'https://www.improvedtube.com/donate',
-				'https://chrome.google.com/webstore/detail/improve-youtube-video-you/bnomihfieiccainjcjblhegjgglakjdd',
-				'https://github.com/code4charity/YouTube-Extension'
-			];
-			chrome.tabs.create({ url: links[info.menuItemId] }); //manifest3
-			// window.open(links[info.menuItemId]); //manifest2
-		});
 	});
 }
+
+chrome.contextMenus.onClicked.addListener(function (info) {
+	const links = [
+		'https://www.improvedtube.com/donate',
+		'https://chrome.google.com/webstore/detail/improve-youtube-video-you/bnomihfieiccainjcjblhegjgglakjdd',
+		'https://github.com/code4charity/YouTube-Extension'
+	];
+	chrome.tabs.create({ url: links[info.menuItemId] }); //manifest3
+	// window.open(links[info.menuItemId]); //manifest2
+});
 chrome.runtime.onInstalled.addListener(function () {
 	chrome.storage.local.get(function (items) {
 		updateContextMenu(items.language);


### PR DESCRIPTION
…top level## Summary
Fixes a listener leak where `chrome.contextMenus.onClicked` was re-registered on every `updateContextMenu()` call, causing listeners to accumulate and open duplicate tabs on click.

Fixes #4124

## Changes
- Moved `chrome.contextMenus.onClicked.addListener(...)` out of `updateContextMenu()` and registered it once at the top level of `background.js`
- `updateContextMenu()` now only rebuilds context menu items; it no longer touches the click listener

## Testing
- Loaded unpacked extension in Chrome MV3
- Changed language twice via extension settings menu (`storage.onChanged` → `updateContextMenu`)
- Right-clicked toolbar icon and clicked "donate" — confirmed only one tab opens instead of three