### PR TITLE
Fix fullscreen scroll lock for hide scroll details setting

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -751,7 +751,7 @@
     "message": "Hide right buttons"
   },
   "hideScrollForDetails": {
-    "message": "Hide «Scroll for details»"
+    "message": "Disable fullscreen scrolling"
   },
   "hideSkipOverlay": {
     "message": "Hide 5 second skip animation"

--- a/js&css/extension/www.youtube.com/appearance/player/player.css
+++ b/js&css/extension/www.youtube.com/appearance/player/player.css
@@ -285,7 +285,7 @@ html[it-player-show-cards-on-mouse-hover='true'] .html5-video-player:hover .ytp-
 }
 
 /*--------------------------------------------------------------
-# HIDE "SCROLL FOR DETAILS"
+# Disable fullscreen scrolling  (formerly HIDE "SCROLL FOR DETAILS" - To-Do:  remove the word Details from the translations )
 --------------------------------------------------------------*/
 
 html[it-hide-scroll-for-details='true'] button.ytp-fullerscreen-edu-button {
@@ -724,36 +724,6 @@ html[data-page-type=video][it-hide-progress-preview='true'] .ytp-chapter-hover-c
     opacity: 0 !important;
     visibility: hidden !important;
     pointer-events: none !important;
-}
-
-/*--------------------------------------------------------------
-# HIDE "SCROLL FOR DETAILS"
---------------------------------------------------------------*/
-
-html[it-hide-scroll-for-details='true'] button.ytp-fullerscreen-edu-button {
-	display: none !important;
-}
-
-html[it-hide-scroll-for-details='true']:has(ytd-watch-flexy[fullscreen]),
-html[it-hide-scroll-for-details='true']:has(ytd-app[player-fullscreen_]),
-html[it-hide-scroll-for-details='true']:has(.html5-video-player.ytp-fullscreen) {
-	overflow: hidden !important;
-	overscroll-behavior: none !important;
-}
-
-html[it-hide-scroll-for-details='true']:has(ytd-watch-flexy[fullscreen]) body,
-html[it-hide-scroll-for-details='true']:has(ytd-app[player-fullscreen_]) body,
-html[it-hide-scroll-for-details='true']:has(.html5-video-player.ytp-fullscreen) body,
-html[it-hide-scroll-for-details='true'] ytd-app[player-fullscreen_],
-html[it-hide-scroll-for-details='true'] ytd-watch-flexy[fullscreen],
-html[it-hide-scroll-for-details='true'] ytd-watch-flexy[fullscreen] #columns {
-	overflow: hidden !important;
-	overscroll-behavior: none !important;
-	max-height: 100vh !important;
-}
-
-html[it-hide-scroll-for-details='true'] ytd-app[scrolling_] {
-	overflow: hidden !important;
 }
 
 /*--------------------------------------------------------------

--- a/js&css/extension/www.youtube.com/appearance/player/player.css
+++ b/js&css/extension/www.youtube.com/appearance/player/player.css
@@ -292,6 +292,24 @@ html[it-hide-scroll-for-details='true'] button.ytp-fullerscreen-edu-button {
 	display: none !important;
 }
 
+html[it-hide-scroll-for-details='true']:has(ytd-watch-flexy[fullscreen]),
+html[it-hide-scroll-for-details='true']:has(ytd-app[player-fullscreen_]),
+html[it-hide-scroll-for-details='true']:has(.html5-video-player.ytp-fullscreen) {
+	overflow: hidden !important;
+	overscroll-behavior: none !important;
+}
+
+html[it-hide-scroll-for-details='true']:has(ytd-watch-flexy[fullscreen]) body,
+html[it-hide-scroll-for-details='true']:has(ytd-app[player-fullscreen_]) body,
+html[it-hide-scroll-for-details='true']:has(.html5-video-player.ytp-fullscreen) body,
+html[it-hide-scroll-for-details='true'] ytd-app[player-fullscreen_],
+html[it-hide-scroll-for-details='true'] ytd-watch-flexy[fullscreen],
+html[it-hide-scroll-for-details='true'] ytd-watch-flexy[fullscreen] #columns {
+	overflow: hidden !important;
+	overscroll-behavior: none !important;
+	max-height: 100vh !important;
+}
+
 html[it-hide-scroll-for-details='true'] ytd-app[scrolling_] {
 	overflow: hidden !important;
 }
@@ -714,6 +732,24 @@ html[data-page-type=video][it-hide-progress-preview='true'] .ytp-chapter-hover-c
 
 html[it-hide-scroll-for-details='true'] button.ytp-fullerscreen-edu-button {
 	display: none !important;
+}
+
+html[it-hide-scroll-for-details='true']:has(ytd-watch-flexy[fullscreen]),
+html[it-hide-scroll-for-details='true']:has(ytd-app[player-fullscreen_]),
+html[it-hide-scroll-for-details='true']:has(.html5-video-player.ytp-fullscreen) {
+	overflow: hidden !important;
+	overscroll-behavior: none !important;
+}
+
+html[it-hide-scroll-for-details='true']:has(ytd-watch-flexy[fullscreen]) body,
+html[it-hide-scroll-for-details='true']:has(ytd-app[player-fullscreen_]) body,
+html[it-hide-scroll-for-details='true']:has(.html5-video-player.ytp-fullscreen) body,
+html[it-hide-scroll-for-details='true'] ytd-app[player-fullscreen_],
+html[it-hide-scroll-for-details='true'] ytd-watch-flexy[fullscreen],
+html[it-hide-scroll-for-details='true'] ytd-watch-flexy[fullscreen] #columns {
+	overflow: hidden !important;
+	overscroll-behavior: none !important;
+	max-height: 100vh !important;
 }
 
 html[it-hide-scroll-for-details='true'] ytd-app[scrolling_] {


### PR DESCRIPTION
Fixes #4129.\n\n## Summary\n- Reuse the existing hide scroll-for-details setting to lock scrolling while YouTube is in fullscreen/fake-fullscreen mode.\n- Scope the lock to YouTube fullscreen state selectors so normal video pages remain scrollable.\n- Rename the English setting label to reflect the broader behavior.\n\n## Verification\n- npm test -- --runInBand\n- npm run lint