### PR TITLE
fix: remove duplicate playback speed button code and settings

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -1523,7 +1523,7 @@
   "exact": {
     "message": "Genaues Datum/Uhrzeit"
   },
-  "player_playback_speed_button": {
+  "playbackSpeedButton": {
     "message": "Wiedergabegeschwindigkeit-Button"
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1101,9 +1101,6 @@
   "player_fit_to_win_button": {
     "message": "Fit to window"
   },
-  "player_playback_speed_button": {
-    "message": "Playback Speed Button"
-  },
   "player_rewind_and_forward_buttons": {
     "message": "Rewind/forward buttons"
   },

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -764,7 +764,7 @@
     "player": {
         "message": "Reproductor"
     },
-    "player_playback_speed_button": {
+    "playbackSpeedButton": {
         "message": "Botón de Velocidad de Reproducción"
     },
     "playerColor": {

--- a/_locales/fa/messages.json
+++ b/_locales/fa/messages.json
@@ -1040,9 +1040,6 @@
     "player_fit_to_win_button": {
         "message": "اندازه کردن به اندازه پنجره"
     },
-    "player_playback_speed_button": {
-        "message": "دکمه سرعت پخش"
-    },
     "player_rewind_and_forward_buttons": {
         "message": "دکمه‌های عقب/جلو بردن"
     },

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -614,7 +614,7 @@
     "player_cinema_mode_button": {
         "message": "Mode Cinéma"
     },
-    "player_playback_speed_button": {
+    "playbackSpeedButton": {
         "message": "Bouton de Vitesse de Lecture"
     },
     "player_rewind_and_forward_buttons": {

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1032,9 +1032,6 @@
   "playerIncreaseDecreaseSpeedButtons": {
     "message": "再生速度増加/減少ボタン"
   },
-  "player_playback_speed_button": {
-    "message": "再生速度ボタン"
-  },
   "playerPlaybackSpeedStep": {
     "message": "再生速度ステップ"
   },

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -1103,9 +1103,6 @@
    "player_fit_to_win_button": {
       "message": "창에 맞추기"
    },
-   "player_playback_speed_button": {
-      "message": "재생 속도 버튼"
-   },
    "player_rewind_and_forward_buttons": {
       "message": "되감기/앞으로 버튼"
    },

--- a/_locales/ne/messages.json
+++ b/_locales/ne/messages.json
@@ -1073,9 +1073,6 @@
   "player_fit_to_win_button": {
     "message": "सञ्झ्यालमा मिलाउनुहोस्"
   },
-  "player_playback_speed_button": {
-    "message": "गति बटन प्लेब्याक गर्नुहोस्"
-  },
   "player_rewind_and_forward_buttons": {
     "message": "बटनहरू रिवाइन्ड गर्नुहोस्/अगाडि"
   },

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -1088,9 +1088,6 @@
     "player_fit_to_win_button": {
         "message": "Ajustar à janela"
     },
-    "player_playback_speed_button": {
-        "message": "Botão de Velocidade de Reprodução"
-    },
     "player_rewind_and_forward_buttons": {
         "message": "Botões Voltar/Avançar"
     },

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -1091,9 +1091,6 @@
   "player_fit_to_win_button": {
     "message": "Вписать в окно"
   },
-  "player_playback_speed_button": {
-    "message": "Кнопка ускорения воспроизведения"
-  },
   "player_rewind_and_forward_buttons": {
     "message": "Кнопки перемотки назад / вперед"
   },

--- a/_locales/th/messages.json
+++ b/_locales/th/messages.json
@@ -1082,9 +1082,6 @@
   "player_fit_to_win_button": {
     "message": "ขนาดพอดีหน้าต่าง"
   },
-  "player_playback_speed_button": {
-    "message": "ปุ่มความเร็วการเล่น"
-  },
   "player_rewind_and_forward_buttons": {
     "message": "ปุ่มกรอเดินหน้า/ถอยหลัง"
   },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -1048,9 +1048,6 @@
     "player_fit_to_win_button": {
         "message": "播放器适应窗口按钮"
     },
-    "player_playback_speed_button": {
-        "message": "播放器播放速度按钮"
-    },
     "player_rewind_and_forward_buttons": {
         "message": "播放器快进快退按钮"
     },

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -1046,9 +1046,6 @@
     "player_fit_to_win_button": {
         "message": "播放器適合視窗按鈕" 
     },
-    "player_playback_speed_button": {
-        "message": "播放器播放速度按鈕" 
-    },
     "player_rewind_and_forward_buttons": {
         "message": "播放器快轉倒轉按鈕" 
     },

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -1678,7 +1678,25 @@ extension.skeleton.main.layers.section.player.on.click = {
 			storage: 'player_playback_speed_button',
 			id: 'player_playback_speed_button'
 		},
-
+		
+		player_playback_speed_button_b: {
+			component: 'switch',
+			text: 'playbackSpeedButton',
+			storage: 'player_playback_speed_button_b',
+			id: 'player_playback_speed_button_b',
+			children: [{
+				id: 'player_custom_playback_speed',
+				storage: 'player_custom_playback_speed',
+				component: 'slider',
+				text: 'preferredSpeed',
+				min: 0.25,
+				max: 4,
+				step: 0.05,
+				text: true,
+				value: 1.25
+			}]
+		},
+		
 		player_cinema_mode_button: {
 			component: 'switch',
 			text: 'player_cinema_mode_button',

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -1676,18 +1676,7 @@ extension.skeleton.main.layers.section.player.on.click = {
 			component: 'switch',
 			text: 'playbackSpeedButton',
 			storage: 'player_playback_speed_button',
-			id: 'player_playback_speed_button',
-			children: [{
-				id: 'player_custom_playback_speed',
-				storage: 'player_custom_playback_speed',
-				component: 'slider',
-				text: 'preferredSpeed',
-				min: 0.25,
-				max: 4,
-				step: 0.05,
-				textarea: true,
-				value: 1.25
-			}]
+			id: 'player_playback_speed_button'
 		},
 
 		player_cinema_mode_button: {
@@ -1799,11 +1788,6 @@ extension.skeleton.main.layers.section.player.on.click = {
 				max: 1,
 				step: 0.05,
 				value: 0.25
-			},
-
-			player_playback_speed_button: {
-				component: 'switch',
-				text: 'player_playback_speed_button'
 			},
 		},
 		fullscreen_return_button: {


### PR DESCRIPTION
## Summary

Follow-up to #3824.

This PR removes the remaining duplicate Playback Speed Button settings entry and
cleans up the now-unused locale key.

#3824 already removed the duplicate runtime `playerPlaybackSpeedButton`
implementation from `js&css/web-accessible/www.youtube.com/player.js`, so this PR
no longer changes the player runtime code.

## Changes

- Keep `Player > Buttons > Playback speed button`.
- Remove the duplicate `Player > Extra buttons inside the player > Playback
  Speed Button` settings entry.
- Remove the non-rendered `player_custom_playback_speed` slider definition under
  the Playback Speed Button switch.
- Move existing localized `player_playback_speed_button` strings to
  `playbackSpeedButton` where needed.
- Remove the now-unused `player_playback_speed_button` locale entries.

## Menu duplication

The playback speed button setting appeared in two menu locations while using the
same storage key, `player_playback_speed_button`.

| Player > Buttons | Player > Extra buttons inside the player |
|---|---|
| <img width="301" height="463" alt="pr-buttons" src="https://github.com/user-attachments/assets/001ca195-c346-4d02-b37c-956efde72f64" /> | <img width="311" height="374" alt="pr-extra" src="https://github.com/user-attachments/assets/165501bf-3190-4867-ad67-13b426b896ff" /> |

Both switches controlled the same feature. The active player button is inserted
into the left controls, so this PR keeps the `Player > Buttons` entry and removes
the duplicate entry from `Extra buttons inside the player`.

The removed `player_custom_playback_speed` slider definition was not rendered by
the current settings renderer, so it was not a functional settings control.
Removing it does not change any editable settings UI.

## Locale cleanup

Before this PR, the related locale keys were split as follows:

| locale | `playbackSpeedButton` | `player_playback_speed_button` |
|---|---|---|
| `de` | - | Wiedergabegeschwindigkeit-Button |
| `en` | Playback speed button | Playback Speed Button |
| `es` | - | Botón de Velocidad de Reproducción |
| `fa` | دکمه سرعت پخش | دکمه سرعت پخش |
| `fr` | - | Bouton de Vitesse de Lecture |
| `ja` | 再生速度調整ボタン | 再生速度ボタン |
| `ko` | 재생 속도 버튼 | 재생 속도 버튼 |
| `ne` | गति प्लेब्याक बटन | गति बटन प्लेब्याक गर्नुहोस् |
| `pt_BR` | Botão de velocidade de reprodução | Botão de Velocidade de Reprodução |
| `ru` | Кнопка скорости воспроизведения | Кнопка ускорения воспроизведения |
| `th` | ปุ่มความเร็วการเล่น | ปุ่มความเร็วการเล่น |
| `uk` | Кнопка швидкості відтворення | - |
| `zh_CN` | 播放速度按钮 | 播放器播放速度按钮 |
| `zh_TW` | 播放速度按鈕 | 播放器播放速度按鈕 |

The remaining settings entry uses the `playbackSpeedButton` locale key. After the
duplicate `player_playback_speed_button` settings entry is removed, the
`player_playback_speed_button` locale key is no longer needed.

For locales where only `player_playback_speed_button` existed (`de`, `es`, and
`fr`), this PR moves that existing translation to `playbackSpeedButton` before
removing the unused key.

For locales where both keys existed, this PR removes
`player_playback_speed_button` and keeps the existing `playbackSpeedButton`
value.

## Testing

- `git diff --check origin/master...HEAD`
- `node --check repo/menu/skeleton-parts/player.js`
- Validate changed `_locales/*/messages.json` files with `JSON.parse`.
- Confirm `origin/master...HEAD` has no diff for
  `js&css/web-accessible/www.youtube.com/player.js`.

## LLM disclosure

English is not my first language, so I use LLMs for drafting
explanations/comments and translation. For this PR, I also used LLM assistance
to investigate storage keys and locale/message usage.
