### PR TITLE
 Draft feat: Extract shared YouTube video data lookup helper

### DIFF
--- a/js&css/extension/init.js
+++ b/js&css/extension/init.js
@@ -78,6 +78,7 @@ const pageWorldFiles = [
 	'/js&css/web-accessible/functions.js',
 	'/js&css/web-accessible/www.youtube.com/appearance.js',
 	'/js&css/web-accessible/www.youtube.com/themes.js',
+	'/js&css/web-accessible/www.youtube.com/video-metadata.js',
 	'/js&css/web-accessible/www.youtube.com/player.js',
 	'/js&css/web-accessible/www.youtube.com/playlist.js',
 	'/js&css/web-accessible/www.youtube.com/playlist-complete-playlist.js',

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -106,152 +106,153 @@ ImprovedTube.playbackSpeed = function (newSpeed) {
 /*------------------------------------------------------------------------------
 PERMANENT PLAYBACK SPEED
 ------------------------------------------------------------------------------*/
-ImprovedTube.playerPlaybackSpeed = function () { if (this.storage.player_forced_playback_speed === true) {
-	var player = this.elements.player; if (!player) return;
-	var video = this.elements.video || player.querySelector('video'); 
-	option = this.storage.player_playback_speed;	
-	if (this.isset(option) === false) { option = 1; }
-	else if ( option !== 1 ) { 
-		const speed = video?.playbackRate ? Number(video.playbackRate.toFixed(2)) : (player?.getPlaybackRate ? Number(player.getPlaybackRate().toFixed(2)) : null);
-		 if (speed !== option && speed !== 1 && speed !== Number((Math.floor(option / 0.05) * 0.05).toFixed(2)))
-		   { console.log("skipping permanent speed, since speed was manually set differently for this video to:" + video.playbackRate + ", was it?"); return; }
+ImprovedTube.playerPlaybackSpeed = function () {
+	if (this.storage.player_forced_playback_speed !== true) {
+		return;
 	}
-	if (!(player.getVideoData() && player.getVideoData().isLive))
-	{ player.setPlaybackRate(Number(option)); if (!video) { video = { playbackRate: 1 }; };	video.playbackRate = Number(option); // #1729 q2 // hi! @raszpl
-		if ( (this.storage.player_force_speed_on_music !== true || this.storage.player_dont_speed_education === true)
-		 	&& option !== 1) {
-			ImprovedTube.speedException = function () {
-				if (this.storage.player_dont_speed_education === true && DATA.genre === 'Education')
-				{player.setPlaybackRate(Number(1));	video.playbackRate = Number(1); return;}
-				if (this.storage.player_force_speed_on_music === true)
-				{ //player.setPlaybackRate(Number(option));	video.playbackRate = Number(option);
-	 return;}
-				if (DATA.keywords && !keywords) { keywords = DATA.keywords.join(', ') || ''; }
-				if (keywords === 'video, sharing, camera phone, video phone, free, upload') { keywords = ''; }
-				var musicIdentifiers = /(official|music|lyrics?)[ -]video|(cover|studio|radio|album|alternate)[- ]version|soundtrack|unplugged|\bmedley\b|\blo-fi\b|\blofi\b|a(lla)? cappella|feat\.|(piano|guitar|jazz|ukulele|violin|reggae)[- ](version|cover)|karaok|backing[- ]track|instrumental|(sing|play)[- ]?along|卡拉OK|卡拉OK|الكاريوكي|караоке|カラオケ|노래방|bootleg|mashup|Radio edit|Guest (vocals|musician)|(title|opening|closing|bonus|hidden)[ -]track|live acoustic|interlude|featuring|recorded (at|live)/i;
-				var musicIdentifiersTitleOnly = /lyrics|theme song|\bremix|\bAMV ?[^a-z0-9]|[^a-z0-9] ?AMV\b|\bfull song\b|\bsong:|\bsong[\!$]|^song\b|( - .*\bSong\b|\bSong\b.* - )|cover ?[^a-z0-9]|[^a-z0-9] ?cover|\bconcert\b/i;
-				var musicIdentifiersTitle = new RegExp(musicIdentifiersTitleOnly.source + '|' + musicIdentifiers.source, "i");
-				var musicRegexMatch = musicIdentifiersTitle.test(DATA.title);
-				if (!musicRegexMatch) {
-					var musicIdentifiersTagsOnly = /, (lyrics|remix|song|music|AMV|theme song|full song),|\(Musical Genre\)|, jazz|, reggae/i;
-					var musicIdentifiersTags = new RegExp(musicIdentifiersTagsOnly.source + '|' + musicIdentifiers.source, "i");
-				  keywordsAmount = 1 + ((keywords || '').match(/,/) || []).length;
-					if ( ((keywords || '').match(musicIdentifiersTags) || []).length / keywordsAmount > 0.08) {
-						musicRegexMatch = true}}
-				notMusicRegexMatch = /\bdo[ck]u|interv[iyj]|back[- ]?stage|インタビュー|entrevista|面试|面試|회견|wawancara|مقابلة|интервью|entretien|기록한 것|记录|記錄|ドキュメンタリ|وثائقي|документальный/i.test(DATA.title + " " + keywords);
-				// (Tags/keywords shouldnt lie & very few songs titles might have these words)
-				if (DATA.duration) {
-					function parseDuration (duration) {	const [_, h = 0, m = 0, s = 0] = duration.match(/PT(?:(\d+)?H)?(?:(\d+)?M)?(\d+)?S?/).map(part => parseInt(part) || 0);
-						return h * 3600 + m * 60 + s; }
-					DATA.lengthSeconds = parseDuration(DATA.duration); 	}
-				function testSongDuration (s, ytMusic) {
-					if (135 <= s && s <= 260) {return 'veryCommon';}
-					if (105 <= s && s <= 420) {return 'common';}
-					if (420 <= s && s <= 720) {return 'long';}
-					if (45 <= s && s <= 105) {return 'short';}
-					if (ytMusic && ytMusic > 1 && (85 <= s / ytMusic && (s / ytMusic <= 375 || ytMusic == 10))) {return 'multiple';}
-				//does Youtube ever show more than 10 songs below the description?
-				}
-				var songDurationType = testSongDuration(DATA.lengthSeconds);
-				console.log("genre: " + DATA.genre + "//title: " + DATA.title + "//keywords: " + keywords + "//music word match: " + musicRegexMatch + "// not music word match:" + notMusicRegexMatch + "//duration: " + DATA.lengthSeconds + "//song duration type: " + songDurationType);
-				// check if the video is PROBABLY MUSIC:
-				if ( 		( DATA.genre === 'Music' && (!notMusicRegexMatch || songDurationType === 'veryCommon'))
-			|| ( musicRegexMatch && !notMusicRegexMatch && (typeof songDurationType !== 'undefined'
-						|| (/album|Álbum|专辑|專輯|एलबम|البوم|アルバム|альбом|앨범|mixtape|concert|playlist|\b(live|cd|vinyl|lp|ep|compilation|collection|symphony|suite|medley)\b/i.test(DATA.title + " " + keywords)
-							&& 1000 <= DATA.lengthSeconds )) ) // && 1150 <= DATA.lengthSeconds <= 5000
-			||	( DATA.genre === 'Music' && musicRegexMatch && (typeof songDurationType !== 'undefined'
-						|| (/album|Álbum|专辑|專輯|एलबम|البوم|アルバム|альбом|앨범|mixtape|concert|playlist|\b(live|cd|vinyl|lp|ep|compilation|collection|symphony|suite|medley)\b/i.test(DATA.title + " " + keywords)
-							&& 1000 <= DATA.lengthSeconds )) ) // && DATA.lengthSeconds <= 5000
-			|| (amountOfSongs && testSongDuration(DATA.lengthSeconds, amountOfSongs ) !== 'undefined')
-		 //	||  location.href.indexOf('music.') !== -1  // (=currently we are only running on www.youtube.com anyways)
-				)	{ player.setPlaybackRate(1); video.playbackRate = 1; console.log ("...,thus must be music?"); }
-				else { 	// Now this video might rarely be music
-					// - however we can make extra-sure after waiting for the video descripion to load... (#1539)
-					if (location.href.indexOf('/watch?') !== -1) {
-						let tries = 0;
-						const intervalMs = 210;
-						const maxTries = 10;
-						const waitForDescription = setInterval(() => {
-							const subtitle = document.querySelector('#title + #subtitle:last-of-type');
-							// console.log("[SPEED] checking for music keywords in the description... try " + tries + "// subtitle: " + subtitle?.innerHTML);
-							const descriptionSongCount = Number((subtitle?.innerHTML?.match(/^\d+/) || [])[0]);
-							if (subtitle && 1 <= descriptionSongCount && typeof testSongDuration(DATA.lengthSeconds, descriptionSongCount) !== 'undefined')
-							{player.setPlaybackRate(1); video.playbackRate = 1; console.log("...but YouTube shows music below the description!"); clearInterval(waitForDescription); return; }
-							if (++tries >= maxTries) {
-								// console.log("[SPEED] max tries reached, stopping description check...");
-								clearInterval(waitForDescription);
-							}
-						}, intervalMs);
-					}
+	if (location.href.indexOf('/watch?') === -1) {
+		return;
+	}
+	const player = this.elements.player;
+	if (!player) {
+		return;
+	}
+	let video = this.elements.video || player.querySelector('video');
+	let option = this.storage.player_playback_speed;
+	if (this.isset(option) === false) {
+		option = 1;
+	} else if (option !== 1) {
+		const speed = video?.playbackRate
+			? Number(video.playbackRate.toFixed(2))
+			: (player?.getPlaybackRate ? Number(player.getPlaybackRate().toFixed(2)) : null);
+		if (speed !== option && speed !== 1 && speed !== Number((Math.floor(option / 0.05) * 0.05).toFixed(2))) {
+			console.log('[improved:forceSpeed] skipping permanent speed, since speed was manually set differently for this video to:' + video.playbackRate + ', was it?');
+			return;
+		}
+	}
+	if (player.getVideoData() && player.getVideoData().isLive) {
+		return;
+	}
+
+	console.debug(`[improved:forceSpeed] setting permanent speed to ${option}`);
+	player.setPlaybackRate(Number(option));
+	if (!video) {
+		video = { playbackRate: 1 };
+	}
+	video.playbackRate = Number(option);
+
+	if ((this.storage.player_force_speed_on_music === true && this.storage.player_dont_speed_education !== true) || option === 1) {
+		return;
+	}
+
+	const testSongDuration = function (seconds, ytMusic) {
+		if (!seconds) {
+			return undefined;
+		}
+		if (135 <= seconds && seconds <= 260) { return 'veryCommon'; }
+		if (105 <= seconds && seconds <= 420) { return 'common'; }
+		if (420 <= seconds && seconds <= 720) { return 'long'; }
+		if (45 <= seconds && seconds <= 105) { return 'short'; }
+		if (ytMusic && ytMusic > 1 && (85 <= seconds / ytMusic && (seconds / ytMusic <= 375 || ytMusic === 10))) { return 'multiple'; }
+		return undefined;
+	};
+
+	const startedVideoId = ImprovedTube.videoId();
+	const defaultKeywords = 'video,sharing,camera,phone,video phone,free,upload';
+
+	(async () => {
+		try {
+			console.debug('[improved:forceSpeed] resolving metadata for videoId=' + startedVideoId);
+			const meta = await ImprovedTube.VideoMetadata.getDataAsync();
+			const amountOfSongs = await ImprovedTube.VideoMetadata.getAmountOfSongsAsync();
+			console.debug('[improved:forceSpeed] resolved metadata', meta, amountOfSongs);
+			if (startedVideoId !== ImprovedTube.videoId()) {
+				return;
+			}
+
+			const title = meta.title || '';
+			const genre = meta.genre || '';
+			const duration = meta.duration || '';
+			const lengthSeconds = meta.lengthSeconds || '';
+			let keywords = Array.isArray(meta.keywords) ? meta.keywords.join(', ') : '';
+
+			if (this.storage.player_dont_speed_education === true && genre === 'Education') {
+				player.setPlaybackRate(1);
+				video.playbackRate = 1;
+				return;
+			}
+			if (this.storage.player_force_speed_on_music === true) {
+				return;
+			}
+			if (keywords === defaultKeywords) {
+				keywords = '';
+			}
+
+			const musicIdentifiers = /(official|music|lyrics?)[ -]video|(cover|studio|radio|album|alternate)[- ]version|soundtrack|unplugged|\bmedley\b|\blo-fi\b|\blofi\b|a(lla)? cappella|feat\.|(piano|guitar|jazz|ukulele|violin|reggae)[- ](version|cover)|karaok|backing[- ]track|instrumental|(sing|play)[- ]?along|卡拉OK|卡拉OK|الكاريوكي|караоке|カラオケ|노래방|bootleg|mashup|Radio edit|Guest (vocals|musician)|(title|opening|closing|bonus|hidden)[ -]track|live acoustic|interlude|featuring|recorded (at|live)/i;
+			const musicIdentifiersTitleOnly = /lyrics|theme song|\bremix|\bAMV ?[^a-z0-9]|[^a-z0-9] ?AMV\b|\bfull song\b|\bsong:|\bsong[\!$]|^song\b|( - .*\bSong\b|\bSong\b.* - )|cover ?[^a-z0-9]|[^a-z0-9] ?cover|\bconcert\b/i;
+			const musicIdentifiersTitle = new RegExp(musicIdentifiersTitleOnly.source + '|' + musicIdentifiers.source, 'i');
+			let musicRegexMatch = musicIdentifiersTitle.test(title);
+			if (!musicRegexMatch) {
+				const musicIdentifiersTagsOnly = /\b(lyrics|remix|song|music|AMV|theme song|full song)\b|\(Musical Genre\)|\bjazz\b|\breggae\b/i;
+				const musicIdentifiersTags = new RegExp(musicIdentifiersTagsOnly.source + '|' + musicIdentifiers.source, 'i');
+				const keywordsAmount = 1 + ((keywords || '').match(/,/) || []).length;
+				if (((keywords || '').match(musicIdentifiersTags) || []).length / keywordsAmount > 0.08) {
+					musicRegexMatch = true;
 				}
 			}
-			//DATA  (TO-DO: make the Data available to more/all features? #1452  #1763  (Then can replace ImprovedTube.elements.category === 'music', VideoID is also used elsewhere)
-			DATA = {};
-			defaultKeywords = "video,sharing,camera,phone,video phone,free,upload";
-			keywords = false; amountOfSongs = false; 
-			
-			ImprovedTube.fetchDOMData = function () {	
-				try { DATA = JSON.parse(document.querySelector('#microformat script')?.textContent) ?? false; DATA.title = DATA.name;}
-			 catch { DATA.genre = false; DATA.keywords = false; DATA.lengthSeconds = false;
-					try { 
-						DATA.title = document.getElementsByTagName('meta')?.title?.content || false;
-						DATA.genre = document.querySelector('meta[itemprop=genre]')?.content || false;
-						DATA.duration = document.querySelector('meta[itemprop=duration]')?.content || false;
-			 } catch {}} 
-			  
-let tries = 0; const maxTries = 11; let intervalMs = 200;
-const waitForVideoTitle = setInterval(() => { const title = ImprovedTube.videoTitle?.();  tries++;
 
-if (title && title !== 'YouTube') {
-    clearInterval(waitForVideoTitle);
-			 DATA.videoID = ImprovedTube.videoId() || false;     // console.log("SPEED: TITLE:" + ImprovedTube.videoTitle() + DATA.title); 
-			 if ( DATA.title && (DATA.title === ImprovedTube.videoTitle() || DATA.title.replace(/\s{2,}/g, ' ') === ImprovedTube.videoTitle()) )
-				{ keywords = document.querySelector('meta[name="keywords"]')?.content || ''; ImprovedTube.speedException(); }
-				else { keywords = ''; (async function () { try { const response = await fetch(`https://www.youtube.com/watch?v=${DATA.videoID}`);
-					console.log("loading the html source:" + `https://www.youtube.com/watch?v=${DATA.videoID}`);
-					const htmlContent = await response.text();
-					const metaRegex = /<meta[^>]+(?:name|itemprop)=["'](keywords|genre|duration|title)["'][^>]+content=["']([^"']+)["'][^>]*>/gi;
-					let match; while ((match = metaRegex.exec(htmlContent)) !== null) { // console.log(match);
-						const [, property, value] = match;
-						if (property === 'keywords') { keywords = value;} else {DATA[property] = value;}
-					}
-					amountOfSongs = (htmlContent.slice(-80000).match(/},"subtitle":{"simpleText":"(\d*)\s/) || [])[1] || false;
-					if (keywords) { ImprovedTube.speedException(); }
-				} catch (error) { console.error('Error: fetching from https://Youtube.com/watch?v=${DATA.videoID}', error); keywords = ''; }
-				})(); 
-				}
-}
+			const notMusicRegexMatch = /\bdo[ck]u|interv[iyj]|back[- ]?stage|インタビュー|entrevista|面试|面試|회견|wawancara|مقابلة|интервью|entretien|기록한 것|记录|記錄|ドキュメンタリ|وثائقي|документальный/i.test(title + ' ' + keywords);
+			const songDurationType = testSongDuration(lengthSeconds);
+			// console.log('[improved:forceSpeed] genre: ' + genre + '//title: ' + title + '//keywords: ' + keywords + '//music word match: ' + musicRegexMatch + '// not music word match:' + notMusicRegexMatch + '//duration: ' + lengthSeconds + '//song duration type: ' + songDurationType);
+			console.log(`[improved:forceSpeed] genre:${genre}, musicRegexMatch:${musicRegexMatch}, notMusicRegexMatch:${notMusicRegexMatch}, songDurationType:${songDurationType}, amountOfSongs:${amountOfSongs}`, {meta:{title, keywords, lengthSeconds}});
 
-if (tries >= maxTries) {  clearInterval(waitForVideoTitle); } intervalMs *= 1.11; }, intervalMs);
-window.addEventListener('load', () => {  setTimeout(() => { clearInterval(waitForVideoTitle) }, 5000);});		 					
-			};
-			ImprovedTube.fetchDOMData();
-/*	
-			if ( (history && history.length === 1) || !history?.state?.endpoint?.watchEndpoint) { ImprovedTube.fetchDOMData(); }
-			else {
-				//Invidious instances. Should be updated automatically!...
-				const invidiousInstances = ['invidious.fdn.fr', 'inv.tux.pizza', 'invidious.flokinet.to', 'invidious.protokolla.fi', 'invidious.private.coffee', 'yt.artemislena.eu', 'invidious.materialio.us', 'iv.datura.network'];
-				function getRandomInvidiousInstance () { return invidiousInstances[Math.floor(Math.random() * invidiousInstances.length)];}
-
-				(async function () {	 let retries = 4;	let invidiousFetched = false;
-					async function fetchInvidiousData () {
-						try {const response = await fetch(`https://${getRandomInvidiousInstance()}/api/v1/videos/${DATA.videoID}?fields=genre,title,lengthSeconds,keywords`);
-			 DATA = await response.json();
-			 if (DATA.genre && DATA.title && DATA.keywords && DATA.lengthSeconds) { if (DATA.keywords.toString() === defaultKeywords ) {DATA.keywords = ''}
-				 ImprovedTube.speedException(); invidiousFetched = true;	}
-						} catch (error) { console.error('Error: Invidious API: ', error); }
-					}
-					while (retries > 0 && !invidiousFetched) { await fetchInvidiousData();
-						if (!invidiousFetched) { await new Promise(resolve => setTimeout(resolve, retries === 4 ? 1500 : 876)); retries--; }	}
-					if (!invidiousFetched) { if (document.readyState === 'loading') {document.addEventListener('DOMContentLoaded', ImprovedTube.fetchDOMData())}
-					else { ImprovedTube.fetchDOMData();} }
-				})();
+			if (
+				(genre === 'Music' && (!notMusicRegexMatch || songDurationType === 'veryCommon'))
+				|| (musicRegexMatch && !notMusicRegexMatch && (typeof songDurationType !== 'undefined'
+					|| (/album|Álbum|专辑|專輯|एलबम|البوم|アルバム|альбом|앨범|mixtape|concert|playlist|\b(live|cd|vinyl|lp|ep|compilation|collection|symphony|suite|medley)\b/i.test(title + ' ' + keywords)
+						&& 1000 <= lengthSeconds)))
+				|| (genre === 'Music' && musicRegexMatch && (typeof songDurationType !== 'undefined'
+					|| (/album|Álbum|专辑|專輯|एलबम|البوم|アルバム|альбом|앨범|mixtape|concert|playlist|\b(live|cd|vinyl|lp|ep|compilation|collection|symphony|suite|medley)\b/i.test(title + ' ' + keywords)
+						&& 1000 <= lengthSeconds)))
+				|| (amountOfSongs && typeof testSongDuration(lengthSeconds, amountOfSongs) !== 'undefined')
+			) {
+				player.setPlaybackRate(1);
+				video.playbackRate = 1;
+				console.log('[improved:forceSpeed] ...,thus must be music?', ImprovedTube.VideoMetadata.dumpData());
+				return;
 			}
-*/		
-		}	// else { }
-	}
-}
-} 
+
+			if (amountOfSongs === null && location.href.indexOf('/watch?') !== -1) {
+				let tries = 0;
+				const intervalMs = 210;
+				const maxTries = 10;
+				const waitForDescription = setInterval(() => {
+					const subtitle = document.querySelector('#title + #subtitle:last-of-type');
+					const descriptionSongCount = Number((subtitle?.innerHTML?.match(/^\d+/) || [])[0]);
+					if (subtitle && 1 <= descriptionSongCount && typeof testSongDuration(lengthSeconds, descriptionSongCount) !== 'undefined') {
+						player.setPlaybackRate(1);
+						video.playbackRate = 1;
+						console.log('[improved:forceSpeed] ...but YouTube shows music below the description!');
+						clearInterval(waitForDescription);
+						return;
+					}
+					if (++tries >= maxTries) {
+						clearInterval(waitForDescription);
+						console.log('[improved:forceSpeed] not music', ImprovedTube.VideoMetadata.dumpData());
+					}
+				}, intervalMs);
+			} else {
+				if (amountOfSongs > 0) {
+					console.log(`[improved:forceSpeed] not music. ${(lengthSeconds/amountOfSongs).toFixed(1)}(sec/song)`, ImprovedTube.VideoMetadata.dumpData());
+				} else {
+					console.log('[improved:forceSpeed] not music.', ImprovedTube.VideoMetadata.dumpData());
+				}
+			}
+		} catch (error) {
+			console.error('[improved:forceSpeed] playerPlaybackSpeed: failed to resolve metadata', error);
+		}
+	})();
+};
 /*------------------------------------------------------------------------------
 SUBTITLES
 ------------------------------------------------------------------------------*/
@@ -2273,98 +2274,27 @@ ImprovedTube.selectDubbedLanguage = function () {
 # JUMP TO THE NEXT KEY SCENE
 ------------------------------------------------------------------------------*/
 ImprovedTube.jumpToKeyScene = function () {
-	ImprovedTube.mostReplayed = function () {	
-	const player = document.querySelector('video');
-
-	const data = extractYtInitialData();
-	if (!data) 
-		return console.warn("Failed to extract ytInitialData.");  
-		
-	const markers = getMostReplayedMarkers(data);
-	if (!markers.length) 
-		return console.warn("No 'Most Replayed' markers found.");
-	
-	const currentMillis = player.currentTime * 1000;
-	const sortedMarkers = markers.slice().sort((a, b) => a.decorationTimeMillis - b.decorationTimeMillis);
-	const nextMarker = sortedMarkers.find(m => m.decorationTimeMillis > currentMillis) || sortedMarkers[0]; // fallback to first if none ahead
-	const targetSeconds = nextMarker.decorationTimeMillis / 1000;
-	
-	player.currentTime = targetSeconds;
-	player.play();
-	console.log(`Jumped to Most Replayed @ ${Math.floor(targetSeconds / 60)}:${Math.floor(targetSeconds % 60).toString().padStart(2, "0")}`);	
-
-	function extractYtInitialData() {		
-		const scriptTags = document.querySelectorAll('script');
-
-		for (let i = 0; i < scriptTags.length; i++) {			
-			if (DATA.ytInitialData) { var ytIData = DATA.ytInitialData; }
-			else {
-			const scriptContent = scriptTags[i].textContent;
-			var ytIData = scriptContent.match(/var ytInitialData = ({.*?});/s);
-			}
-			
-			if (ytIData) {
-				try {
-					return JSON.parse(ytIData[1]);
-				} catch (e) {
-					console.warn("Failed to parse ytInitialData JSON", e);
-					return null;
-				}	
-			}
+	ImprovedTube.VideoMetadata.getMostReplayedMarkersAsync().then(markers => {
+		if (!markers.length) {
+			console.debug("[Improved:jump] No 'Most Replayed' markers found.");
+			return;
 		}
-
-		return null;
-	}
-
-	function getMostReplayedMarkers(parsedJson) {    
-		const decorations = parsedJson?.['frameworkUpdates']?.['entityBatchUpdate']?.['mutations']?.[0]
-			?.['payload']?.['macroMarkersListEntity']?.['markersList']?.['markersDecoration']?.['timedMarkerDecorations'];
-		return decorations;
-	}
-	}
-	
-		DATA = {};
-			ImprovedTube.fetchDOMData2 = function () {	
-				try { DATA = JSON.parse(document.querySelector('#microformat script')?.textContent) ?? false; DATA.title = DATA.name;}
-			 catch { DATA.genre = false; DATA.keywords = false; DATA.lengthSeconds = false;
-					try { 
-						DATA.title = document.getElementsByTagName('meta')?.title?.content || false;
-						DATA.genre = document.querySelector('meta[itemprop=genre]')?.content || false;
-						DATA.duration = document.querySelector('meta[itemprop=duration]')?.content || false;
-			 } catch {}} 
-			  
-let tries = 0; const maxTries = 3; let intervalMs = 25;
-const waitForVideoTitle = setInterval(() => { const title = ImprovedTube.videoTitle?.();  tries++;
-if (title && title !== 'YouTube') {
-    clearInterval(waitForVideoTitle);
-			 DATA.videoID = ImprovedTube.videoId() || false;  
-			 console.log("MOST REPLAYED: TITLE:" + ImprovedTube.videoTitle() + DATA.title); 
-			 if ( (DATA.title === ImprovedTube.videoTitle() || DATA.title.replace(/\s{2,}/g, ' ') === ImprovedTube.videoTitle())
-				   && ((history && history.length === 1) || !history?.state?.endpoint?.watchEndpoint)) 
-				   { ImprovedTube.mostReplayed(); }
-				else { keywords = ''; (async function () { try { const response = await fetch(`https://www.youtube.com/watch?v=${DATA.videoID}`);
-					console.log("loading the html source:" + `https://www.youtube.com/watch?v=${DATA.videoID}`);
-					const htmlContent = await response.text();
-					DATA.ytInitialData = htmlContent.match(/var ytInitialData = ({.*?});/s);
-					if (DATA.ytInitialData) { ImprovedTube.mostReplayed(); }
-				} catch (error) { 
-const o = Object.assign(document.createElement('div'), { innerText: 'too few views' });
-const keySceneButton = document.querySelector('button[data-tooltip="Key Scene"]');
-		if (keySceneButton) {  keySceneButton.style.transition = 'opacity 0.4s';  keySceneButton.style.opacity = '0.3'; 
-		setTimeout(() => {    keySceneButton.style.opacity = '0.8';    }, 5000);}
-		console.error(`Error: fetching from https://Youtube.com/watch?v=${DATA.videoID}`, error);  }
-				})(); 
-				}
-}
-
-if (tries >= maxTries) {  clearInterval(waitForVideoTitle); } intervalMs *= 1.11; }, intervalMs);
-window.addEventListener('load', () => {  setTimeout(() => { clearInterval(waitForVideoTitle) }, 5000);});		 					
-			};
-			ImprovedTube.fetchDOMData2();
-
-
-
-
+		const player = document.querySelector('video');
+		if (!player) {
+			console.warn("[Improved:jump] No video player found.");
+			return;
+		}
+		const currentMillis = player.currentTime * 1000;
+		const sortedMarkers = markers.slice().sort((a, b) => a.decorationTimeMillis - b.decorationTimeMillis);
+		const nextMarker = sortedMarkers.find(m => m.decorationTimeMillis > currentMillis) || sortedMarkers[0]; // fallback to first if none ahead
+		const targetSeconds = nextMarker.decorationTimeMillis / 1000;
+		
+		player.currentTime = targetSeconds;
+		player.play();
+		console.log(`[Improved:jump] Jumped to Most Replayed @ ${Math.floor(targetSeconds / 60)}:${Math.floor(targetSeconds % 60).toString().padStart(2, "0")}`);	
+	}).catch(error => {
+		console.error("[Improved:jump] Error fetching Most Replayed markers:", error);
+	});
 }
 
 /*------------------------------------------------------------------------------

--- a/js&css/web-accessible/www.youtube.com/video-metadata.js
+++ b/js&css/web-accessible/www.youtube.com/video-metadata.js
@@ -1,0 +1,929 @@
+/*
+ * VideoMetadata resolves metadata for the active YouTube video.
+ * It ignores stale DOM payloads after SPA navigations, prefers current player
+ * state, and falls back to fetching the watch page when required fields or
+ * marker data are missing.
+ */
+let videoMetadataTrustedTypesPolicy = null;
+const VIDEO_METADATA_BASE_KEYS = ['title', 'keywords', 'genre', 'duration', 'lengthSeconds'];
+const VIDEO_METADATA_DEFERRED_KEYS = ['mostReplayedMarkers', 'heatmapMarkers', 'amountOfSongs'];
+const VIDEO_METADATA_FIELD_KEYS = [...VIDEO_METADATA_BASE_KEYS, ...VIDEO_METADATA_DEFERRED_KEYS];
+const VIDEO_METADATA_REQUIRED_KEYS = ['title', 'keywords', 'genre', 'duration'];
+
+function createVideoMetadataData (videoId = null) {
+	const data = {videoId};
+	for (const key of VIDEO_METADATA_FIELD_KEYS) {
+		data[key] = null;
+	}
+	return data;
+}
+
+ImprovedTube.VideoMetadata = {
+	// Public async entry point for callers that want a stable basic metadata snapshot.
+	getDataAsync: async function (force) {
+		try {
+			this._init(force);
+			await this._waitForPendingWork();
+		} catch (error) {
+			console.warn('[improved:meta] getDataAsync: failed', error);
+		}
+		return this.data;
+	},
+	// Public async entry point for callers that also need Most Replayed and heatmap marker data.
+	getDataWithHeatmapAsync: async function (force) {
+		try {
+			await this.getDataAsync(force);
+			await this.getMostReplayedMarkersAsync();
+			await this.getHeatmapMarkersAsync();
+		} catch (error) {
+			console.warn('[improved:meta] getDataWithHeatmapAsync: failed', error);
+		}
+		return this.data;
+	},
+	// Experimental API for querySelector-style access.
+	// The returned DOM is not the complete DOM,
+	// as it is only the parsed fetched HTML and no scripts have been executed.
+	// Returns { videoId, document, source }.
+	// - videoId : resolved target video id
+	// - document: current page DOM, fetched watch page DOM, or null
+	// - source  : 'current', 'fetched', or null
+	getResolvedDocumentAsync: async function (force) {
+		try {
+			this._init(force);
+			await this._waitForPendingWork();
+
+			const videoId = this.data.videoId || this._getVideoId();
+			if (!videoId) {
+				return { videoId: null, document: null, source: null };
+			}
+
+			let fetchedDocument = this._getCachedFetchedDocument(videoId) || this._parseFetchedHtml(videoId);
+			if (fetchedDocument) {
+				return { videoId, document: fetchedDocument, source: 'fetched' };
+			}
+
+			const currentTitle = this._getCurrentTitle();
+			const domStatus = this._getDomStatus(videoId, currentTitle);
+			this.state.domStatus = domStatus;
+
+			if (!force && domStatus === 'current') {
+				return { videoId, document, source: 'current' };
+			}
+
+			if (force || domStatus !== 'current') {
+				await this._fetchWatchPage(videoId, 'query-document');
+				await this._waitForPendingWork();
+				fetchedDocument = this._getCachedFetchedDocument(videoId) || this._parseFetchedHtml(videoId);
+			}
+
+			if (fetchedDocument) {
+				return { videoId, document: fetchedDocument, source: 'fetched' };
+			}
+
+			if (domStatus === 'current') {
+				return { videoId, document, source: 'current' };
+			}
+
+			return { videoId, document: null, source: null };
+		} catch (error) {
+			console.warn('[improved:meta] getResolvedDocumentAsync: failed', error);
+			return { videoId: this.data?.videoId || null, document: null, source: null };
+		}
+	},
+	// getter
+	getVideoTitleAsync: async function (force) {
+		return this._getFieldAsync('title', force);
+	},
+	getKeywordsAsync: async function (force) {
+		return this._getFieldAsync('keywords', force);
+	},
+	getGenreAsync: async function (force) {
+		return this._getFieldAsync('genre', force);
+	},
+	getDurationAsync: async function (force) {
+		return this._getFieldAsync('duration', force);
+	},
+	getLengthSecondsAsync: async function (force) {
+		return this._getFieldAsync('lengthSeconds', force);
+	},
+	getMostReplayedMarkersAsync: async function (force) {
+		return this._getDeferredFieldAsync('mostReplayedMarkers', () => this._loadMarkerField('mostReplayedMarkers'), force);
+	},
+	getHeatmapMarkersAsync: async function (force) {
+		return this._getDeferredFieldAsync('heatmapMarkers', () => this._loadMarkerField('heatmapMarkers'), force);
+	},
+	// Returns null when the song count is unknown or not found; it does not mean zero songs.
+	getAmountOfSongsAsync: async function (force) {
+		return this._getDeferredFieldAsync('amountOfSongs', () => this._loadAmountOfSongs(), force);
+	},
+	_getFieldAsync: async function (key, force) {
+		await this.getDataAsync(force);
+		return this.data[key];
+	},
+	_getDeferredFieldAsync: async function (key, loader, force) {
+		try {
+			this._init(force);
+			loader();
+			await this._waitForPendingWork();
+			return this.data[key] != null ? this.data[key] : loader();
+		} catch (error) {
+			console.warn(`[improved:meta] getDeferredFieldAsync: failed key=${key}`, error);
+			return this.data?.[key] ?? null;
+		}
+	},
+	dumpData: function () {
+		try {
+			// Extract and handle `fetchedDocument` separately because `structuredClone()` fails on it.
+			const {fetchedDocument, ...state} = this.state;
+			const ret = {
+				data: this.data,
+				state: state,
+				rawYtInitialData: this.rawYtInitialData,
+				rawYtInitialPlayerResponse: this.rawYtInitialPlayerResponse,
+				fetchPromise: this.fetchPromise === null ? 'null' : '(promise)',
+			}
+			ret.state.fetchedDocument = fetchedDocument?.documentElement?.outerHTML;
+			return structuredClone(ret);
+		} catch (e) {
+			console.warn('[improved:meta] dumpData: structuredClone failed', e);
+			return structuredClone(this.data);
+		}
+	},
+	_reset: function (videoId = null) {
+		this._clearRefreshRetry();
+		this.data = createVideoMetadataData(videoId);
+		this.state = {
+			domStatus: 'unknown',
+			fetchStatus: 'idle',
+			fetchedDocument: null,
+			fetchedDocumentVideoId: null,
+			fetchedHtml: null,
+			fetchedHtmlVideoId: null,
+			lastFetchReason: null,
+			lastUpdate: 0,
+			retryCount: 0,
+			retryTimer: null,
+			retryVideoId: null,
+			source: {},
+		};
+		this.rawYtInitialData = null;
+		this.rawYtInitialPlayerResponse = null;
+		this.fetchPromise = null;
+		return this.data;
+	},
+	_init: function (force) {
+		if (!this.data || !this.state) {
+			this._reset();
+		}
+
+		const videoId = this._getVideoId();
+		if (!videoId) {
+			return this.data;
+		}
+
+		if (force || this.data.videoId !== videoId) {
+			this._reset(videoId);
+		} else if (this.data.videoId === videoId && this.state?.lastUpdate) {
+			return this.data;
+		}
+
+		return this._refresh(force);
+	},
+	_refresh: function (force) {
+		const videoId = this.data.videoId || this._getVideoId();
+		if (!videoId) {
+			return this.data;
+		}
+
+		const currentTitle = this._getCurrentTitle();
+		this._setValue('title', currentTitle, 'currentTitle');
+		const domStatus = this._getDomStatus(videoId, currentTitle);
+		this.state.domStatus = domStatus;
+
+		// Fill base metadata from current player/page first; fetched cache is only used for fields still missing.
+		const playerResponse = this._getPlayerResponse();
+		this._applyPartialData(this._buildPlayerPartial(playerResponse, videoId), 'playerResponse');
+
+		if (domStatus !== 'stale') {
+			this._applyPartialData(this._buildDomPartial(document, videoId, currentTitle), 'dom');
+		}
+		if (VIDEO_METADATA_BASE_KEYS.some(key => !this._hasValue(this.data[key]))) {
+			const cachedFetchedDocument = this._getCachedFetchedDocument(videoId) || this._parseFetchedHtml(videoId);
+			if (cachedFetchedDocument) {
+				this._applyPartialData(this._buildDomPartial(cachedFetchedDocument, videoId, currentTitle || this.data.title), 'cachedFetchedDom');
+			}
+		}
+
+		// Fetch only when required fields are still missing or the current DOM is stale.
+		const fetchReason = this._getFetchReason(force);
+		if (!fetchReason) {
+			this._clearRefreshRetry();
+			console.debug(`[improved:meta] refresh: no fetch needed videoId=${videoId}`);
+		} else if (fetchReason === 'stale-dom') {
+			// console.debug(`[improved:meta] refresh: stale DOM, fetching watch page videoId=${videoId}`, this.dumpData());
+			this._clearRefreshRetry();
+			this._fetchWatchPage(videoId, fetchReason);
+		} else if (this._shouldRetryBeforeFetch(videoId, fetchReason, currentTitle, playerResponse)) {
+			// console.debug(`[improved:meta] refresh: scheduling retry for videoId=${videoId} fetchReason=${fetchReason}`, this.dumpData());
+			this._scheduleRefreshRetry(videoId, fetchReason);
+		} else {
+			// console.debug(`[improved:meta] refresh: fetching watch page videoId=${videoId}`, this.dumpData());
+			this._clearRefreshRetry();
+			this._fetchWatchPage(videoId, fetchReason);
+		}
+
+		if (!this._hasValue(this.data.duration) && this._hasValue(this.data.lengthSeconds)) {
+			this.data.duration = this._secondsToIsoDuration(this.data.lengthSeconds);
+			this.state.source.duration = this.state.source.duration || this.state.source.lengthSeconds || 'derived';
+		}
+
+		if (!this._hasValue(this.data.lengthSeconds) && this._hasValue(this.data.duration)) {
+			this.data.lengthSeconds = this._isoDurationToSeconds(this.data.duration);
+			this.state.source.lengthSeconds = this.state.source.lengthSeconds || this.state.source.duration || 'derived';
+		}
+
+		this.state.lastUpdate = Date.now();
+		// console.debug(`[improved:meta] refresh: completed videoId=${videoId}`, this.dumpData());
+		return this.data;
+	},
+	_waitForPendingWork: async function () {
+		while (this.state?.retryTimer || this.fetchPromise) {
+			if (this.fetchPromise) {
+				await this.fetchPromise;
+				continue;
+			}
+			await new Promise(resolve => setTimeout(resolve, 25));
+		}
+	},
+	_loadMarkerField: function (fieldName) {
+		if (this.data[fieldName] != null) {
+			return this.data[fieldName];
+		}
+		const expectedVideoId = this.data.videoId;
+		const playerResponse = this._getPlayerResponse();
+		const currentPlayerResponse = this._isPlayerResponseCurrent(playerResponse, expectedVideoId) ? playerResponse : null;
+		const currentWindowPlayerResponse = this._isPlayerResponseCurrent(window.ytInitialPlayerResponse, expectedVideoId) ? window.ytInitialPlayerResponse : null;
+		const currentRawPlayerResponse = this._isPlayerResponseCurrent(this.rawYtInitialPlayerResponse, expectedVideoId) ? this.rawYtInitialPlayerResponse : null;
+		// Prefer current player/page data, then fall back to fetched watch-page data kept in rawYtInitial*.
+		const markerSources = [
+			['playerResponse', currentPlayerResponse],
+			['window.ytInitialData', this.state?.domStatus === 'current' ? window.ytInitialData : null],
+			['window.ytInitialPlayerResponse', currentWindowPlayerResponse],
+			['rawYtInitialData', this.rawYtInitialData],
+			['rawYtInitialPlayerResponse', currentRawPlayerResponse],
+		];
+
+		for (const [sourceName, rootObject] of markerSources) {
+			const markerData = this._extractMarkerData(rootObject);
+			if (markerData) {
+				this._setValue('mostReplayedMarkers', markerData.mostReplayedMarkers, sourceName);
+				this._setValue('heatmapMarkers', markerData.heatmapMarkers, sourceName);
+			}
+			if (this.data[fieldName] != null) {
+				return this.data[fieldName];
+			}
+		}
+		if (this.data[fieldName] == null && this.data.videoId && this.state.fetchStatus === 'idle') {
+			this._fetchWatchPage(this.data.videoId, 'missing:ytInitialData');
+		}
+		if (this.data[fieldName] == null && this.state.fetchStatus === 'done') {
+			this.data[fieldName] = [];
+			this.state.source[fieldName] = 'not-found';
+		}
+
+		return this.data[fieldName];
+	},
+	_loadAmountOfSongs: function () {
+		if (this.data.amountOfSongs != null) {
+			return this.data.amountOfSongs;
+		}
+		if (this.state.source.amountOfSongs === 'not-found') {
+			return null;
+		}
+
+		// Use the same source order as marker loading; rawYtInitialData is only updated by watch-page fetches.
+		const songCountSources = [
+			['window.ytInitialData', this.state?.domStatus === 'current' ? window.ytInitialData : null],
+			['rawYtInitialData', this.rawYtInitialData],
+		];
+
+		for (const [sourceName, rootObject] of songCountSources) {
+			const count = this._findSongCount(rootObject);
+			if (count) {
+				this._setValue('amountOfSongs', count, sourceName);
+				return this.data.amountOfSongs;
+			}
+		}
+
+		if (this.data.amountOfSongs == null && this.data.videoId && this.state.fetchStatus === 'idle') {
+			this._fetchWatchPage(this.data.videoId, 'missing:ytInitialData');
+		}
+		if (this.data.amountOfSongs == null && this.state.fetchStatus === 'done') {
+			this.state.source.amountOfSongs = 'not-found';
+		}
+
+		return this.data.amountOfSongs;
+	},
+	_getFetchReason: function (force) {
+		if (force) {
+			return 'forced';
+		}
+		if (this.fetchPromise) {
+			return null;
+		}
+		if (this.state.fetchStatus === 'done' || this.state.fetchStatus === 'failed') {
+			return null;
+		}
+
+		const missingRequired = VIDEO_METADATA_REQUIRED_KEYS.filter(key => !this._hasValue(this.data[key]));
+		if (missingRequired.length) {
+			return 'missing:' + missingRequired.join(',');
+		}
+		if (this.state.domStatus === 'stale') {
+			return 'stale-dom';
+		}
+
+		return null;
+	},
+	_shouldRetryBeforeFetch: function (videoId, fetchReason, currentTitle, playerResponse) {
+		if (!videoId || !fetchReason?.startsWith('missing:')) {
+			return false;
+		}
+		if (this.state.retryCount >= 10 || this.state.domStatus === 'stale') {
+			return false;
+		}
+
+		const hasCurrentTitle = this._hasValue(currentTitle);
+		const hasPlayerResponse = Boolean(playerResponse);
+		return !hasCurrentTitle || !hasPlayerResponse || this.state.domStatus === 'unknown';
+	},
+	_scheduleRefreshRetry: function (videoId, fetchReason) {
+		if (this.state.retryTimer && this.state.retryVideoId === videoId) {
+			return;
+		}
+
+		this._clearRefreshRetry(false);
+		this.state.retryVideoId = videoId;
+		this.state.retryCount += 1;
+
+		const delay = this.state.retryCount === 1 ? 150 : 300;
+		console.debug(`[improved:meta] scheduleRefreshRetry: videoId=${videoId} reason=${fetchReason} retry=${this.state.retryCount} delay=${delay}`);
+		this.state.retryTimer = setTimeout(() => {
+			if (!this.state) {
+				return;
+			}
+			this.state.retryTimer = null;
+
+			if (this.data.videoId !== videoId) {
+				console.debug(`[improved:meta] scheduleRefreshRetry: canceled stale retry videoId=${videoId} current=${this.data.videoId}`);
+				return;
+			}
+
+			console.debug(`[improved:meta] scheduleRefreshRetry: retrying refresh videoId=${videoId} retry=${this.state.retryCount}`);
+			try {
+				this._refresh(false);
+			} catch (error) {
+				console.warn(`[improved:meta] scheduleRefreshRetry: refresh failed videoId=${videoId}`, error);
+			}
+		}, delay);
+	},
+	_clearRefreshRetry: function (resetCount = true) {
+		if (this.state?.retryTimer) {
+			clearTimeout(this.state.retryTimer);
+		}
+		if (!this.state) {
+			return;
+		}
+
+		this.state.retryTimer = null;
+		this.state.retryVideoId = null;
+		if (resetCount) {
+			this.state.retryCount = 0;
+		}
+	},
+	_getVideoId: function (url = document.URL) {
+		return ImprovedTube.videoId(url);
+	},
+	_getCurrentTitle: function () {
+		const player = document.getElementById('movie_player');
+		const playerTitle = this._normalizeText(player?.getVideoData?.().title);
+		if (playerTitle) {
+			console.debug(`[improved:meta] getCurrentTitle: playerTitle:${playerTitle}`);
+			return playerTitle;
+		}
+
+		const headingTitle = this._normalizeText(document.querySelector('title')?.textContent?.replace(/\s*-\s*YouTube$/, ''));
+		if (headingTitle) {
+			console.debug(`[improved:meta] getCurrentTitle: headingTitle:${headingTitle}`);
+			return headingTitle;
+		}
+
+		console.warn('[improved:meta] getCurrentTitle: failed to resolve current title from player and DOM heading');
+		return '';
+	},
+	_getPlayerResponse: function () {
+		try {
+			return movie_player?.getPlayerResponse?.() || window.ytInitialPlayerResponse || null;
+		} catch (error) {
+			console.warn('[ImprovedTube:VideoMetadata] Failed to read player response.', error);
+			return null;
+		}
+	},
+	_getPlayerResponseVideoId: function (playerResponse) {
+		return this._normalizeText(
+			playerResponse?.videoDetails?.videoId
+			|| playerResponse?.currentVideoEndpoint?.watchEndpoint?.videoId
+		);
+	},
+	_isPlayerResponseCurrent: function (playerResponse, expectedVideoId) {
+		if (!playerResponse) {
+			return false;
+		}
+		const responseVideoId = this._getPlayerResponseVideoId(playerResponse);
+		return Boolean(responseVideoId && expectedVideoId && responseVideoId === expectedVideoId);
+	},
+	_getDomStatus: function (currentVideoId, currentTitle) {
+		const metaTitle = this._normalizeText(document.querySelector('meta[name="title"]')?.getAttribute('content'));
+		if (metaTitle && currentTitle && metaTitle !== currentTitle) {
+			console.log('[improved:meta] getDomStatus: title mismatch.', { currentTitle, metaTitle });
+			return 'stale';
+		}
+		return 'current';
+	},
+	_storeFetchedHtml: function (videoId, html) {
+		if (!videoId || typeof html !== 'string') {
+			return;
+		}
+		this.state.fetchedHtml = html;
+		this.state.fetchedHtmlVideoId = videoId;
+		this.state.fetchedDocument = null;
+		this.state.fetchedDocumentVideoId = null;
+	},
+	_getCachedFetchedHtml: function (videoId) {
+		if (!videoId || this.state.fetchedHtmlVideoId !== videoId) {
+			return null;
+		}
+		return this.state.fetchedHtml || null;
+	},
+	_storeFetchedDocument: function (videoId, doc) {
+		if (!videoId || !doc) {
+			return;
+		}
+		this.state.fetchedDocument = doc;
+		this.state.fetchedDocumentVideoId = videoId;
+	},
+	_getCachedFetchedDocument: function (videoId) {
+		if (!videoId || this.state.fetchedDocumentVideoId !== videoId) {
+			return null;
+		}
+		return this.state.fetchedDocument || null;
+	},
+	_parseFetchedHtml: function (videoId) {
+		const cachedDocument = this._getCachedFetchedDocument(videoId);
+		if (cachedDocument) {
+			return cachedDocument;
+		}
+
+		const html = this._getCachedFetchedHtml(videoId);
+		if (!html) {
+			return null;
+		}
+
+		try {
+			const safeHtml = this._getSafeHtmlForParser(html);
+			if (!safeHtml) {
+				console.warn(`[improved:meta] parseFetchedHtml: skipped fetched DOM parse videoId=${videoId}`);
+				return null;
+			}
+
+			const parser = new DOMParser();
+			const doc = parser.parseFromString(safeHtml, 'text/html');
+			this._storeFetchedDocument(videoId, doc);
+			console.debug(`[improved:meta] parseFetchedHtml: parsed cached fetched DOM videoId=${videoId}`);
+			return doc;
+		} catch (error) {
+			console.warn(`[improved:meta] parseFetchedHtml: failed to parse fetched DOM videoId=${videoId}`, error);
+			return null;
+		}
+	},
+	_fetchWatchPage: function (videoId, reason) {
+		if (!videoId) {
+			return null;
+		}
+		if (this.fetchPromise) {
+			return this.fetchPromise;
+		}
+
+		this._clearRefreshRetry();
+		this.state.fetchStatus = 'pending';
+		this.state.lastFetchReason = reason;
+		console.debug(`[improved:meta] fetchWatchPage: start videoId=${videoId} reason=${reason || 'unknown'}`);
+
+		this.fetchPromise = fetch(`https://www.youtube.com/watch?v=${videoId}`, {credentials: 'same-origin'})
+			.then(response => response.text())
+			.then(html => {
+				if (this.data.videoId !== videoId) {
+					console.debug(`[improved:meta] fetchWatchPage: ignored stale response videoId=${videoId} current=${this.data.videoId}`);
+					return this.data;
+				}
+
+				this._storeFetchedHtml(videoId, html);
+				const fetchedYtInitialData = this._extractInlineJsonByMarker(html, 'var ytInitialData = ');
+				const fetchedPlayerResponse = this._extractInlineJsonByMarker(html, 'var ytInitialPlayerResponse = ');
+				// console.debug(`[improved:meta] fetchWatchPage: parsed videoId=${videoId} ytInitialData=${Boolean(fetchedYtInitialData)} ytInitialPlayerResponse=${Boolean(fetchedPlayerResponse)}`);
+				if (!fetchedYtInitialData && !fetchedPlayerResponse) {
+					console.warn(`[improved:meta] fetchWatchPage: fetched html did not contain ytInitialData or ytInitialPlayerResponse videoId=${videoId}`);
+				}
+
+				// Keep fetched inline payloads as the raw fallback source for deferred metadata loaders.
+				this.rawYtInitialData = fetchedYtInitialData;
+				this.rawYtInitialPlayerResponse = fetchedPlayerResponse;
+				this._applyPartialData(this._buildPlayerPartial(fetchedPlayerResponse, videoId), 'fetchedPlayerResponse');
+
+				if (VIDEO_METADATA_BASE_KEYS.some(key => !this._hasValue(this.data[key]))) {
+					const doc = this._parseFetchedHtml(videoId);
+					if (doc) {
+						console.debug(`[improved:meta] fetchWatchPage: applying fetched DOM partial videoId=${videoId}`);
+						this._applyPartialData(this._buildDomPartial(doc, videoId, this.data.title), 'fetchedDom');
+					}
+				} else {
+					console.debug(`[improved:meta] fetchWatchPage: skipped fetched HTML parsing videoId=${videoId}`);
+				}
+
+				this.state.fetchStatus = 'done';
+				this.state.lastUpdate = Date.now();
+				// console.debug(`[improved:meta] fetchWatchPage: done videoId=${videoId}`);
+				return this.data;
+			}).catch(error => {
+				this.state.fetchStatus = 'failed';
+				console.error('[improved:meta] fetchWatchPage: failed', {error: error, dump: this.dumpData()});
+				return this.data;
+			}).finally(() => {
+				// console.debug(`[improved:meta] fetchWatchPage: finalize videoId=${videoId} status=${this.state.fetchStatus}`, this.dumpData());
+				console.debug(`[improved:meta] fetchWatchPage: finalize videoId=${videoId} status=${this.state.fetchStatus}`);
+				this.fetchPromise = null;
+			});
+
+		return this.fetchPromise;
+	},
+	_readMicroformat: function (doc) {
+		try {
+			const text = doc.querySelector('#microformat script')?.textContent;
+			return text ? JSON.parse(text) : null;
+		} catch (error) {
+			return null;
+		}
+	},
+	_getSafeHtmlForParser: function (html) {
+		if (!html || typeof html !== 'string') {
+			return null;
+		}
+		if (!window.trustedTypes || typeof window.trustedTypes.createPolicy !== 'function') {
+			return null;
+		}
+		if (!videoMetadataTrustedTypesPolicy) {
+			try {
+				videoMetadataTrustedTypesPolicy = window.trustedTypes.createPolicy('improvedtube-metadata-parser', {
+					createHTML: value => value,
+				});
+			} catch (error) {
+				console.warn('[improved:meta] getSafeHtmlForParser: failed to create Trusted Types policy', error);
+				return null;
+			}
+		}
+		try {
+			const trustedHtml = videoMetadataTrustedTypesPolicy.createHTML(html);
+			return trustedHtml;
+		} catch (error) {
+			console.warn('[improved:meta] getSafeHtmlForParser: failed to convert html to TrustedHTML', error);
+			return null;
+		}
+	},
+	_extractInlineJsonByMarker: function (text, marker) {
+		if (!text) {
+			return null;
+		}
+
+		const markerIndex = text.indexOf(marker);
+		if (markerIndex === -1) {
+			return null;
+		}
+
+		const objectText = this._extractInlineObjectLiteral(text, markerIndex + marker.length);
+		if (!objectText) {
+			console.warn(`[improved:meta] extractInlineJsonByMarker: failed to find object literal for marker=${marker}`);
+			return null;
+		}
+
+		try {
+			return JSON.parse(objectText);
+		} catch (error) {
+			console.warn(`[improved:meta] extractInlineJsonByMarker: failed to parse JSON for marker=${marker}`, error);
+		}
+
+		return null;
+	},
+	_extractInlineObjectLiteral: function (text, startIndex) {
+		const objectStart = text.indexOf('{', startIndex);
+		if (objectStart === -1) {
+			return null;
+		}
+		// Extract the first balanced object literal after startIndex, ignoring braces inside quoted strings.
+		let depth = 0;
+		let quote = '';
+		let escaped = false;
+		for (let index = objectStart; index < text.length; index++) {
+			const char = text[index];
+
+			if (quote) {
+				if (escaped) {
+					escaped = false;
+					continue;
+				}
+				if (char === '\\') {
+					escaped = true;
+					continue;
+				}
+				if (char === quote) {
+					quote = '';
+				}
+				continue;
+			}
+
+			if (char === '"' || char === '\'') {
+				quote = char;
+				continue;
+			}
+			if (char === '{') {
+				depth++;
+				continue;
+			}
+			if (char === '}') {
+				depth--;
+				if (depth === 0) {
+					return text.slice(objectStart, index + 1);
+				}
+			}
+		}
+
+		return null;
+	},
+	_buildPlayerPartial: function (playerResponse, expectedVideoId) {
+		if (!playerResponse) {
+			return null;
+		}
+
+		const responseVideoId = this._getPlayerResponseVideoId(playerResponse);
+		if (responseVideoId && expectedVideoId && responseVideoId !== expectedVideoId) {
+			console.warn(`[improved:meta] buildPlayerPartial: playerResponse videoId mismatch response=${responseVideoId} expected=${expectedVideoId}`);
+			return null;
+		}
+
+		const lengthSeconds = this._normalizeLengthSeconds(
+			playerResponse?.videoDetails?.lengthSeconds
+			|| playerResponse?.microformat?.playerMicroformatRenderer?.lengthSeconds
+		);
+
+		return {
+			title: this._normalizeText(playerResponse?.videoDetails?.title),
+			keywords: this._normalizeKeywords(playerResponse?.videoDetails?.keywords),
+			genre: this._normalizeText(playerResponse?.microformat?.playerMicroformatRenderer?.category),
+			duration: this._secondsToIsoDuration(lengthSeconds),
+			lengthSeconds,
+		};
+	},
+	_buildDomPartial: function (doc, expectedVideoId, currentTitle) {
+		const partial = {};
+		const metaTitle = this._normalizeText(doc.querySelector('meta[name="title"]')?.getAttribute('content'));
+		// Do not use link[rel="canonical"] here; YouTube may update it after SPA navigation.
+		const metaVideoId = this._extractVideoIdFromUrl(doc.querySelector('meta[property="og:url"]')?.getAttribute('content') || '');
+		const metaLooksCurrent = metaVideoId
+			? metaVideoId === expectedVideoId
+			: Boolean(metaTitle && currentTitle && metaTitle === currentTitle);
+
+		if (metaLooksCurrent) {
+			partial.title = metaTitle;
+			partial.keywords = this._normalizeKeywords(doc.querySelector('meta[name="keywords"]')?.getAttribute('content'));
+		}
+
+		const microformat = this._readMicroformat(doc);
+		const microformatVideoId = this._extractVideoIdFromUrl(microformat?.['@id'] || microformat?.embedUrl || '');
+		const microformatTitle = this._normalizeText(microformat?.name);
+		const microformatLooksCurrent = microformatVideoId
+			? microformatVideoId === expectedVideoId
+			: Boolean(microformatTitle && currentTitle && microformatTitle === currentTitle);
+
+		if (microformatLooksCurrent) {
+			partial.title = partial.title || microformatTitle;
+			partial.genre = partial.genre || this._normalizeText(microformat?.genre);
+			partial.duration = partial.duration || this._normalizeText(microformat?.duration);
+			partial.lengthSeconds = partial.lengthSeconds || this._isoDurationToSeconds(partial.duration);
+		}
+
+		return partial;
+	},
+	_extractMarkerData: function (rootObject) {
+		try {
+			if (!rootObject || typeof rootObject !== 'object') {
+				return null;
+			}
+
+			let mostReplayedMarkers = null;
+			let heatmapMarkers = null;
+			const mutations = rootObject?.frameworkUpdates?.entityBatchUpdate?.mutations || [];
+			for (const mutation of mutations) {
+				const markersList = mutation?.payload?.macroMarkersListEntity?.markersList;
+				if (!markersList) {
+					continue;
+				}
+
+				const decorations = markersList?.markersDecoration?.timedMarkerDecorations;
+				if (mostReplayedMarkers == null && Array.isArray(decorations) && decorations.length) {
+					mostReplayedMarkers = decorations;
+				}
+				if (
+					heatmapMarkers == null
+					&& markersList.markerType === 'MARKER_TYPE_HEATMAP'
+					&& Array.isArray(markersList.markers)
+					&& markersList.markers.length
+				) {
+					heatmapMarkers = markersList.markers;
+				}
+				if (mostReplayedMarkers && heatmapMarkers) {
+					break;
+				}
+			}
+
+			// Fallback: only heatmap markers are searched recursively outside the expected mutations path.
+			if (heatmapMarkers == null) {
+				heatmapMarkers = this._findHeatmapMarkers(rootObject);
+			}
+
+			if (mostReplayedMarkers == null && heatmapMarkers == null) {
+				return null;
+			}
+
+			return {
+				mostReplayedMarkers,
+				heatmapMarkers: heatmapMarkers?.length ? heatmapMarkers : null,
+			};
+		} catch (error) {
+			console.warn('[improved:meta] extractMarkerData: failed', error);
+			return null;
+		}
+	},
+	_findHeatmapMarkers: function (value) {
+		return this._findInObjectTree(value, current => {
+			if (current.markerType === 'MARKER_TYPE_HEATMAP' && Array.isArray(current.markers)) {
+				return current.markers;
+			}
+			if (current.key === 'MARKER_TYPE_HEATMAP' && Array.isArray(current.value?.markers)) {
+				return current.value.markers;
+			}
+			return null;
+		});
+	},
+	// rawYtInitialData.engagementPanels[n].engagementPanelSectionListRenderer.content.structuredDescriptionContentRenderer.items[n].horizontalCardListRenderer.header.richListHeaderRenderer.subtitle.simpleText
+	//  ....{"header":{"richListHeaderRenderer":{"title":{"simpleText":"Music"},"subtitle":{"simpleText":"6 songs"},...
+	_findSongCount: function (value) {
+		return this._findInObjectTree(value, current => {
+			if (!Object.prototype.hasOwnProperty.call(current, 'richListHeaderRenderer')) {
+				return null;
+			}
+			const match = current.richListHeaderRenderer.subtitle?.simpleText?.match(/(\d*)\s/);
+			return match ? match[1] : null;
+		});
+	},
+	_walkObjectTree: function (value, visitor, path = '') {
+		if (value === null || typeof value !== 'object') {
+			return true;
+		}
+		if (visitor(value, path) === false) {
+			return false;
+		}
+		if (Array.isArray(value)) {
+			for (let index = 0; index < value.length; index++) {
+				if (this._walkObjectTree(value[index], visitor, `${path}[${index}]`) === false) {
+					return false;
+				}
+			}
+			return true;
+		}
+		for (const key in value) {
+			if (!Object.prototype.hasOwnProperty.call(value, key)) {
+				continue;
+			}
+			const currentPath = path ? `${path}.${key}` : key;
+			if (this._walkObjectTree(value[key], visitor, currentPath) === false) {
+				return false;
+			}
+		}
+		return true;
+	},
+	_findInObjectTree: function (value, matcher) {
+		try {
+			let result = null;
+			this._walkObjectTree(value, (current, path) => {
+				const match = matcher(current, path);
+				if (match !== null && match !== undefined) {
+					result = match;
+					return false;
+				}
+			});
+			return result;
+		} catch (error) {
+			console.warn('[improved:meta] findInObjectTree: failed', error);
+			return null;
+		}
+	},
+	_applyPartialData: function (partialData, sourceName) {
+		if (!partialData) {
+			return;
+		}
+
+		for (const key of VIDEO_METADATA_BASE_KEYS) {
+			this._setValue(key, partialData[key], sourceName);
+		}
+	},
+	_setValue: function (key, value, sourceName) {
+		if (!this._hasValue(value) || this._hasValue(this.data[key])) {
+			return false;
+		}
+		// console.debug(`[improved:meta] _setValue: key=${key}, value=${value}, source=${sourceName}`);
+
+		this.data[key] = value;
+		this.state.source[key] = sourceName;
+		return true;
+	},
+	_hasValue: function (value) {
+		if (Array.isArray(value)) {
+			return value.length > 0;
+		}
+		return value !== null && value !== undefined && value !== '';
+	},
+	_normalizeText: function (value) {
+		return typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : '';
+	},
+	_normalizeKeywords: function (value) {
+		if (Array.isArray(value)) {
+			return value.map(keyword => this._normalizeText(keyword)).filter(Boolean);
+		}
+		if (typeof value === 'string') {
+			return value.split(',').map(keyword => this._normalizeText(keyword)).filter(Boolean);
+		}
+		return null;
+	},
+	_normalizeLengthSeconds: function (value) {
+		const lengthSeconds = Number(value);
+		return Number.isFinite(lengthSeconds) && lengthSeconds > 0 ? lengthSeconds : null;
+	},
+	_secondsToIsoDuration: function (value) {
+		const totalSeconds = this._normalizeLengthSeconds(value);
+		if (!totalSeconds) {
+			return null;
+		}
+
+		const hours = Math.floor(totalSeconds / 3600);
+		const minutes = Math.floor((totalSeconds % 3600) / 60);
+		const seconds = totalSeconds % 60;
+		let iso = 'PT';
+		if (hours) {
+			iso += `${hours}H`;
+		}
+		if (minutes) {
+			iso += `${minutes}M`;
+		}
+		if (seconds || iso === 'PT') {
+			iso += `${seconds}S`;
+		}
+		return iso;
+	},
+	_isoDurationToSeconds: function (value) {
+		if (!value || typeof value !== 'string') {
+			return null;
+		}
+
+		const match = value.match(/PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/);
+		if (!match) {
+			return null;
+		}
+
+		const hours = Number(match[1] || 0);
+		const minutes = Number(match[2] || 0);
+		const seconds = Number(match[3] || 0);
+		const totalSeconds = (hours * 3600) + (minutes * 60) + seconds;
+		return totalSeconds > 0 ? totalSeconds : null;
+	},
+	_extractVideoIdFromUrl: function (value) {
+		if (!value || typeof value !== 'string') {
+			return null;
+		}
+		try {
+			return this._getVideoId(value);
+		} catch (error) {
+			return value.match(/[?&]v=([a-zA-Z0-9_-]{11})/)?.[1]
+				|| value.match(/\/embed\/([a-zA-Z0-9_-]{11})/)?.[1]
+				|| null;
+		}
+	},
+};

--- a/manifest.json
+++ b/manifest.json
@@ -68,6 +68,7 @@
         "js&css/web-accessible/core.js",
         "js&css/web-accessible/functions.js",
         "js&css/web-accessible/www.youtube.com/appearance.js",
+        "js&css/web-accessible/www.youtube.com/video-metadata.js",
         "js&css/web-accessible/www.youtube.com/player.js",
         "js&css/web-accessible/www.youtube.com/themes.js",
         "js&css/web-accessible/www.youtube.com/playlist.js",


### PR DESCRIPTION

Several player features currently maintain their own YouTube video metadata lookup logic inside `player.js`. This duplicates logic and makes feature code harder to follow, especially as fallback behavior and data inputs start to overlap between playback speed inputs, jump-to-key-scene, and Smart Speed / Most Replayed marker handling.

I had been considering this extraction for a while, and issue #4147 made it worth sharing the architectural direction sooner as a draft. Before implementing this across more features, I would like to align on the extraction direction, module boundary, and naming, especially if there is already a preferred direction for this area.

### Summary

- Introduce `ImprovedTube.VideoMetadata` as a shared helper for YouTube video data lookup.
- Centralize cached metadata state, DOM reads, SPA-navigation handling, and optional watch-page fetch fallback logic.
- Add heatmap / Most Replayed marker extraction with a shared flow so Smart Speed can reuse it later.
- Update `jumpToKeyScene` as a reference implementation to load Most Replayed markers via `ImprovedTube.VideoMetadata.getMostReplayedMarkersAsync()`.
- Update `playerPlaybackSpeed` as a reference implementation to read required video inputs through `ImprovedTube.VideoMetadata`.

### Design / Implementation Direction

- **Keep features decoupled:** `VideoMetadata` provides metadata and marker inputs; it does not decide whether a video is music, where to seek, or how Smart Speed should behave.
- **Cache only the active video lookup:** Cache resolved metadata only for the current active video to avoid repeated DOM lookups and fallback fetches. Reset it when the active video changes.
- **Prefer current-page data:** Prioritize existing on-page data, falling back to a watch-page fetch only when the required data is missing from the current context.
- **Use asynchronous APIs:** Expose async boundaries because fallback paths may require network requests.
- **Encapsulate implementation details:** Keep DOM parsing, fetched watch-page parsing, SPA-navigation handling, and heatmap marker lookup internal so feature code does not need to know which source produced the data.
- **Keep the public API minimal:** For now, explore both bundled and focused access patterns, such as `getDataAsync()` / `getDataWithHeatmapAsync()` and `getMostReplayedMarkersAsync()` / `getHeatmapMarkersAsync()`.
- **Isolate feature changes:** Use the `playerPlaybackSpeed()` and `jumpToKeyScene()` changes as call-site examples. These can be split into separate PRs before final review if needed.

### Review Questions

This draft is opened primarily to confirm:

1. Is `video-metadata.js` the appropriate module boundary?
2. Is `ImprovedTube.VideoMetadata` the right public namespace, or should this use a broader term like `VideoData` because it also covers heatmap / Most Replayed marker data?
3. Is this helper the right architectural place to centralize active-video cache management, DOM lookup, SPA navigation logic, fetch fallbacks, and heatmap parsing?
4. Should the fallback-heavy parsing implementation remain grouped here or be refactored into internal sub-modules?


### Testing / Current Status

- [x] Basic behavior check passes.
- [x] Manual testing completed for the current `jumpToKeyScene` reference path.
- [x] Manual testing completed for the current `playerPlaybackSpeed` reference path.
- [x] Identified small fixes during manual testing.
- [x] Possible follow-up integration, such as Smart Speed reuse, is intentionally deferred until the extraction direction is confirmed.
- [ ] Finalize the file name and public namespace.
- [ ] Push the final cleanup, including debug/logging cleanup and the small fixes found during manual testing.

Scope note: the `jumpToKeyScene` and `playerPlaybackSpeed` changes are included as current reference call sites for this helper. I intend to keep them in this PR if this direction looks acceptable. If you would prefer to review the shared helper first and move those call-site changes to follow-up PRs, I can do that.

Debug/logging note: I will keep useful commented debug hooks/notes where they help future fallback investigation, and clean up anything too noisy before marking the PR ready.

### LLM disclosure

English is not my first language, so I use LLMs to help draft explanations/comments, translations, and small wording in code comments or log messages. The implementation decisions and final review are my responsibility.