### PR TITLE
Add setting to disable touch swipe miniplayer

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -153,6 +153,9 @@
   "autoContinueWatching": {
     "message": "Auto-accept «Continue watching?»"
   },
+  "disableTouchSwipeToMiniplayer": {
+    "message": "Disable touch swipe to mini-player"
+  },
   "autoPlayNextShort": {
     "message": "Shorts up next autoplay"
   },

--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -483,6 +483,7 @@ ImprovedTube.initPlayer = function () {
 		ImprovedTube.playerPlaybackSpeedButton();
 		ImprovedTube.playerHamburgerButton();
 		ImprovedTube.playerControls();
+		ImprovedTube.playerDisableTouchSwipeToMiniplayer();
 		ImprovedTube.playerHideProgressPreview();
 		ImprovedTube.expandDescription();
 		setTimeout(function () { ImprovedTube.forcedTheaterMode(); }, 150);

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -78,6 +78,179 @@ ImprovedTube.playerAutoPip = function () {
 	}
 };
 /*------------------------------------------------------------------------------
+DISABLE TOUCH SWIPE TO MINI-PLAYER
+------------------------------------------------------------------------------*/
+ImprovedTube.playerDisableTouchSwipeToMiniplayer = function () {
+	var key = 'player_disable_touch_swipe_to_miniplayer',
+		options = {capture: true, passive: false},
+		blocker = this._touchSwipeToMiniplayerBlocker;
+
+	if (!blocker) {
+		blocker = this._touchSwipeToMiniplayerBlocker = {
+			touchId: null,
+			pointerId: null,
+			startX: 0,
+			startY: 0,
+			blocking: false,
+			enabled: false,
+			isPlayerSurfaceEvent: function (event) {
+				var path = typeof event.composedPath === 'function' ? event.composedPath() : [],
+					controlsSelector = 'button, a, input, textarea, select, [role="button"], .ytp-chrome-bottom, .ytp-progress-bar-container, .ytp-settings-menu, .ytp-popup, .ytp-tooltip, .ytp-caption-window-container',
+					surfaceSelector = 'video.html5-main-video, .html5-main-video, .html5-video-container, .ytp-cued-thumbnail-overlay';
+
+				for (var i = 0, l = path.length; i < l; i++) {
+					if (!path[i] || typeof path[i].matches !== 'function') {
+						continue;
+					}
+
+					if (path[i].matches(controlsSelector)) {
+						return false;
+					}
+
+					if (path[i].matches(surfaceSelector)) {
+						return true;
+					}
+				}
+
+				if (event.target && typeof event.target.closest === 'function') {
+					return !event.target.closest(controlsSelector) && Boolean(event.target.closest(surfaceSelector));
+				}
+
+				return false;
+			},
+			start: function (x, y, id, isPointer) {
+				this.startX = x;
+				this.startY = y;
+				this.blocking = false;
+				if (isPointer) {
+					this.pointerId = id;
+				} else {
+					this.touchId = id;
+				}
+			},
+			end: function () {
+				this.touchId = null;
+				this.pointerId = null;
+				this.blocking = false;
+			},
+			shouldBlock: function (x, y) {
+				var deltaX = Math.abs(x - this.startX),
+					deltaY = y - this.startY;
+
+				return deltaY >= 8 && deltaY > deltaX * 1.2;
+			},
+			stopGesture: function (event) {
+				if (event.cancelable) {
+					event.preventDefault();
+				}
+
+				event.stopImmediatePropagation();
+				event.stopPropagation();
+			}
+		};
+
+		blocker.touchStart = function (event) {
+			if (event.touches.length !== 1 || !blocker.isPlayerSurfaceEvent(event)) {
+				blocker.end();
+				return;
+			}
+
+			blocker.start(event.touches[0].clientX, event.touches[0].clientY, event.touches[0].identifier, false);
+		};
+
+		blocker.touchMove = function (event) {
+			var touch = null;
+
+			for (var i = 0, l = event.touches.length; i < l; i++) {
+				if (event.touches[i].identifier === blocker.touchId) {
+					touch = event.touches[i];
+					break;
+				}
+			}
+
+			if (!touch) {
+				return;
+			}
+
+			if (blocker.blocking || blocker.shouldBlock(touch.clientX, touch.clientY)) {
+				blocker.blocking = true;
+				blocker.stopGesture(event);
+			}
+		};
+
+		blocker.touchEnd = function (event) {
+			var ended = event.touches.length === 0;
+
+			for (var i = 0, l = event.changedTouches.length; i < l; i++) {
+				ended = ended || event.changedTouches[i].identifier === blocker.touchId;
+			}
+
+			if (blocker.blocking) {
+				blocker.stopGesture(event);
+			}
+
+			if (ended) {
+				blocker.end();
+			}
+		};
+
+		blocker.pointerDown = function (event) {
+			if (event.pointerType !== 'touch' || !blocker.isPlayerSurfaceEvent(event)) {
+				blocker.end();
+				return;
+			}
+
+			blocker.start(event.clientX, event.clientY, event.pointerId, true);
+		};
+
+		blocker.pointerMove = function (event) {
+			if (event.pointerId !== blocker.pointerId) {
+				return;
+			}
+
+			if (blocker.blocking || blocker.shouldBlock(event.clientX, event.clientY)) {
+				blocker.blocking = true;
+				blocker.stopGesture(event);
+			}
+		};
+
+		blocker.pointerEnd = function (event) {
+			if (event.pointerId !== blocker.pointerId) {
+				return;
+			}
+
+			if (blocker.blocking) {
+				blocker.stopGesture(event);
+			}
+
+			blocker.end();
+		};
+	}
+
+	if (this.storage[key] === true && blocker.enabled === false) {
+		document.addEventListener('touchstart', blocker.touchStart, options);
+		document.addEventListener('touchmove', blocker.touchMove, options);
+		document.addEventListener('touchend', blocker.touchEnd, options);
+		document.addEventListener('touchcancel', blocker.touchEnd, options);
+		document.addEventListener('pointerdown', blocker.pointerDown, options);
+		document.addEventListener('pointermove', blocker.pointerMove, options);
+		document.addEventListener('pointerup', blocker.pointerEnd, options);
+		document.addEventListener('pointercancel', blocker.pointerEnd, options);
+		blocker.enabled = true;
+	} else if (this.storage[key] !== true && blocker.enabled === true) {
+		document.removeEventListener('touchstart', blocker.touchStart, options);
+		document.removeEventListener('touchmove', blocker.touchMove, options);
+		document.removeEventListener('touchend', blocker.touchEnd, options);
+		document.removeEventListener('touchcancel', blocker.touchEnd, options);
+		document.removeEventListener('pointerdown', blocker.pointerDown, options);
+		document.removeEventListener('pointermove', blocker.pointerMove, options);
+		document.removeEventListener('pointerup', blocker.pointerEnd, options);
+		document.removeEventListener('pointercancel', blocker.pointerEnd, options);
+		blocker.enabled = false;
+		blocker.end();
+	}
+};
+/*------------------------------------------------------------------------------
 PLAYBACK SPEED
 ------------------------------------------------------------------------------*/
 ImprovedTube.playbackSpeed = function (newSpeed) {

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -86,6 +86,11 @@ extension.skeleton.main.layers.section.player.on.click = {
 			id: 'player_auto_continue_watching',
 			value: true
 		},
+		player_disable_touch_swipe_to_miniplayer: {
+			component: 'switch',
+			text: 'disableTouchSwipeToMiniplayer',
+			value: false
+		},
 		prevent_shorts_autoloop:{
 			component: 'switch',
 			text: 'preventShortVideoAutoloop',

--- a/tests/unit/touch-swipe-miniplayer.test.js
+++ b/tests/unit/touch-swipe-miniplayer.test.js
@@ -1,0 +1,148 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('Disable touch swipe to mini-player', () => {
+	let playerContent;
+	let functionsContent;
+	let playerMenuContent;
+	let messagesJson;
+
+	function loadTouchSwipeGuard(storageValue = true) {
+		const assignmentStart = playerContent.indexOf('ImprovedTube.playerDisableTouchSwipeToMiniplayer = function');
+		const bodyStart = playerContent.indexOf('{', assignmentStart);
+		let depth = 0;
+		let assignmentEnd = -1;
+
+		for (let i = bodyStart; i < playerContent.length; i++) {
+			if (playerContent[i] === '{') {
+				depth++;
+			} else if (playerContent[i] === '}') {
+				depth--;
+				if (depth === 0) {
+					assignmentEnd = i + 2;
+					break;
+				}
+			}
+		}
+
+		const documentListeners = {};
+		const sandbox = {
+			ImprovedTube: {
+				storage: {
+					player_disable_touch_swipe_to_miniplayer: storageValue
+				}
+			},
+			document: {
+				addEventListener: jest.fn((type, listener, options) => {
+					documentListeners[type] = { listener, options };
+				}),
+				removeEventListener: jest.fn((type) => {
+					delete documentListeners[type];
+				})
+			},
+			Math,
+			Boolean
+		};
+
+		vm.runInNewContext(playerContent.slice(assignmentStart, assignmentEnd), sandbox);
+
+		return { sandbox, documentListeners };
+	}
+
+	function fakeNode(matchName) {
+		return {
+			matches: (selector) => selector.split(',').map(item => item.trim()).includes(matchName),
+			closest: (selector) => selector.split(',').map(item => item.trim()).includes(matchName) ? true : null
+		};
+	}
+
+	beforeAll(() => {
+		playerContent = fs.readFileSync(
+			path.join(__dirname, '../../js&css/web-accessible/www.youtube.com/player.js'),
+			'utf8'
+		);
+		functionsContent = fs.readFileSync(
+			path.join(__dirname, '../../js&css/web-accessible/functions.js'),
+			'utf8'
+		);
+		playerMenuContent = fs.readFileSync(
+			path.join(__dirname, '../../menu/skeleton-parts/player.js'),
+			'utf8'
+		);
+		messagesJson = JSON.parse(fs.readFileSync(
+			path.join(__dirname, '../../_locales/en/messages.json'),
+			'utf8'
+		));
+	});
+
+	test('defines playerDisableTouchSwipeToMiniplayer on ImprovedTube', () => {
+		expect(playerContent).toContain('ImprovedTube.playerDisableTouchSwipeToMiniplayer = function');
+	});
+
+	test('blocks touch and pointer drag gestures before YouTube handles them', () => {
+		expect(playerContent).toContain("document.addEventListener('touchmove'");
+		expect(playerContent).toContain("document.addEventListener('pointermove'");
+		expect(playerContent).toContain('passive: false');
+		expect(playerContent).toContain('event.preventDefault()');
+		expect(playerContent).toContain('event.stopImmediatePropagation()');
+	});
+
+	test('touch guard prevents a downward player-surface drag', () => {
+		const { sandbox, documentListeners } = loadTouchSwipeGuard(true);
+		const surface = fakeNode('.html5-video-container');
+		const moveEvent = {
+			touches: [{ identifier: 1, clientX: 101, clientY: 112 }],
+			cancelable: true,
+			preventDefault: jest.fn(),
+			stopImmediatePropagation: jest.fn(),
+			stopPropagation: jest.fn()
+		};
+
+		sandbox.ImprovedTube.playerDisableTouchSwipeToMiniplayer();
+		documentListeners.touchstart.listener({
+			touches: [{ identifier: 1, clientX: 100, clientY: 100 }],
+			composedPath: () => [surface],
+			target: surface
+		});
+		documentListeners.touchmove.listener(moveEvent);
+
+		expect(moveEvent.preventDefault).toHaveBeenCalledTimes(1);
+		expect(moveEvent.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+		expect(moveEvent.stopPropagation).toHaveBeenCalledTimes(1);
+	});
+
+	test('touch guard ignores player controls', () => {
+		const { sandbox, documentListeners } = loadTouchSwipeGuard(true);
+		const button = fakeNode('button');
+		const moveEvent = {
+			touches: [{ identifier: 1, clientX: 100, clientY: 130 }],
+			cancelable: true,
+			preventDefault: jest.fn(),
+			stopImmediatePropagation: jest.fn(),
+			stopPropagation: jest.fn()
+		};
+
+		sandbox.ImprovedTube.playerDisableTouchSwipeToMiniplayer();
+		documentListeners.touchstart.listener({
+			touches: [{ identifier: 1, clientX: 100, clientY: 100 }],
+			composedPath: () => [button],
+			target: button
+		});
+		documentListeners.touchmove.listener(moveEvent);
+
+		expect(moveEvent.preventDefault).not.toHaveBeenCalled();
+		expect(moveEvent.stopImmediatePropagation).not.toHaveBeenCalled();
+		expect(moveEvent.stopPropagation).not.toHaveBeenCalled();
+	});
+
+	test('init wires the player touch swipe guard', () => {
+		expect(functionsContent).toContain('ImprovedTube.playerDisableTouchSwipeToMiniplayer()');
+	});
+
+	test('player menu exposes the setting and English locale', () => {
+		expect(playerMenuContent).toContain('player_disable_touch_swipe_to_miniplayer');
+		expect(playerMenuContent).toContain('disableTouchSwipeToMiniplayer');
+		expect(messagesJson.disableTouchSwipeToMiniplayer.message).toBe('Disable touch swipe to mini-player');
+	});
+});


### PR DESCRIPTION
Closes #4127.

## Summary
- Add a Player setting to disable touch swipe-to-mini-player behavior.
- Install an idempotent touch/pointer guard when the setting is enabled.
- Stop downward drags that start on the player video surface before YouTube can route the watch page to home/miniplayer.
- Ignore player controls so normal controls remain usable.
- Add English locale text and unit coverage for the wiring plus simulated touch-drag behavior.

## Validation
- npm ci
- npm test -- --runInBand
- npm run lint

Note: I do not have a Windows touchscreen tablet available, so the regression coverage uses synthetic touch events for the affected gesture path.