### PR TITLE
Disable scrolling in fullscreen

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -751,7 +751,7 @@
     "message": "Hide right buttons"
   },
   "hideScrollForDetails": {
-    "message": "Hide «Scroll for details»"
+    "message": "Disable scrolling in fullscreen"
   },
   "hideSkipOverlay": {
     "message": "Hide 5 second skip animation"

--- a/js&css/extension/www.youtube.com/appearance/player/player.css
+++ b/js&css/extension/www.youtube.com/appearance/player/player.css
@@ -292,7 +292,12 @@ html[it-hide-scroll-for-details='true'] button.ytp-fullerscreen-edu-button {
 	display: none !important;
 }
 
-html[it-hide-scroll-for-details='true'] ytd-app[scrolling_] {
+html[it-hide-scroll-for-details='true'] ytd-app[scrolling_],
+html[it-hide-scroll-for-details='true'] ytd-watch-flexy[fullscreen],
+html[it-hide-scroll-for-details='true'] ytd-watch-flexy[fullscreen] #columns,
+html[it-hide-scroll-for-details='true'] ytd-watch-flexy[fullscreen] #primary,
+html[it-hide-scroll-for-details='true'] ytd-watch-flexy[fullscreen] #secondary,
+html[it-hide-scroll-for-details='true'] ytd-watch-flexy[fullscreen] #below {
 	overflow: hidden !important;
 }
 
@@ -716,7 +721,12 @@ html[it-hide-scroll-for-details='true'] button.ytp-fullerscreen-edu-button {
 	display: none !important;
 }
 
-html[it-hide-scroll-for-details='true'] ytd-app[scrolling_] {
+html[it-hide-scroll-for-details='true'] ytd-app[scrolling_],
+html[it-hide-scroll-for-details='true'] ytd-watch-flexy[fullscreen],
+html[it-hide-scroll-for-details='true'] ytd-watch-flexy[fullscreen] #columns,
+html[it-hide-scroll-for-details='true'] ytd-watch-flexy[fullscreen] #primary,
+html[it-hide-scroll-for-details='true'] ytd-watch-flexy[fullscreen] #secondary,
+html[it-hide-scroll-for-details='true'] ytd-watch-flexy[fullscreen] #below {
 	overflow: hidden !important;
 }
 

--- a/tests/unit/disable-fullscreen-scroll.test.js
+++ b/tests/unit/disable-fullscreen-scroll.test.js
@@ -1,0 +1,37 @@
+// Test for Issue #4129: disable scrolling in fake fullscreen
+
+const fs = require('fs');
+const path = require('path');
+
+describe('Disable fullscreen scrolling (#4129)', () => {
+	let appearanceContent;
+	let playerCssContent;
+	let messages;
+
+	beforeAll(() => {
+		appearanceContent = fs.readFileSync(path.join(__dirname, '../../menu/skeleton-parts/appearance.js'), 'utf8');
+		playerCssContent = fs.readFileSync(path.join(__dirname, '../../js&css/extension/www.youtube.com/appearance/player/player.css'), 'utf8');
+		messages = JSON.parse(fs.readFileSync(path.join(__dirname, '../../_locales/en/messages.json'), 'utf8'));
+	});
+
+	test('keeps the existing appearance toggle wired up', () => {
+		expect(appearanceContent).toContain('hide_scroll_for_details');
+		expect(appearanceContent).toContain('text: "hideScrollForDetails"');
+	});
+
+	test('locks page scrolling while fake fullscreen is active', () => {
+		expect(playerCssContent).toContain("html[it-hide-scroll-for-details='true'] ytd-app[scrolling_]");
+		expect(playerCssContent).toContain("html[it-hide-scroll-for-details='true'] ytd-watch-flexy[fullscreen]");
+		expect(playerCssContent).toContain("html[it-hide-scroll-for-details='true'] ytd-watch-flexy[fullscreen] #columns");
+		expect(playerCssContent).toContain('overflow: hidden !important;');
+	});
+
+	test('still hides the fullscreen education button', () => {
+		expect(playerCssContent).toContain('button.ytp-fullerscreen-edu-button');
+	});
+
+	test('updates the toggle label to describe fullscreen scrolling', () => {
+		expect(messages.hideScrollForDetails).toBeDefined();
+		expect(messages.hideScrollForDetails.message).toBe('Disable scrolling in fullscreen');
+	});
+});


### PR DESCRIPTION
## What Changed
- repurpose the existing `hide_scroll_for_details` setting so it disables page scrolling while YouTube is in fake fullscreen
- keep hiding the fullscreen education button, but also lock the fullscreen watch layout containers that currently allow wheel scrolling into details, comments, and recommendations
- update the setting label so it describes the fullscreen scrolling behavior users actually care about now
- add regression coverage for the menu wiring, fullscreen selectors, and translation text

## Why
Issue #4129 reports that fake fullscreen is no longer truly fullscreen because mouse wheel scrolling can still move the page and reveal surrounding content. This change keeps the fullscreen experience locked in place when the setting is enabled.

Closes #4129

## Testing / Evidence
- `npm test -- --runInBand tests/unit/disable-fullscreen-scroll.test.js`
- Result: `21 passed, 21 total` test suites and `92 passed, 92 total` tests
