### PR TITLE
fix(player): guard against undefined button from createPlayerButton

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -735,6 +735,8 @@ ImprovedTube.playerPlaybackSpeedButton = function () {
       title: "Playback Speed Control",
     });
 
+    if (!button) return;
+
     const updateSpeedText = () => {
       const currentSpeed = (this.elements.video?.playbackRate || 1.0).toFixed(
         2
@@ -1121,6 +1123,8 @@ ImprovedTube.playerPlaybackSpeedButton = function () {
 			},
 			title: 'Playback Speed (Scroll: adjust, Left: custom, Right: 1.0x)'
 		});
+
+		if (!button) return;
 
 		// Add right-click handler
 		button.addEventListener('contextmenu', function (e) {


### PR DESCRIPTION
## Problem

When YouTube's playback speed button hasn't been added to the DOM yet, `createPlayerButton()` returns `undefined` because `player_left_controls` or `player_right_controls` don't exist. Calling `onclick` / `addEventListener` on `undefined` throws a `TypeError` and breaks subsequent button initialization (repeat, screenshot, rotate, etc.).

Error: `Uncaught TypeError: can't access property "addEventListener", button is undefined`

This manifests as ImproveTube's extra buttons not appearing until the page is manually refreshed.

## Fix

Add an early return check `if (!button) return;` after `createPlayerButton()` in both `playerPlaybackSpeedButton` function definitions.

## Changes

- `js&css/web-accessible/www.youtube.com/player.js`: Added null guard in both `playerPlaybackSpeedButton` function definitions (lines 701 and 1100)