### PR TITLE
feat: add customizable double-tap seek distance

### DIFF
--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -491,6 +491,7 @@ ImprovedTube.initPlayer = function () {
 		if (ImprovedTube.storage.disable_auto_dubbing === true) { ImprovedTube.observeAutoDubbedMenu(); }
 		if (ImprovedTube.storage.preferred_dubbing_language) { ImprovedTube.preferredDubbingLanguage(); }
 		if (ImprovedTube.storage.player_default_dubbed_language && ImprovedTube.storage.player_default_dubbed_language !== 'disabled') { ImprovedTube.selectDubbedLanguage(); }
+		ImprovedTube.playerDoubleTapSeek();
 	}
 };
 

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -3071,3 +3071,41 @@ ImprovedTube.playerAutoContinueWatching = function () {
 		});
 	}
 };
+
+/*------------------------------------------------------------------------------
+DOUBLE TAP SEEK DISTANCE
+------------------------------------------------------------------------------*/
+ImprovedTube.playerDoubleTapSeek = function() {
+    if (this.storage.player_double_tap_seek_distance === false) return;
+
+    const player = this.elements.player;
+    const video = this.elements.video;
+    if (!player) return;
+
+    if (player._doubleTapBound) return;
+    player._doubleTapBound = true;
+
+    var self = this;
+
+    function handler(e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        var rect = player.getBoundingClientRect();
+        var x = e.clientX - rect.left;
+        var isForward = x > rect.width / 2;
+        var distance = parseInt(self.storage.player_double_tap_seek_distance) || 10;
+
+        if (isForward) {
+            player.seekBy(distance);
+        } else {
+            player.seekBy(-distance);
+        }
+    }
+
+    // Use capture phase to intercept before native handler
+    player.addEventListener('dblclick', handler, true);
+    if (video) {
+        video.addEventListener('dblclick', handler, true);
+    }
+};

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -1785,6 +1785,15 @@ extension.skeleton.main.layers.section.player.on.click = {
 				component: 'switch',
 				text: 'player_rewind_and_forward_buttons'
 			},
+			player_double_tap_seek_distance: {
+				component: 'slider',
+				text: 'player_double_tap_seek_distance',
+				min: 1,
+				max: 60,
+				step: 1,
+				value: 10,
+				textarea: true
+			},
 			player_increase_decrease_speed_buttons: {
 				component: 'switch',
 				text: 'playerIncreaseDecreaseSpeedButtons',


### PR DESCRIPTION
Adds new setting to customize double-tap seek distance on the player.

This implements the requested feature: users can now set the seek distance (in seconds) when double-tapping on the video. The default is 10 seconds.

The feature intercepts double-clicks on the player area and performs forward/backward seek based on tap position (left side = back, right side = forward).

Fixes #4132

Payout Address (ERC-20): 0x1fDAD6aa8E70C0F5E4C76B83559f9487313a50e9