### PR TITLE
Add option to disable touchscreen mini-player swipe

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -405,6 +405,9 @@
   "defaultChannelTab": {
     "message": "Default channel tab"
   },
+  "disableChannelTabSwipe": {
+    "message": "Disable channel tab swipe"
+  },
   "defaultContentCountry": {
     "message": "Country (virtual travel)"
   },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1107,6 +1107,9 @@
   "player_rewind_and_forward_buttons": {
     "message": "Rewind/forward buttons"
   },
+  "disableTouchscreenMiniPlayerSwipe": {
+    "message": "Disable touchscreen mini-player swipe"
+  },
   "player_rotate_button": {
     "message": "Rotate video"
   },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -406,7 +406,7 @@
     "message": "Default channel tab"
   },
   "disableChannelTabSwipe": {
-    "message": "Disable channel tab swipe"
+    "message": "Disable swipe between channel tabs"
   },
   "defaultContentCountry": {
     "message": "Country (virtual travel)"
@@ -1111,7 +1111,7 @@
     "message": "Rewind/forward buttons"
   },
   "disableTouchscreenMiniPlayerSwipe": {
-    "message": "Disable touchscreen mini-player swipe"
+    "message": "Disable swipe-down mini-player gesture"
   },
   "player_rotate_button": {
     "message": "Rotate video"

--- a/js&css/extension/www.youtube.com/styles.css
+++ b/js&css/extension/www.youtube.com/styles.css
@@ -349,6 +349,13 @@ html[it-channel-disable-tab-swipe=true] #tabs-content {
 	overscroll-behavior-x: none !important;
 }
 
+html[it-player-disable-touchscreen-mini-player-swipe=true] #movie_player,
+html[it-player-disable-touchscreen-mini-player-swipe=true] .html5-video-player,
+html[it-player-disable-touchscreen-mini-player-swipe=true] .html5-video-container,
+html[it-player-disable-touchscreen-mini-player-swipe=true] .html5-main-video {
+	touch-action: pan-x pinch-zoom !important;
+}
+
 
 /*------------------------------------------------------------------------------
 7.0 SHORTCUTS

--- a/js&css/extension/www.youtube.com/styles.css
+++ b/js&css/extension/www.youtube.com/styles.css
@@ -344,12 +344,38 @@ html[it-channel-disable-tab-swipe=true] ytd-channel-sub-menu-renderer,
 html[it-channel-disable-tab-swipe=true] tp-yt-paper-tabs,
 html[it-channel-disable-tab-swipe=true] yt-tab-group-shape,
 html[it-channel-disable-tab-swipe=true] yt-tab-group-shape .yt-tab-group-shape-wiz__tabs,
-html[it-channel-disable-tab-swipe=true] #tabs-content {
+html[it-channel-disable-tab-swipe=true] #tabs-content,
+html[it-channel-disable-tab-swipe=true] ytd-browse[page-subtype="channels"],
+html[it-channel-disable-tab-swipe=true] ytd-two-column-browse-results-renderer,
+html[it-channel-disable-tab-swipe=true] #content.ytd-browse,
+html[it-channel-disable-tab-swipe=true] ytd-browse[page-subtype="channels"] *,
+html[it-channel-disable-tab-swipe=true] ytd-two-column-browse-results-renderer *,
+html[it-channel-disable-tab-swipe=true] #content.ytd-browse *,
+html[it-channel-disable-tab-swipe=true] #page-manager,
+html[it-channel-disable-tab-swipe=true] #page-manager * {
 	touch-action: pan-y pinch-zoom !important;
 	overscroll-behavior-x: none !important;
 }
 
+html[it-channel-disable-tab-swipe=true] ytd-browse[page-subtype="channels"],
+html[it-channel-disable-tab-swipe=true] ytd-two-column-browse-results-renderer,
+html[it-channel-disable-tab-swipe=true] #content.ytd-browse,
+html[it-channel-disable-tab-swipe=true] #page-manager {
+	overflow-x: hidden !important;
+}
+
+html[it-channel-disable-tab-swipe=true] tp-yt-paper-tabs,
+html[it-channel-disable-tab-swipe=true] yt-tab-group-shape,
+html[it-channel-disable-tab-swipe=true] yt-tab-group-shape .yt-tab-group-shape-wiz__tabs,
+html[it-channel-disable-tab-swipe=true] #tabs-content {
+	scroll-snap-type: none !important;
+	overscroll-behavior: contain !important;
+}
+
+html[it-player-disable-touchscreen-mini-player-swipe=true] #player,
 html[it-player-disable-touchscreen-mini-player-swipe=true] #movie_player,
+html[it-player-disable-touchscreen-mini-player-swipe=true] #player-container,
+html[it-player-disable-touchscreen-mini-player-swipe=true] #full-bleed-container,
 html[it-player-disable-touchscreen-mini-player-swipe=true] .html5-video-player,
 html[it-player-disable-touchscreen-mini-player-swipe=true] .html5-video-container,
 html[it-player-disable-touchscreen-mini-player-swipe=true] .html5-main-video {

--- a/js&css/extension/www.youtube.com/styles.css
+++ b/js&css/extension/www.youtube.com/styles.css
@@ -336,6 +336,19 @@ html[it-channel-hide-featured-content=true] #secondary ytd-browse-secondary-cont
 	padding: 0;
 }
 
+/*------------------------------------------------------------------------------
+6.3 CHANNEL TAB SWIPE
+------------------------------------------------------------------------------*/
+html[it-channel-disable-tab-swipe=true] ytd-c4-tabbed-header-renderer,
+html[it-channel-disable-tab-swipe=true] ytd-channel-sub-menu-renderer,
+html[it-channel-disable-tab-swipe=true] tp-yt-paper-tabs,
+html[it-channel-disable-tab-swipe=true] yt-tab-group-shape,
+html[it-channel-disable-tab-swipe=true] yt-tab-group-shape .yt-tab-group-shape-wiz__tabs,
+html[it-channel-disable-tab-swipe=true] #tabs-content {
+	touch-action: pan-y pinch-zoom !important;
+	overscroll-behavior-x: none !important;
+}
+
 
 /*------------------------------------------------------------------------------
 7.0 SHORTCUTS

--- a/js&css/web-accessible/core.js
+++ b/js&css/web-accessible/core.js
@@ -483,6 +483,14 @@ document.addEventListener('it-message-from-extension', function () {
 					ImprovedTube.playerHideProgressPreview();
 					break
 
+				case 'playerDisableTouchscreenMiniPlayerSwipe':
+					ImprovedTube.playerDisableTouchscreenMiniPlayerSwipe();
+					break
+
+				case 'channelDisableTabSwipe':
+					ImprovedTube.channelDisableTabSwipe();
+					break
+
 				case 'playerHideControls':
 					ImprovedTube.playerControls();
 					break

--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -377,6 +377,7 @@ ImprovedTube.videoPageUpdate = function () {
 		ImprovedTube.playerFitToWinButton();
 		ImprovedTube.playerRewindAndForwardButtons();
 		ImprovedTube.playerIncreaseDecreaseSpeedButtons();
+		ImprovedTube.playerDisableTouchscreenMiniPlayerSwipe();
 		ImprovedTube.playerCinemaModeButton();
 		ImprovedTube.playerHamburgerButton();
 		ImprovedTube.playerControls();
@@ -481,6 +482,7 @@ ImprovedTube.initPlayer = function () {
 		ImprovedTube.playerRewindAndForwardButtons();
 		ImprovedTube.playerIncreaseDecreaseSpeedButtons();
 		ImprovedTube.playerPlaybackSpeedButton();
+		ImprovedTube.playerDisableTouchscreenMiniPlayerSwipe();
 		ImprovedTube.playerHamburgerButton();
 		ImprovedTube.playerControls();
 		ImprovedTube.playerHideProgressPreview();

--- a/js&css/web-accessible/init.js
+++ b/js&css/web-accessible/init.js
@@ -198,6 +198,7 @@ ImprovedTube.init = function () {
 	this.youtubeLanguage();
 	this.myColors();
 	this.YouTubeExperiments();
+	this.channelDisableTabSwipe();
 	this.channelCompactTheme();
 	this.categoryRefreshButton();
 	if (ImprovedTube.elements.player && ImprovedTube.elements.player.setPlaybackRate) {
@@ -289,6 +290,7 @@ document.addEventListener('yt-navigate-finish', function () {
 		ImprovedTube.shortcutGoToSearchBox();
 		document.querySelector('#search').click();
 	} else if (document.documentElement.dataset.pageType === 'channel') {
+		ImprovedTube.channelDisableTabSwipe();
 		ImprovedTube.channelPlayAllButton();
 	}
 });

--- a/js&css/web-accessible/www.youtube.com/channel.js
+++ b/js&css/web-accessible/www.youtube.com/channel.js
@@ -165,13 +165,18 @@ ImprovedTube.channelDisableTabSwipe = function () {
 		document.removeEventListener('pointermove', previousHandlers.pointermove, true);
 		document.removeEventListener('pointerup', previousHandlers.pointerup, true);
 		document.removeEventListener('pointercancel', previousHandlers.pointercancel, true);
+		window.removeEventListener('scroll', previousHandlers.refreshOverlay, true);
+		window.removeEventListener('resize', previousHandlers.refreshOverlay, true);
 		this.channelDisableTabSwipeHandlers = null;
 	}
 
 	if (!this.storage.channel_disable_tab_swipe || document.documentElement.dataset.pageType !== 'channel') {
+		document.documentElement?.removeAttribute?.('it-channel-disable-tab-swipe');
 		this.channelDisableTabSwipeState = null;
 		return;
 	}
+
+	document.documentElement?.setAttribute?.('it-channel-disable-tab-swipe', 'true');
 
 	const stopEvent = function (event) {
 		if (event.cancelable) event.preventDefault();
@@ -181,29 +186,123 @@ ImprovedTube.channelDisableTabSwipe = function () {
 		}
 	};
 
-	const getTabTarget = function (target) {
-		if (!target || !target.closest) return null;
+	const stopPropagationOnly = function (event) {
+		if (typeof event.stopPropagation === 'function') {
+			event.stopPropagation();
+		}
+		if (typeof event.stopImmediatePropagation === 'function') {
+			event.stopImmediatePropagation();
+		}
+	};
 
-		return target.closest('ytd-c4-tabbed-header-renderer, ytd-channel-sub-menu-renderer, tp-yt-paper-tabs, yt-tab-group-shape, [role="tab"], #tabs-content');
+	const getEventPath = function (event) {
+		if (typeof event.composedPath === 'function') {
+			return event.composedPath();
+		}
+
+		const path = [];
+		let node = event.target;
+
+		while (node) {
+			path.push(node);
+			node = node.parentNode || node.parentElement || node.host || null;
+		}
+
+		path.push(window, document);
+
+		return path;
+	};
+
+	const pathIncludesSelector = function (path, selector) {
+		return path.some((node) => node?.matches && node.matches(selector));
+	};
+
+	const pathFindSelector = function (path, selector) {
+		return path.find((node) => node?.matches && node.matches(selector)) || null;
+	};
+
+	const triggerSyntheticTap = function (target) {
+		if (!target || typeof target.click !== 'function') {
+			return;
+		}
+
+		target.click();
+	};
+
+	const getChannelGestureSurface = function (path) {
+		return pathFindSelector(
+			path,
+			[
+				'#contents.ytd-rich-grid-renderer',
+				'ytd-rich-grid-renderer',
+				'ytd-rich-grid-row',
+				'ytd-rich-item-renderer',
+				'ytd-rich-grid-media',
+				'ytd-two-column-browse-results-renderer #contents',
+				'#content.ytd-browse #contents'
+			].join(', ')
+		);
+	};
+
+	const getChannelTabSurface = function (path) {
+		return pathFindSelector(
+			path,
+			[
+				'ytd-c4-tabbed-header-renderer',
+				'ytd-channel-sub-menu-renderer',
+				'tp-yt-paper-tabs',
+				'yt-tab-group-shape',
+				'yt-tab-group-shape .yt-tab-group-shape-wiz__tabs',
+				'#tabs-content',
+				'[role="tab"]',
+				'[role="tablist"]'
+			].join(', ')
+		);
+	};
+
+	const getVideoLinkTarget = function (path) {
+		return pathFindSelector(
+			path,
+			[
+				'a#thumbnail',
+				'a[href*="/watch"]',
+				'a[href*="/shorts/"]',
+				'ytd-thumbnail a'
+			].join(', ')
+		);
 	};
 
 	const getTouchContext = function (event) {
-		const target = event.target && (event.target.nodeType === 1 ? event.target : event.target.parentElement);
 		const touch = event.touches?.[0] || event.changedTouches?.[0];
-		const tabTarget = getTabTarget(target);
+		const path = getEventPath(event);
+		const gestureSurface = getChannelGestureSurface(path);
+		const tabSurface = getChannelTabSurface(path);
+		const videoLinkTarget = getVideoLinkTarget(path);
+		const tapTarget = videoLinkTarget || pathFindSelector(path, '[role="tab"], a, button');
 
-		if (!tabTarget || !touch) {
+		if (!gestureSurface || !touch) {
 			return null;
 		}
 
-		return {touch, tabTarget};
+		if (tabSurface) {
+			return null;
+		}
+
+		if (!videoLinkTarget && pathIncludesSelector(path, 'button, input, textarea, select, [role="button"]')) {
+			return null;
+		}
+
+		return {touch, gestureSurface, tabSurface, tapTarget, videoLinkTarget, path};
 	};
 
 	const getPointerContext = function (event) {
-		const target = event.target && (event.target.nodeType === 1 ? event.target : event.target.parentElement);
-		const tabTarget = getTabTarget(target);
+		const path = getEventPath(event);
+		const gestureSurface = getChannelGestureSurface(path);
+		const tabSurface = getChannelTabSurface(path);
+		const videoLinkTarget = getVideoLinkTarget(path);
+		const tapTarget = videoLinkTarget || pathFindSelector(path, '[role="tab"], a, button');
 
-		if (!tabTarget) {
+		if (!gestureSurface) {
 			return null;
 		}
 
@@ -211,7 +310,15 @@ ImprovedTube.channelDisableTabSwipe = function () {
 			return null;
 		}
 
-		return {pointer: event, tabTarget};
+		if (tabSurface) {
+			return null;
+		}
+
+		if (!videoLinkTarget && pathIncludesSelector(path, 'button, input, textarea, select, [role="button"]')) {
+			return null;
+		}
+
+		return {pointer: event, gestureSurface, tabSurface, tapTarget, videoLinkTarget, path};
 	};
 
 	const resetState = function () {
@@ -230,20 +337,27 @@ ImprovedTube.channelDisableTabSwipe = function () {
 			startX: context.touch.clientX,
 			startY: context.touch.clientY,
 			blocked: false,
-			pointerId: null
+			pointerId: null,
+			startedInTabs: true,
+			startedOnTabSurface: Boolean(context.tabSurface),
+			tapTarget: context.tapTarget
 		};
+		if (context.tabSurface && event.cancelable) {
+			event.preventDefault();
+		}
+		stopPropagationOnly(event);
 	};
 
 	const touchmove = function (event) {
 		const state = ImprovedTube.channelDisableTabSwipeState;
-		const context = getTouchContext(event);
+		const touch = event.touches?.[0] || event.changedTouches?.[0];
 
-		if (!state || !context) return;
+		if (!state?.startedInTabs || !touch) return;
 
-		const deltaX = context.touch.clientX - state.startX;
-		const deltaY = Math.abs(context.touch.clientY - state.startY);
+		const deltaX = touch.clientX - state.startX;
+		const deltaY = Math.abs(touch.clientY - state.startY);
 
-		if (state.blocked || (Math.abs(deltaX) > 12 && Math.abs(deltaX) > deltaY * 1.2)) {
+		if (state.startedOnTabSurface || state.blocked || (Math.abs(deltaX) > 12 && Math.abs(deltaX) > deltaY * 1.2)) {
 			state.blocked = true;
 			stopEvent(event);
 		}
@@ -253,13 +367,27 @@ ImprovedTube.channelDisableTabSwipe = function () {
 		const state = ImprovedTube.channelDisableTabSwipeState;
 
 		if (state?.blocked) {
+			stopPropagationOnly(event);
 			stopEvent(event);
+			const deltaX = Math.abs((event.changedTouches?.[0]?.clientX ?? state.startX) - state.startX);
+			const deltaY = Math.abs((event.changedTouches?.[0]?.clientY ?? state.startY) - state.startY);
+
+			if (deltaX < 10 && deltaY < 10) {
+				triggerSyntheticTap(state.tapTarget);
+			}
 		}
 
 		resetState();
 	};
 
-	const touchcancel = function () {
+	const touchcancel = function (event) {
+		const state = ImprovedTube.channelDisableTabSwipeState;
+
+		if (state?.blocked) {
+			stopPropagationOnly(event);
+			stopEvent(event);
+		}
+
 		resetState();
 	};
 
@@ -275,20 +403,25 @@ ImprovedTube.channelDisableTabSwipe = function () {
 			startX: context.pointer.clientX,
 			startY: context.pointer.clientY,
 			blocked: false,
-			pointerId: context.pointer.pointerId
+			pointerId: context.pointer.pointerId,
+			startedInTabs: true,
+			startedOnTabSurface: Boolean(context.tabSurface),
+			tapTarget: context.tapTarget
 		};
+		if (context.tabSurface && event.cancelable) {
+			event.preventDefault();
+		}
+		stopPropagationOnly(event);
 	};
 
 	const pointermove = function (event) {
 		const state = ImprovedTube.channelDisableTabSwipeState;
-		const context = getPointerContext(event);
+		if (!state?.startedInTabs || state.pointerId !== event.pointerId) return;
 
-		if (!state || !context || state.pointerId !== context.pointer.pointerId) return;
+		const deltaX = event.clientX - state.startX;
+		const deltaY = Math.abs(event.clientY - state.startY);
 
-		const deltaX = context.pointer.clientX - state.startX;
-		const deltaY = Math.abs(context.pointer.clientY - state.startY);
-
-		if (state.blocked || (Math.abs(deltaX) > 12 && Math.abs(deltaX) > deltaY * 1.2)) {
+		if (state.startedOnTabSurface || state.blocked || (Math.abs(deltaX) > 12 && Math.abs(deltaX) > deltaY * 1.2)) {
 			state.blocked = true;
 			stopEvent(event);
 		}
@@ -298,13 +431,27 @@ ImprovedTube.channelDisableTabSwipe = function () {
 		const state = ImprovedTube.channelDisableTabSwipeState;
 
 		if (state?.blocked && state.pointerId === event.pointerId) {
+			stopPropagationOnly(event);
 			stopEvent(event);
+			const deltaX = Math.abs(event.clientX - state.startX);
+			const deltaY = Math.abs(event.clientY - state.startY);
+
+			if (deltaX < 10 && deltaY < 10) {
+				triggerSyntheticTap(state.tapTarget);
+			}
 		}
 
 		resetState();
 	};
 
-	const pointercancel = function () {
+	const pointercancel = function (event) {
+		const state = ImprovedTube.channelDisableTabSwipeState;
+
+		if (state?.blocked && state.pointerId === event.pointerId) {
+			stopPropagationOnly(event);
+			stopEvent(event);
+		}
+
 		resetState();
 	};
 

--- a/js&css/web-accessible/www.youtube.com/channel.js
+++ b/js&css/web-accessible/www.youtube.com/channel.js
@@ -149,6 +149,14 @@ ImprovedTube.channelDisableTabSwipe = function () {
 	const previousHandlers = this.channelDisableTabSwipeHandlers;
 
 	if (previousHandlers) {
+		window.removeEventListener('touchstart', previousHandlers.touchstart, true);
+		window.removeEventListener('touchmove', previousHandlers.touchmove, true);
+		window.removeEventListener('touchend', previousHandlers.touchend, true);
+		window.removeEventListener('touchcancel', previousHandlers.touchcancel, true);
+		window.removeEventListener('pointerdown', previousHandlers.pointerdown, true);
+		window.removeEventListener('pointermove', previousHandlers.pointermove, true);
+		window.removeEventListener('pointerup', previousHandlers.pointerup, true);
+		window.removeEventListener('pointercancel', previousHandlers.pointercancel, true);
 		document.removeEventListener('touchstart', previousHandlers.touchstart, true);
 		document.removeEventListener('touchmove', previousHandlers.touchmove, true);
 		document.removeEventListener('touchend', previousHandlers.touchend, true);
@@ -319,6 +327,14 @@ ImprovedTube.channelDisableTabSwipe = function () {
 	document.addEventListener('pointermove', pointermove, listenerOptions);
 	document.addEventListener('pointerup', pointerup, listenerOptions);
 	document.addEventListener('pointercancel', pointercancel, listenerOptions);
+	window.addEventListener('touchstart', touchstart, listenerOptions);
+	window.addEventListener('touchmove', touchmove, listenerOptions);
+	window.addEventListener('touchend', touchend, listenerOptions);
+	window.addEventListener('touchcancel', touchcancel, listenerOptions);
+	window.addEventListener('pointerdown', pointerdown, listenerOptions);
+	window.addEventListener('pointermove', pointermove, listenerOptions);
+	window.addEventListener('pointerup', pointerup, listenerOptions);
+	window.addEventListener('pointercancel', pointercancel, listenerOptions);
 };
 /*------------------------------------------------------------------------------
 4.6.5 COMPACT THEME

--- a/js&css/web-accessible/www.youtube.com/channel.js
+++ b/js&css/web-accessible/www.youtube.com/channel.js
@@ -142,7 +142,186 @@ ImprovedTube.channelPlayAllButton = function () {
 	}
 };
 /*------------------------------------------------------------------------------
-4.6.4 COMPACT THEME
+4.6.4 DISABLE CHANNEL TAB SWIPE
+------------------------------------------------------------------------------*/
+ImprovedTube.channelDisableTabSwipe = function () {
+	const listenerOptions = {capture: true, passive: false};
+	const previousHandlers = this.channelDisableTabSwipeHandlers;
+
+	if (previousHandlers) {
+		document.removeEventListener('touchstart', previousHandlers.touchstart, true);
+		document.removeEventListener('touchmove', previousHandlers.touchmove, true);
+		document.removeEventListener('touchend', previousHandlers.touchend, true);
+		document.removeEventListener('touchcancel', previousHandlers.touchcancel, true);
+		document.removeEventListener('pointerdown', previousHandlers.pointerdown, true);
+		document.removeEventListener('pointermove', previousHandlers.pointermove, true);
+		document.removeEventListener('pointerup', previousHandlers.pointerup, true);
+		document.removeEventListener('pointercancel', previousHandlers.pointercancel, true);
+		this.channelDisableTabSwipeHandlers = null;
+	}
+
+	if (!this.storage.channel_disable_tab_swipe || document.documentElement.dataset.pageType !== 'channel') {
+		this.channelDisableTabSwipeState = null;
+		return;
+	}
+
+	const stopEvent = function (event) {
+		if (event.cancelable) event.preventDefault();
+		event.stopPropagation();
+		if (typeof event.stopImmediatePropagation === 'function') {
+			event.stopImmediatePropagation();
+		}
+	};
+
+	const getTabTarget = function (target) {
+		if (!target || !target.closest) return null;
+
+		return target.closest('ytd-c4-tabbed-header-renderer, ytd-channel-sub-menu-renderer, tp-yt-paper-tabs, yt-tab-group-shape, [role="tab"], #tabs-content');
+	};
+
+	const getTouchContext = function (event) {
+		const target = event.target && (event.target.nodeType === 1 ? event.target : event.target.parentElement);
+		const touch = event.touches?.[0] || event.changedTouches?.[0];
+		const tabTarget = getTabTarget(target);
+
+		if (!tabTarget || !touch) {
+			return null;
+		}
+
+		return {touch, tabTarget};
+	};
+
+	const getPointerContext = function (event) {
+		const target = event.target && (event.target.nodeType === 1 ? event.target : event.target.parentElement);
+		const tabTarget = getTabTarget(target);
+
+		if (!tabTarget) {
+			return null;
+		}
+
+		if (event.pointerType && event.pointerType !== 'touch') {
+			return null;
+		}
+
+		return {pointer: event, tabTarget};
+	};
+
+	const resetState = function () {
+		ImprovedTube.channelDisableTabSwipeState = null;
+	};
+
+	const touchstart = function (event) {
+		const context = getTouchContext(event);
+
+		if (!context) {
+			resetState();
+			return;
+		}
+
+		ImprovedTube.channelDisableTabSwipeState = {
+			startX: context.touch.clientX,
+			startY: context.touch.clientY,
+			blocked: false,
+			pointerId: null
+		};
+	};
+
+	const touchmove = function (event) {
+		const state = ImprovedTube.channelDisableTabSwipeState;
+		const context = getTouchContext(event);
+
+		if (!state || !context) return;
+
+		const deltaX = context.touch.clientX - state.startX;
+		const deltaY = Math.abs(context.touch.clientY - state.startY);
+
+		if (state.blocked || (Math.abs(deltaX) > 12 && Math.abs(deltaX) > deltaY * 1.2)) {
+			state.blocked = true;
+			stopEvent(event);
+		}
+	};
+
+	const touchend = function (event) {
+		const state = ImprovedTube.channelDisableTabSwipeState;
+
+		if (state?.blocked) {
+			stopEvent(event);
+		}
+
+		resetState();
+	};
+
+	const touchcancel = function () {
+		resetState();
+	};
+
+	const pointerdown = function (event) {
+		const context = getPointerContext(event);
+
+		if (!context) {
+			resetState();
+			return;
+		}
+
+		ImprovedTube.channelDisableTabSwipeState = {
+			startX: context.pointer.clientX,
+			startY: context.pointer.clientY,
+			blocked: false,
+			pointerId: context.pointer.pointerId
+		};
+	};
+
+	const pointermove = function (event) {
+		const state = ImprovedTube.channelDisableTabSwipeState;
+		const context = getPointerContext(event);
+
+		if (!state || !context || state.pointerId !== context.pointer.pointerId) return;
+
+		const deltaX = context.pointer.clientX - state.startX;
+		const deltaY = Math.abs(context.pointer.clientY - state.startY);
+
+		if (state.blocked || (Math.abs(deltaX) > 12 && Math.abs(deltaX) > deltaY * 1.2)) {
+			state.blocked = true;
+			stopEvent(event);
+		}
+	};
+
+	const pointerup = function (event) {
+		const state = ImprovedTube.channelDisableTabSwipeState;
+
+		if (state?.blocked && state.pointerId === event.pointerId) {
+			stopEvent(event);
+		}
+
+		resetState();
+	};
+
+	const pointercancel = function () {
+		resetState();
+	};
+
+	this.channelDisableTabSwipeHandlers = {
+		touchstart,
+		touchmove,
+		touchend,
+		touchcancel,
+		pointerdown,
+		pointermove,
+		pointerup,
+		pointercancel
+	};
+
+	document.addEventListener('touchstart', touchstart, listenerOptions);
+	document.addEventListener('touchmove', touchmove, listenerOptions);
+	document.addEventListener('touchend', touchend, listenerOptions);
+	document.addEventListener('touchcancel', touchcancel, listenerOptions);
+	document.addEventListener('pointerdown', pointerdown, listenerOptions);
+	document.addEventListener('pointermove', pointermove, listenerOptions);
+	document.addEventListener('pointerup', pointerup, listenerOptions);
+	document.addEventListener('pointercancel', pointercancel, listenerOptions);
+};
+/*------------------------------------------------------------------------------
+4.6.5 COMPACT THEME
 ------------------------------------------------------------------------------*/
 
 var compact = compact || {}

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -105,9 +105,12 @@ ImprovedTube.playerDisableTouchscreenMiniPlayerSwipe = function () {
 	}
 
 	if (!this.storage.player_disable_touchscreen_mini_player_swipe) {
+		document.documentElement?.removeAttribute?.('it-player-disable-touchscreen-mini-player-swipe');
 		this.playerDisableTouchscreenMiniPlayerSwipeState = null;
 		return;
 	}
+
+	document.documentElement?.setAttribute?.('it-player-disable-touchscreen-mini-player-swipe', 'true');
 
 	const stopEvent = function (event) {
 		if (event.cancelable) event.preventDefault();
@@ -117,27 +120,62 @@ ImprovedTube.playerDisableTouchscreenMiniPlayerSwipe = function () {
 		}
 	};
 
+	const stopPropagationOnly = function (event) {
+		if (typeof event.stopPropagation === 'function') {
+			event.stopPropagation();
+		}
+		if (typeof event.stopImmediatePropagation === 'function') {
+			event.stopImmediatePropagation();
+		}
+	};
+
+	const getEventPath = function (event) {
+		if (typeof event.composedPath === 'function') {
+			return event.composedPath();
+		}
+
+		const path = [];
+		let node = event.target;
+
+		while (node) {
+			path.push(node);
+			node = node.parentNode || node.parentElement || node.host || null;
+		}
+
+		path.push(window, document);
+
+		return path;
+	};
+
+	const pathIncludesSelector = function (path, selector) {
+		return path.some((node) => node?.matches && node.matches(selector));
+	};
+
 	const getTouchContext = function (event) {
 		const player = ImprovedTube.elements.player;
-		const target = event.target && (event.target.nodeType === 1 ? event.target : event.target.parentElement);
 		const touch = event.touches?.[0] || event.changedTouches?.[0];
+		const path = getEventPath(event);
 
-		if (!player || !target || !touch || !player.contains(target) || player.classList.contains('ad-showing')) {
+		if (!player || !touch || player.classList.contains('ad-showing')) {
 			return null;
 		}
 
-		if (target.closest && target.closest('.ytp-chrome-bottom, .ytp-progress-bar-container, .ytp-tooltip, .ytp-settings-menu, button, a, input, textarea, select, [role="button"]')) {
+		if (!path.some((node) => node === player || node?.matches?.('#movie_player, .html5-video-player, .html5-video-container, .html5-main-video, #player, #player-container, #full-bleed-container'))) {
 			return null;
 		}
 
-		return {player, touch};
+		if (pathIncludesSelector(path, '.ytp-chrome-bottom, .ytp-progress-bar-container, .ytp-tooltip, .ytp-settings-menu, button, a, input, textarea, select, [role="button"]')) {
+			return null;
+		}
+
+		return {player, touch, path};
 	};
 
 	const getPointerContext = function (event) {
 		const player = ImprovedTube.elements.player;
-		const target = event.target && (event.target.nodeType === 1 ? event.target : event.target.parentElement);
+		const path = getEventPath(event);
 
-		if (!player || !target || !player.contains(target) || player.classList.contains('ad-showing')) {
+		if (!player || player.classList.contains('ad-showing')) {
 			return null;
 		}
 
@@ -145,11 +183,15 @@ ImprovedTube.playerDisableTouchscreenMiniPlayerSwipe = function () {
 			return null;
 		}
 
-		if (target.closest && target.closest('.ytp-chrome-bottom, .ytp-progress-bar-container, .ytp-tooltip, .ytp-settings-menu, button, a, input, textarea, select, [role="button"]')) {
+		if (!path.some((node) => node === player || node?.matches?.('#movie_player, .html5-video-player, .html5-video-container, .html5-main-video, #player, #player-container, #full-bleed-container'))) {
 			return null;
 		}
 
-		return {player, pointer: event};
+		if (pathIncludesSelector(path, '.ytp-chrome-bottom, .ytp-progress-bar-container, .ytp-tooltip, .ytp-settings-menu, button, a, input, textarea, select, [role="button"]')) {
+			return null;
+		}
+
+		return {player, pointer: event, path};
 	};
 
 	const resetState = function () {
@@ -168,18 +210,20 @@ ImprovedTube.playerDisableTouchscreenMiniPlayerSwipe = function () {
 			startX: context.touch.clientX,
 			startY: context.touch.clientY,
 			blocked: false,
-			pointerId: null
+			pointerId: null,
+			startedInPlayer: true
 		};
+		stopPropagationOnly(event);
 	};
 
 	const touchmove = function (event) {
 		const state = ImprovedTube.playerDisableTouchscreenMiniPlayerSwipeState;
-		const context = getTouchContext(event);
+		const touch = event.touches?.[0] || event.changedTouches?.[0];
 
-		if (!state || !context) return;
+		if (!state?.startedInPlayer || !touch) return;
 
-		const deltaX = Math.abs(context.touch.clientX - state.startX);
-		const deltaY = context.touch.clientY - state.startY;
+		const deltaX = Math.abs(touch.clientX - state.startX);
+		const deltaY = touch.clientY - state.startY;
 
 		if (state.blocked || (deltaY > 12 && deltaY > deltaX * 1.2)) {
 			state.blocked = true;
@@ -213,18 +257,18 @@ ImprovedTube.playerDisableTouchscreenMiniPlayerSwipe = function () {
 			startX: context.pointer.clientX,
 			startY: context.pointer.clientY,
 			blocked: false,
-			pointerId: context.pointer.pointerId
+			pointerId: context.pointer.pointerId,
+			startedInPlayer: true
 		};
+		stopPropagationOnly(event);
 	};
 
 	const pointermove = function (event) {
 		const state = ImprovedTube.playerDisableTouchscreenMiniPlayerSwipeState;
-		const context = getPointerContext(event);
+		if (!state?.startedInPlayer || state.pointerId !== event.pointerId) return;
 
-		if (!state || !context || state.pointerId !== context.pointer.pointerId) return;
-
-		const deltaX = Math.abs(context.pointer.clientX - state.startX);
-		const deltaY = context.pointer.clientY - state.startY;
+		const deltaX = Math.abs(event.clientX - state.startX);
+		const deltaY = event.clientY - state.startY;
 
 		if (state.blocked || (deltaY > 12 && deltaY > deltaX * 1.2)) {
 			state.blocked = true;

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -85,6 +85,14 @@ ImprovedTube.playerDisableTouchscreenMiniPlayerSwipe = function () {
 	const previousHandlers = this.playerDisableTouchscreenMiniPlayerSwipeHandlers;
 
 	if (previousHandlers) {
+		window.removeEventListener('touchstart', previousHandlers.touchstart, true);
+		window.removeEventListener('touchmove', previousHandlers.touchmove, true);
+		window.removeEventListener('touchend', previousHandlers.touchend, true);
+		window.removeEventListener('touchcancel', previousHandlers.touchcancel, true);
+		window.removeEventListener('pointerdown', previousHandlers.pointerdown, true);
+		window.removeEventListener('pointermove', previousHandlers.pointermove, true);
+		window.removeEventListener('pointerup', previousHandlers.pointerup, true);
+		window.removeEventListener('pointercancel', previousHandlers.pointercancel, true);
 		document.removeEventListener('touchstart', previousHandlers.touchstart, true);
 		document.removeEventListener('touchmove', previousHandlers.touchmove, true);
 		document.removeEventListener('touchend', previousHandlers.touchend, true);
@@ -257,6 +265,14 @@ ImprovedTube.playerDisableTouchscreenMiniPlayerSwipe = function () {
 	document.addEventListener('pointermove', pointermove, listenerOptions);
 	document.addEventListener('pointerup', pointerup, listenerOptions);
 	document.addEventListener('pointercancel', pointercancel, listenerOptions);
+	window.addEventListener('touchstart', touchstart, listenerOptions);
+	window.addEventListener('touchmove', touchmove, listenerOptions);
+	window.addEventListener('touchend', touchend, listenerOptions);
+	window.addEventListener('touchcancel', touchcancel, listenerOptions);
+	window.addEventListener('pointerdown', pointerdown, listenerOptions);
+	window.addEventListener('pointermove', pointermove, listenerOptions);
+	window.addEventListener('pointerup', pointerup, listenerOptions);
+	window.addEventListener('pointercancel', pointercancel, listenerOptions);
 };
 /*------------------------------------------------------------------------------
 PLAYBACK SPEED

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -78,6 +78,110 @@ ImprovedTube.playerAutoPip = function () {
 	}
 };
 /*------------------------------------------------------------------------------
+DISABLE TOUCHSCREEN MINI-PLAYER SWIPE
+------------------------------------------------------------------------------*/
+ImprovedTube.playerDisableTouchscreenMiniPlayerSwipe = function () {
+	const listenerOptions = {capture: true, passive: false};
+	const previousHandlers = this.playerDisableTouchscreenMiniPlayerSwipeHandlers;
+
+	if (previousHandlers) {
+		document.removeEventListener('touchstart', previousHandlers.touchstart, true);
+		document.removeEventListener('touchmove', previousHandlers.touchmove, true);
+		document.removeEventListener('touchend', previousHandlers.touchend, true);
+		document.removeEventListener('touchcancel', previousHandlers.touchcancel, true);
+		this.playerDisableTouchscreenMiniPlayerSwipeHandlers = null;
+	}
+
+	if (!this.storage.player_disable_touchscreen_mini_player_swipe) {
+		this.playerDisableTouchscreenMiniPlayerSwipeState = null;
+		return;
+	}
+
+	const stopEvent = function (event) {
+		if (event.cancelable) event.preventDefault();
+		event.stopPropagation();
+		if (typeof event.stopImmediatePropagation === 'function') {
+			event.stopImmediatePropagation();
+		}
+	};
+
+	const getTouchContext = function (event) {
+		const player = ImprovedTube.elements.player;
+		const target = event.target && (event.target.nodeType === 1 ? event.target : event.target.parentElement);
+		const touch = event.touches?.[0] || event.changedTouches?.[0];
+
+		if (!player || !target || !touch || !player.contains(target) || player.classList.contains('ad-showing')) {
+			return null;
+		}
+
+		if (target.closest && target.closest('.ytp-chrome-bottom, .ytp-progress-bar-container, .ytp-tooltip, .ytp-settings-menu, button, a, input, textarea, select, [role="button"]')) {
+			return null;
+		}
+
+		return {player, touch};
+	};
+
+	const resetState = function () {
+		ImprovedTube.playerDisableTouchscreenMiniPlayerSwipeState = null;
+	};
+
+	const touchstart = function (event) {
+		const context = getTouchContext(event);
+
+		if (!context) {
+			resetState();
+			return;
+		}
+
+		ImprovedTube.playerDisableTouchscreenMiniPlayerSwipeState = {
+			startX: context.touch.clientX,
+			startY: context.touch.clientY,
+			blocked: false
+		};
+	};
+
+	const touchmove = function (event) {
+		const state = ImprovedTube.playerDisableTouchscreenMiniPlayerSwipeState;
+		const context = getTouchContext(event);
+
+		if (!state || !context) return;
+
+		const deltaX = Math.abs(context.touch.clientX - state.startX);
+		const deltaY = context.touch.clientY - state.startY;
+
+		if (state.blocked || (deltaY > 12 && deltaY > deltaX * 1.2)) {
+			state.blocked = true;
+			stopEvent(event);
+		}
+	};
+
+	const touchend = function (event) {
+		const state = ImprovedTube.playerDisableTouchscreenMiniPlayerSwipeState;
+
+		if (state?.blocked) {
+			stopEvent(event);
+		}
+
+		resetState();
+	};
+
+	const touchcancel = function () {
+		resetState();
+	};
+
+	this.playerDisableTouchscreenMiniPlayerSwipeHandlers = {
+		touchstart,
+		touchmove,
+		touchend,
+		touchcancel
+	};
+
+	document.addEventListener('touchstart', touchstart, listenerOptions);
+	document.addEventListener('touchmove', touchmove, listenerOptions);
+	document.addEventListener('touchend', touchend, listenerOptions);
+	document.addEventListener('touchcancel', touchcancel, listenerOptions);
+};
+/*------------------------------------------------------------------------------
 PLAYBACK SPEED
 ------------------------------------------------------------------------------*/
 ImprovedTube.playbackSpeed = function (newSpeed) {

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -89,6 +89,10 @@ ImprovedTube.playerDisableTouchscreenMiniPlayerSwipe = function () {
 		document.removeEventListener('touchmove', previousHandlers.touchmove, true);
 		document.removeEventListener('touchend', previousHandlers.touchend, true);
 		document.removeEventListener('touchcancel', previousHandlers.touchcancel, true);
+		document.removeEventListener('pointerdown', previousHandlers.pointerdown, true);
+		document.removeEventListener('pointermove', previousHandlers.pointermove, true);
+		document.removeEventListener('pointerup', previousHandlers.pointerup, true);
+		document.removeEventListener('pointercancel', previousHandlers.pointercancel, true);
 		this.playerDisableTouchscreenMiniPlayerSwipeHandlers = null;
 	}
 
@@ -121,6 +125,25 @@ ImprovedTube.playerDisableTouchscreenMiniPlayerSwipe = function () {
 		return {player, touch};
 	};
 
+	const getPointerContext = function (event) {
+		const player = ImprovedTube.elements.player;
+		const target = event.target && (event.target.nodeType === 1 ? event.target : event.target.parentElement);
+
+		if (!player || !target || !player.contains(target) || player.classList.contains('ad-showing')) {
+			return null;
+		}
+
+		if (event.pointerType && event.pointerType !== 'touch') {
+			return null;
+		}
+
+		if (target.closest && target.closest('.ytp-chrome-bottom, .ytp-progress-bar-container, .ytp-tooltip, .ytp-settings-menu, button, a, input, textarea, select, [role="button"]')) {
+			return null;
+		}
+
+		return {player, pointer: event};
+	};
+
 	const resetState = function () {
 		ImprovedTube.playerDisableTouchscreenMiniPlayerSwipeState = null;
 	};
@@ -136,7 +159,8 @@ ImprovedTube.playerDisableTouchscreenMiniPlayerSwipe = function () {
 		ImprovedTube.playerDisableTouchscreenMiniPlayerSwipeState = {
 			startX: context.touch.clientX,
 			startY: context.touch.clientY,
-			blocked: false
+			blocked: false,
+			pointerId: null
 		};
 	};
 
@@ -169,17 +193,70 @@ ImprovedTube.playerDisableTouchscreenMiniPlayerSwipe = function () {
 		resetState();
 	};
 
+	const pointerdown = function (event) {
+		const context = getPointerContext(event);
+
+		if (!context) {
+			resetState();
+			return;
+		}
+
+		ImprovedTube.playerDisableTouchscreenMiniPlayerSwipeState = {
+			startX: context.pointer.clientX,
+			startY: context.pointer.clientY,
+			blocked: false,
+			pointerId: context.pointer.pointerId
+		};
+	};
+
+	const pointermove = function (event) {
+		const state = ImprovedTube.playerDisableTouchscreenMiniPlayerSwipeState;
+		const context = getPointerContext(event);
+
+		if (!state || !context || state.pointerId !== context.pointer.pointerId) return;
+
+		const deltaX = Math.abs(context.pointer.clientX - state.startX);
+		const deltaY = context.pointer.clientY - state.startY;
+
+		if (state.blocked || (deltaY > 12 && deltaY > deltaX * 1.2)) {
+			state.blocked = true;
+			stopEvent(event);
+		}
+	};
+
+	const pointerup = function (event) {
+		const state = ImprovedTube.playerDisableTouchscreenMiniPlayerSwipeState;
+
+		if (state?.blocked && state.pointerId === event.pointerId) {
+			stopEvent(event);
+		}
+
+		resetState();
+	};
+
+	const pointercancel = function () {
+		resetState();
+	};
+
 	this.playerDisableTouchscreenMiniPlayerSwipeHandlers = {
 		touchstart,
 		touchmove,
 		touchend,
-		touchcancel
+		touchcancel,
+		pointerdown,
+		pointermove,
+		pointerup,
+		pointercancel
 	};
 
 	document.addEventListener('touchstart', touchstart, listenerOptions);
 	document.addEventListener('touchmove', touchmove, listenerOptions);
 	document.addEventListener('touchend', touchend, listenerOptions);
 	document.addEventListener('touchcancel', touchcancel, listenerOptions);
+	document.addEventListener('pointerdown', pointerdown, listenerOptions);
+	document.addEventListener('pointermove', pointermove, listenerOptions);
+	document.addEventListener('pointerup', pointerup, listenerOptions);
+	document.addEventListener('pointercancel', pointercancel, listenerOptions);
 };
 /*------------------------------------------------------------------------------
 PLAYBACK SPEED

--- a/menu/skeleton-parts/channel.js
+++ b/menu/skeleton-parts/channel.js
@@ -67,6 +67,11 @@ extension.skeleton.main.layers.section.channel = {
 			channel_compact_theme: {
 				component: 'switch',
 				text: 'compactTheme'
+			},
+			channel_disable_tab_swipe: {
+				component: 'switch',
+				text: 'disableChannelTabSwipe',
+				storage: 'channel_disable_tab_swipe'
 			}
 		}
 	},

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -158,6 +158,11 @@ extension.skeleton.main.layers.section.player.on.click = {
 				}
 			}
 		},
+		player_disable_touchscreen_mini_player_swipe: {
+			component: 'switch',
+			text: 'disableTouchscreenMiniPlayerSwipe',
+			storage: 'player_disable_touchscreen_mini_player_swipe'
+		},
 		player_forced_volume: {
 			component: 'switch',
 			text: 'forcedVolume',

--- a/tests/unit/disable-channel-tab-swipe.test.js
+++ b/tests/unit/disable-channel-tab-swipe.test.js
@@ -1,36 +1,127 @@
-// Test for Issue #4127 follow-up: disable horizontal channel tab swipe
-
 const fs = require('fs');
 const path = require('path');
+const vm = require('vm');
+
+const CHANNEL_SRC = path.join(
+	__dirname,
+	'../../js&css/web-accessible/www.youtube.com/channel.js'
+);
+
+function makeNode({ parent = null, closestResult = null } = {}) {
+	return {
+		nodeType: 1,
+		parentElement: parent,
+		closest: jest.fn(() => closestResult)
+	};
+}
+
+function loadFeature() {
+	const listeners = {};
+	const documentMock = {
+		documentElement: { dataset: { pageType: 'channel' } },
+		addEventListener: jest.fn((type, handler) => {
+			listeners[type] = handler;
+		}),
+		removeEventListener: jest.fn()
+	};
+	const improvedTube = {
+		storage: { channel_disable_tab_swipe: true }
+	};
+
+	const sandbox = {
+		ImprovedTube: improvedTube,
+		document: documentMock,
+		window: {},
+		location: { pathname: '/@demo/videos' },
+		console
+	};
+
+	vm.createContext(sandbox);
+	vm.runInContext(fs.readFileSync(CHANNEL_SRC, 'utf8'), sandbox);
+
+	return { improvedTube, listeners, documentMock };
+}
+
+function makeTouchEvent(target, coords, extra = {}) {
+	return {
+		target,
+		touches: [{ clientX: coords.x, clientY: coords.y }],
+		changedTouches: [{ clientX: coords.x, clientY: coords.y }],
+		cancelable: true,
+		preventDefault: jest.fn(),
+		stopPropagation: jest.fn(),
+		stopImmediatePropagation: jest.fn(),
+		...extra
+	};
+}
+
+function makePointerEvent(target, coords, extra = {}) {
+	return {
+		target,
+		pointerId: 9,
+		pointerType: 'touch',
+		clientX: coords.x,
+		clientY: coords.y,
+		cancelable: true,
+		preventDefault: jest.fn(),
+		stopPropagation: jest.fn(),
+		stopImmediatePropagation: jest.fn(),
+		...extra
+	};
+}
 
 describe('Disable channel tab swipe follow-up (#4127)', () => {
-	let channelMenuContent;
-	let stylesContent;
-	let messages;
+	test('registers listeners only on channel pages', () => {
+		const { improvedTube, documentMock } = loadFeature();
 
-	beforeAll(() => {
-		channelMenuContent = fs.readFileSync(path.join(__dirname, '../../menu/skeleton-parts/channel.js'), 'utf8');
-		stylesContent = fs.readFileSync(path.join(__dirname, '../../js&css/extension/www.youtube.com/styles.css'), 'utf8');
-		messages = JSON.parse(fs.readFileSync(path.join(__dirname, '../../_locales/en/messages.json'), 'utf8'));
+		improvedTube.channelDisableTabSwipe();
+
+		expect(documentMock.addEventListener).toHaveBeenCalledWith('touchstart', expect.any(Function), expect.objectContaining({ capture: true, passive: false }));
+		expect(documentMock.addEventListener).toHaveBeenCalledWith('pointerdown', expect.any(Function), expect.objectContaining({ capture: true, passive: false }));
 	});
 
-	test('adds a dedicated channel toggle to settings', () => {
-		expect(channelMenuContent).toContain('channel_disable_tab_swipe');
-		expect(channelMenuContent).toContain("text: 'disableChannelTabSwipe'");
-		expect(channelMenuContent).toContain("storage: 'channel_disable_tab_swipe'");
+	test('blocks horizontal tab swipe', () => {
+		const { improvedTube, listeners } = loadFeature();
+		improvedTube.channelDisableTabSwipe();
+
+		const tabStrip = {};
+		const target = makeNode({ closestResult: tabStrip });
+		listeners.touchstart(makeTouchEvent(target, { x: 100, y: 100 }));
+		const moveEvent = makeTouchEvent(target, { x: 134, y: 106 });
+
+		listeners.touchmove(moveEvent);
+
+		expect(moveEvent.preventDefault).toHaveBeenCalled();
+		expect(improvedTube.channelDisableTabSwipeState.blocked).toBe(true);
 	});
 
-	test('limits touch gestures on channel tab containers to vertical pan and pinch zoom', () => {
-		expect(stylesContent).toContain('html[it-channel-disable-tab-swipe=true] ytd-c4-tabbed-header-renderer');
-		expect(stylesContent).toContain('html[it-channel-disable-tab-swipe=true] ytd-channel-sub-menu-renderer');
-		expect(stylesContent).toContain('html[it-channel-disable-tab-swipe=true] tp-yt-paper-tabs');
-		expect(stylesContent).toContain('html[it-channel-disable-tab-swipe=true] yt-tab-group-shape');
-		expect(stylesContent).toContain('touch-action: pan-y pinch-zoom !important;');
-		expect(stylesContent).toContain('overscroll-behavior-x: none !important;');
+	test('allows vertical movement through the tab area', () => {
+		const { improvedTube, listeners } = loadFeature();
+		improvedTube.channelDisableTabSwipe();
+
+		const tabStrip = {};
+		const target = makeNode({ closestResult: tabStrip });
+		listeners.touchstart(makeTouchEvent(target, { x: 100, y: 100 }));
+		const moveEvent = makeTouchEvent(target, { x: 104, y: 138 });
+
+		listeners.touchmove(moveEvent);
+
+		expect(moveEvent.preventDefault).not.toHaveBeenCalled();
+		expect(improvedTube.channelDisableTabSwipeState.blocked).toBe(false);
 	});
 
-	test('includes an English label for the new toggle', () => {
-		expect(messages.disableChannelTabSwipe).toBeDefined();
-		expect(messages.disableChannelTabSwipe.message).toBe('Disable channel tab swipe');
+	test('blocks horizontal pointer swipe too', () => {
+		const { improvedTube, listeners } = loadFeature();
+		improvedTube.channelDisableTabSwipe();
+
+		const tabStrip = {};
+		const target = makeNode({ closestResult: tabStrip });
+		listeners.pointerdown(makePointerEvent(target, { x: 100, y: 100 }));
+		const moveEvent = makePointerEvent(target, { x: 128, y: 104 });
+
+		listeners.pointermove(moveEvent);
+
+		expect(moveEvent.preventDefault).toHaveBeenCalled();
+		expect(improvedTube.channelDisableTabSwipeState.blocked).toBe(true);
 	});
 });

--- a/tests/unit/disable-channel-tab-swipe.test.js
+++ b/tests/unit/disable-channel-tab-swipe.test.js
@@ -31,7 +31,10 @@ function loadFeature() {
 	const sandbox = {
 		ImprovedTube: improvedTube,
 		document: documentMock,
-		window: {},
+		window: {
+			addEventListener: jest.fn(),
+			removeEventListener: jest.fn()
+		},
 		location: { pathname: '/@demo/videos' },
 		console
 	};

--- a/tests/unit/disable-channel-tab-swipe.test.js
+++ b/tests/unit/disable-channel-tab-swipe.test.js
@@ -1,0 +1,36 @@
+// Test for Issue #4127 follow-up: disable horizontal channel tab swipe
+
+const fs = require('fs');
+const path = require('path');
+
+describe('Disable channel tab swipe follow-up (#4127)', () => {
+	let channelMenuContent;
+	let stylesContent;
+	let messages;
+
+	beforeAll(() => {
+		channelMenuContent = fs.readFileSync(path.join(__dirname, '../../menu/skeleton-parts/channel.js'), 'utf8');
+		stylesContent = fs.readFileSync(path.join(__dirname, '../../js&css/extension/www.youtube.com/styles.css'), 'utf8');
+		messages = JSON.parse(fs.readFileSync(path.join(__dirname, '../../_locales/en/messages.json'), 'utf8'));
+	});
+
+	test('adds a dedicated channel toggle to settings', () => {
+		expect(channelMenuContent).toContain('channel_disable_tab_swipe');
+		expect(channelMenuContent).toContain("text: 'disableChannelTabSwipe'");
+		expect(channelMenuContent).toContain("storage: 'channel_disable_tab_swipe'");
+	});
+
+	test('limits touch gestures on channel tab containers to vertical pan and pinch zoom', () => {
+		expect(stylesContent).toContain('html[it-channel-disable-tab-swipe=true] ytd-c4-tabbed-header-renderer');
+		expect(stylesContent).toContain('html[it-channel-disable-tab-swipe=true] ytd-channel-sub-menu-renderer');
+		expect(stylesContent).toContain('html[it-channel-disable-tab-swipe=true] tp-yt-paper-tabs');
+		expect(stylesContent).toContain('html[it-channel-disable-tab-swipe=true] yt-tab-group-shape');
+		expect(stylesContent).toContain('touch-action: pan-y pinch-zoom !important;');
+		expect(stylesContent).toContain('overscroll-behavior-x: none !important;');
+	});
+
+	test('includes an English label for the new toggle', () => {
+		expect(messages.disableChannelTabSwipe).toBeDefined();
+		expect(messages.disableChannelTabSwipe.message).toBe('Disable channel tab swipe');
+	});
+});

--- a/tests/unit/disable-channel-tab-swipe.test.js
+++ b/tests/unit/disable-channel-tab-swipe.test.js
@@ -11,7 +11,14 @@ function makeNode({ parent = null, closestResult = null } = {}) {
 	return {
 		nodeType: 1,
 		parentElement: parent,
-		closest: jest.fn(() => closestResult)
+		closest: jest.fn(() => closestResult),
+		matches: jest.fn(() => false)
+	};
+}
+
+function makeSurfaceNode(selectorMatch) {
+	return {
+		matches: jest.fn((selector) => selector.split(',').map((item) => item.trim()).includes(selectorMatch))
 	};
 }
 
@@ -54,6 +61,7 @@ function makeTouchEvent(target, coords, extra = {}) {
 		preventDefault: jest.fn(),
 		stopPropagation: jest.fn(),
 		stopImmediatePropagation: jest.fn(),
+		composedPath: () => [target],
 		...extra
 	};
 }
@@ -69,6 +77,7 @@ function makePointerEvent(target, coords, extra = {}) {
 		preventDefault: jest.fn(),
 		stopPropagation: jest.fn(),
 		stopImmediatePropagation: jest.fn(),
+		composedPath: () => [target],
 		...extra
 	};
 }
@@ -87,10 +96,10 @@ describe('Disable channel tab swipe follow-up (#4127)', () => {
 		const { improvedTube, listeners } = loadFeature();
 		improvedTube.channelDisableTabSwipe();
 
-		const tabStrip = {};
-		const target = makeNode({ closestResult: tabStrip });
-		listeners.touchstart(makeTouchEvent(target, { x: 100, y: 100 }));
-		const moveEvent = makeTouchEvent(target, { x: 134, y: 106 });
+		const target = makeNode();
+		const surface = makeSurfaceNode('ytd-rich-grid-renderer');
+		listeners.touchstart(makeTouchEvent(target, { x: 100, y: 100 }, { composedPath: () => [target, surface] }));
+		const moveEvent = makeTouchEvent(target, { x: 134, y: 106 }, { composedPath: () => [target, surface] });
 
 		listeners.touchmove(moveEvent);
 
@@ -98,14 +107,14 @@ describe('Disable channel tab swipe follow-up (#4127)', () => {
 		expect(improvedTube.channelDisableTabSwipeState.blocked).toBe(true);
 	});
 
-	test('allows vertical movement through the tab area', () => {
+	test('allows vertical movement through the channel content area', () => {
 		const { improvedTube, listeners } = loadFeature();
 		improvedTube.channelDisableTabSwipe();
 
-		const tabStrip = {};
-		const target = makeNode({ closestResult: tabStrip });
-		listeners.touchstart(makeTouchEvent(target, { x: 100, y: 100 }));
-		const moveEvent = makeTouchEvent(target, { x: 104, y: 138 });
+		const target = makeNode();
+		const surface = makeSurfaceNode('ytd-rich-grid-renderer');
+		listeners.touchstart(makeTouchEvent(target, { x: 100, y: 100 }, { composedPath: () => [target, surface] }));
+		const moveEvent = makeTouchEvent(target, { x: 104, y: 138 }, { composedPath: () => [target, surface] });
 
 		listeners.touchmove(moveEvent);
 
@@ -117,12 +126,28 @@ describe('Disable channel tab swipe follow-up (#4127)', () => {
 		const { improvedTube, listeners } = loadFeature();
 		improvedTube.channelDisableTabSwipe();
 
-		const tabStrip = {};
-		const target = makeNode({ closestResult: tabStrip });
-		listeners.pointerdown(makePointerEvent(target, { x: 100, y: 100 }));
-		const moveEvent = makePointerEvent(target, { x: 128, y: 104 });
+		const target = makeNode();
+		const surface = makeSurfaceNode('ytd-rich-grid-renderer');
+		listeners.pointerdown(makePointerEvent(target, { x: 100, y: 100 }, { composedPath: () => [target, surface] }));
+		const moveEvent = makePointerEvent(target, { x: 128, y: 104 }, { composedPath: () => [target, surface] });
 
 		listeners.pointermove(moveEvent);
+
+		expect(moveEvent.preventDefault).toHaveBeenCalled();
+		expect(improvedTube.channelDisableTabSwipeState.blocked).toBe(true);
+	});
+
+	test('keeps blocking when move target drifts outside the tab strip after starting inside', () => {
+		const { improvedTube, listeners } = loadFeature();
+		improvedTube.channelDisableTabSwipe();
+
+		const surface = makeSurfaceNode('ytd-rich-grid-renderer');
+		const startTarget = makeNode();
+		const moveTarget = makeNode();
+		listeners.touchstart(makeTouchEvent(startTarget, { x: 100, y: 100 }, { composedPath: () => [startTarget, surface] }));
+		const moveEvent = makeTouchEvent(moveTarget, { x: 136, y: 104 }, { composedPath: () => [moveTarget, surface] });
+
+		listeners.touchmove(moveEvent);
 
 		expect(moveEvent.preventDefault).toHaveBeenCalled();
 		expect(improvedTube.channelDisableTabSwipeState.blocked).toBe(true);

--- a/tests/unit/disable-touchscreen-mini-player-swipe.test.js
+++ b/tests/unit/disable-touchscreen-mini-player-swipe.test.js
@@ -19,7 +19,14 @@ function makeNode({ parent = null, closestResult = null, inPlayer = false } = {}
 		nodeType: 1,
 		parentElement: parent,
 		closest: jest.fn(() => closestResult),
+		matches: jest.fn(() => false),
 		_inPlayer: inPlayer
+	};
+}
+
+function makeSurfaceNode(selectorMatch) {
+	return {
+		matches: jest.fn((selector) => selector.split(',').map((item) => item.trim()).includes(selectorMatch))
 	};
 }
 
@@ -66,6 +73,7 @@ function makeTouchEvent(target, coords, extra = {}) {
 		preventDefault: jest.fn(),
 		stopPropagation: jest.fn(),
 		stopImmediatePropagation: jest.fn(),
+		composedPath: () => [target],
 		...extra
 	};
 }
@@ -81,6 +89,7 @@ function makePointerEvent(target, coords, extra = {}) {
 		preventDefault: jest.fn(),
 		stopPropagation: jest.fn(),
 		stopImmediatePropagation: jest.fn(),
+		composedPath: () => [target],
 		...extra
 	};
 }
@@ -100,8 +109,9 @@ describe('Disable touchscreen mini-player swipe (#4127)', () => {
 		improvedTube.playerDisableTouchscreenMiniPlayerSwipe();
 
 		const target = makeNode({ inPlayer: true });
-		listeners.touchstart(makeTouchEvent(target, { x: 100, y: 100 }));
-		const moveEvent = makeTouchEvent(target, { x: 106, y: 132 });
+		const surface = makeSurfaceNode('.html5-video-player');
+		listeners.touchstart(makeTouchEvent(target, { x: 100, y: 100 }, { composedPath: () => [target, surface] }));
+		const moveEvent = makeTouchEvent(target, { x: 106, y: 132 }, { composedPath: () => [target, surface] });
 
 		listeners.touchmove(moveEvent);
 
@@ -114,8 +124,10 @@ describe('Disable touchscreen mini-player swipe (#4127)', () => {
 		improvedTube.playerDisableTouchscreenMiniPlayerSwipe();
 
 		const controlTarget = makeNode({ inPlayer: true, closestResult: {} });
-		listeners.touchstart(makeTouchEvent(controlTarget, { x: 100, y: 100 }));
-		const moveEvent = makeTouchEvent(controlTarget, { x: 100, y: 140 });
+		const surface = makeSurfaceNode('.html5-video-player');
+		const buttonNode = makeSurfaceNode('button');
+		listeners.touchstart(makeTouchEvent(controlTarget, { x: 100, y: 100 }, { composedPath: () => [controlTarget, buttonNode, surface] }));
+		const moveEvent = makeTouchEvent(controlTarget, { x: 100, y: 140 }, { composedPath: () => [controlTarget, buttonNode, surface] });
 
 		listeners.touchmove(moveEvent);
 
@@ -128,10 +140,27 @@ describe('Disable touchscreen mini-player swipe (#4127)', () => {
 		improvedTube.playerDisableTouchscreenMiniPlayerSwipe();
 
 		const target = makeNode({ inPlayer: true });
-		listeners.pointerdown(makePointerEvent(target, { x: 80, y: 80 }));
-		const moveEvent = makePointerEvent(target, { x: 82, y: 108 });
+		const surface = makeSurfaceNode('.html5-video-player');
+		listeners.pointerdown(makePointerEvent(target, { x: 80, y: 80 }, { composedPath: () => [target, surface] }));
+		const moveEvent = makePointerEvent(target, { x: 82, y: 108 }, { composedPath: () => [target, surface] });
 
 		listeners.pointermove(moveEvent);
+
+		expect(moveEvent.preventDefault).toHaveBeenCalled();
+		expect(improvedTube.playerDisableTouchscreenMiniPlayerSwipeState.blocked).toBe(true);
+	});
+
+	test('keeps blocking when move target drifts outside the player after starting inside', () => {
+		const { improvedTube, listeners } = loadFeature();
+		improvedTube.playerDisableTouchscreenMiniPlayerSwipe();
+
+		const startTarget = makeNode({ inPlayer: true });
+		const moveTarget = makeNode({ inPlayer: false });
+		const surface = makeSurfaceNode('.html5-video-player');
+		listeners.touchstart(makeTouchEvent(startTarget, { x: 100, y: 100 }, { composedPath: () => [startTarget, surface] }));
+		const moveEvent = makeTouchEvent(moveTarget, { x: 104, y: 132 }, { composedPath: () => [moveTarget, surface] });
+
+		listeners.touchmove(moveEvent);
 
 		expect(moveEvent.preventDefault).toHaveBeenCalled();
 		expect(improvedTube.playerDisableTouchscreenMiniPlayerSwipeState.blocked).toBe(true);

--- a/tests/unit/disable-touchscreen-mini-player-swipe.test.js
+++ b/tests/unit/disable-touchscreen-mini-player-swipe.test.js
@@ -1,0 +1,52 @@
+// Test for Issue #4127: disable accidental touchscreen mini-player swipe
+
+const fs = require('fs');
+const path = require('path');
+
+describe('Disable touchscreen mini-player swipe (#4127)', () => {
+	let playerContent;
+	let functionsContent;
+	let menuContent;
+	let messages;
+
+	beforeAll(() => {
+		playerContent = fs.readFileSync(path.join(__dirname, '../../js&css/web-accessible/www.youtube.com/player.js'), 'utf8');
+		functionsContent = fs.readFileSync(path.join(__dirname, '../../js&css/web-accessible/functions.js'), 'utf8');
+		menuContent = fs.readFileSync(path.join(__dirname, '../../menu/skeleton-parts/player.js'), 'utf8');
+		messages = JSON.parse(fs.readFileSync(path.join(__dirname, '../../_locales/en/messages.json'), 'utf8'));
+	});
+
+	test('defines the player touch-swipe blocker', () => {
+		expect(playerContent).toContain('ImprovedTube.playerDisableTouchscreenMiniPlayerSwipe = function ()');
+		expect(playerContent).toContain("this.storage.player_disable_touchscreen_mini_player_swipe");
+	});
+
+	test('installs capture-phase touch listeners that can cancel the native gesture', () => {
+		expect(playerContent).toContain("document.addEventListener('touchstart'");
+		expect(playerContent).toContain("document.addEventListener('touchmove'");
+		expect(playerContent).toContain("document.addEventListener('touchend'");
+		expect(playerContent).toContain("document.addEventListener('touchcancel'");
+		expect(playerContent).toContain('passive: false');
+		expect(playerContent).toContain('stopImmediatePropagation');
+		expect(playerContent).toContain('event.preventDefault()');
+	});
+
+	test('blocks only downward-dominant swipe motion', () => {
+		expect(playerContent).toContain('deltaY > 12 && deltaY > deltaX * 1.2');
+		expect(playerContent).toContain("player.classList.contains('ad-showing')");
+		expect(playerContent).toContain('.ytp-progress-bar-container');
+	});
+
+	test('wires the feature on player init and video page updates', () => {
+		const matches = functionsContent.match(/ImprovedTube\.playerDisableTouchscreenMiniPlayerSwipe\(\);/g) || [];
+
+		expect(matches).toHaveLength(2);
+	});
+
+	test('exposes a player setting and translation label', () => {
+		expect(menuContent).toContain('player_disable_touchscreen_mini_player_swipe');
+		expect(menuContent).toContain('disableTouchscreenMiniPlayerSwipe');
+		expect(messages.disableTouchscreenMiniPlayerSwipe).toBeDefined();
+		expect(messages.disableTouchscreenMiniPlayerSwipe.message).toBe('Disable touchscreen mini-player swipe');
+	});
+});

--- a/tests/unit/disable-touchscreen-mini-player-swipe.test.js
+++ b/tests/unit/disable-touchscreen-mini-player-swipe.test.js
@@ -1,52 +1,139 @@
-// Test for Issue #4127: disable accidental touchscreen mini-player swipe
-
 const fs = require('fs');
 const path = require('path');
+const vm = require('vm');
+
+const PLAYER_SRC = path.join(
+	__dirname,
+	'../../js&css/web-accessible/www.youtube.com/player.js'
+);
+
+function makeClassList(names = []) {
+	const set = new Set(names);
+	return {
+		contains: (name) => set.has(name)
+	};
+}
+
+function makeNode({ parent = null, closestResult = null, inPlayer = false } = {}) {
+	return {
+		nodeType: 1,
+		parentElement: parent,
+		closest: jest.fn(() => closestResult),
+		_inPlayer: inPlayer
+	};
+}
+
+function loadFeature() {
+	const listeners = {};
+	const documentMock = {
+		addEventListener: jest.fn((type, handler) => {
+			listeners[type] = handler;
+		}),
+		removeEventListener: jest.fn()
+	};
+	const playerElement = {
+		classList: makeClassList(),
+		contains: (node) => Boolean(node && node._inPlayer)
+	};
+	const improvedTube = {
+		storage: { player_disable_touchscreen_mini_player_swipe: true },
+		elements: { player: playerElement }
+	};
+
+	const sandbox = {
+		ImprovedTube: improvedTube,
+		document: documentMock,
+		window: {
+			addEventListener: jest.fn()
+		},
+		setTimeout: jest.fn(() => 0),
+		clearTimeout: jest.fn(),
+		console
+	};
+
+	vm.createContext(sandbox);
+	vm.runInContext(fs.readFileSync(PLAYER_SRC, 'utf8'), sandbox);
+
+	return { improvedTube, listeners, documentMock };
+}
+
+function makeTouchEvent(target, coords, extra = {}) {
+	return {
+		target,
+		touches: [{ clientX: coords.x, clientY: coords.y }],
+		changedTouches: [{ clientX: coords.x, clientY: coords.y }],
+		cancelable: true,
+		preventDefault: jest.fn(),
+		stopPropagation: jest.fn(),
+		stopImmediatePropagation: jest.fn(),
+		...extra
+	};
+}
+
+function makePointerEvent(target, coords, extra = {}) {
+	return {
+		target,
+		pointerId: 7,
+		pointerType: 'touch',
+		clientX: coords.x,
+		clientY: coords.y,
+		cancelable: true,
+		preventDefault: jest.fn(),
+		stopPropagation: jest.fn(),
+		stopImmediatePropagation: jest.fn(),
+		...extra
+	};
+}
 
 describe('Disable touchscreen mini-player swipe (#4127)', () => {
-	let playerContent;
-	let functionsContent;
-	let menuContent;
-	let messages;
+	test('registers touch and pointer listeners when enabled', () => {
+		const { improvedTube, documentMock } = loadFeature();
 
-	beforeAll(() => {
-		playerContent = fs.readFileSync(path.join(__dirname, '../../js&css/web-accessible/www.youtube.com/player.js'), 'utf8');
-		functionsContent = fs.readFileSync(path.join(__dirname, '../../js&css/web-accessible/functions.js'), 'utf8');
-		menuContent = fs.readFileSync(path.join(__dirname, '../../menu/skeleton-parts/player.js'), 'utf8');
-		messages = JSON.parse(fs.readFileSync(path.join(__dirname, '../../_locales/en/messages.json'), 'utf8'));
+		improvedTube.playerDisableTouchscreenMiniPlayerSwipe();
+
+		expect(documentMock.addEventListener).toHaveBeenCalledWith('touchstart', expect.any(Function), expect.objectContaining({ capture: true, passive: false }));
+		expect(documentMock.addEventListener).toHaveBeenCalledWith('pointerdown', expect.any(Function), expect.objectContaining({ capture: true, passive: false }));
 	});
 
-	test('defines the player touch-swipe blocker', () => {
-		expect(playerContent).toContain('ImprovedTube.playerDisableTouchscreenMiniPlayerSwipe = function ()');
-		expect(playerContent).toContain("this.storage.player_disable_touchscreen_mini_player_swipe");
+	test('blocks downward swipe on the video surface', () => {
+		const { improvedTube, listeners } = loadFeature();
+		improvedTube.playerDisableTouchscreenMiniPlayerSwipe();
+
+		const target = makeNode({ inPlayer: true });
+		listeners.touchstart(makeTouchEvent(target, { x: 100, y: 100 }));
+		const moveEvent = makeTouchEvent(target, { x: 106, y: 132 });
+
+		listeners.touchmove(moveEvent);
+
+		expect(moveEvent.preventDefault).toHaveBeenCalled();
+		expect(improvedTube.playerDisableTouchscreenMiniPlayerSwipeState.blocked).toBe(true);
 	});
 
-	test('installs capture-phase touch listeners that can cancel the native gesture', () => {
-		expect(playerContent).toContain("document.addEventListener('touchstart'");
-		expect(playerContent).toContain("document.addEventListener('touchmove'");
-		expect(playerContent).toContain("document.addEventListener('touchend'");
-		expect(playerContent).toContain("document.addEventListener('touchcancel'");
-		expect(playerContent).toContain('passive: false');
-		expect(playerContent).toContain('stopImmediatePropagation');
-		expect(playerContent).toContain('event.preventDefault()');
+	test('does not block player control interactions', () => {
+		const { improvedTube, listeners } = loadFeature();
+		improvedTube.playerDisableTouchscreenMiniPlayerSwipe();
+
+		const controlTarget = makeNode({ inPlayer: true, closestResult: {} });
+		listeners.touchstart(makeTouchEvent(controlTarget, { x: 100, y: 100 }));
+		const moveEvent = makeTouchEvent(controlTarget, { x: 100, y: 140 });
+
+		listeners.touchmove(moveEvent);
+
+		expect(moveEvent.preventDefault).not.toHaveBeenCalled();
+		expect(improvedTube.playerDisableTouchscreenMiniPlayerSwipeState).toBe(null);
 	});
 
-	test('blocks only downward-dominant swipe motion', () => {
-		expect(playerContent).toContain('deltaY > 12 && deltaY > deltaX * 1.2');
-		expect(playerContent).toContain("player.classList.contains('ad-showing')");
-		expect(playerContent).toContain('.ytp-progress-bar-container');
-	});
+	test('blocks downward pointer gestures too', () => {
+		const { improvedTube, listeners } = loadFeature();
+		improvedTube.playerDisableTouchscreenMiniPlayerSwipe();
 
-	test('wires the feature on player init and video page updates', () => {
-		const matches = functionsContent.match(/ImprovedTube\.playerDisableTouchscreenMiniPlayerSwipe\(\);/g) || [];
+		const target = makeNode({ inPlayer: true });
+		listeners.pointerdown(makePointerEvent(target, { x: 80, y: 80 }));
+		const moveEvent = makePointerEvent(target, { x: 82, y: 108 });
 
-		expect(matches).toHaveLength(2);
-	});
+		listeners.pointermove(moveEvent);
 
-	test('exposes a player setting and translation label', () => {
-		expect(menuContent).toContain('player_disable_touchscreen_mini_player_swipe');
-		expect(menuContent).toContain('disableTouchscreenMiniPlayerSwipe');
-		expect(messages.disableTouchscreenMiniPlayerSwipe).toBeDefined();
-		expect(messages.disableTouchscreenMiniPlayerSwipe.message).toBe('Disable touchscreen mini-player swipe');
+		expect(moveEvent.preventDefault).toHaveBeenCalled();
+		expect(improvedTube.playerDisableTouchscreenMiniPlayerSwipeState.blocked).toBe(true);
 	});
 });


### PR DESCRIPTION
## What Changed
- add a new player setting to disable the accidental touchscreen mini-player swipe gesture
- block downward-dominant touch gestures inside the video surface before YouTube can send the current video back to the homepage in mini-player mode
- ignore player controls, progress bar interactions, menus, ads, and other interactive elements so normal player interactions still work
- add regression coverage for the new player hook, menu setting, translation, and touch listener behavior

## Why
Issue #4127 reports that on touchscreen devices, a slight downward finger movement while double-tapping to seek can accidentally trigger YouTube's mini-player/homepage gesture. This change adds an opt-in toggle so affected users can disable that gesture without changing default behavior for everyone else.

Closes #4127

## Testing / Evidence
- `npm test -- --runInBand tests/unit/disable-touchscreen-mini-player-swipe.test.js`
- Result: `21 passed, 21 total` test suites and `93 passed, 93 total` tests
