### PR TITLE
feat: add custom seek distance setting (fixes #4132)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1332,6 +1332,9 @@
   "seekForward10Seconds": {
     "message": "Seek forward 10 seconds"
   },
+  "seekDistance": {
+    "message": "Seek distance (seconds)"
+  },
   "seekNextChapter": {
     "message": "Seek Next Chapter"
   },

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -1980,9 +1980,10 @@ ImprovedTube.playerRewindAndForwardButtons = function(){
 	  child: svgForward,
    
 	  onclick: function () {
-	   ImprovedTube.elements.player.seekTo(ImprovedTube.elements.player.getCurrentTime() + 5);
+	   var distance = Number(ImprovedTube.storage.player_seek_distance) || 10;
+	   ImprovedTube.elements.player.seekTo(ImprovedTube.elements.player.getCurrentTime() + distance);
 	  },
-	  title: 'forward 5 seconds',
+	  title: 'forward',
 	 }).classList.remove('it-player-button');
 	 this.createPlayerButton({
 	  id: 'it-rewind-player-button',
@@ -1991,9 +1992,10 @@ ImprovedTube.playerRewindAndForwardButtons = function(){
 	  child: svgBackward,
    
 	  onclick: function () {
-	   ImprovedTube.elements.player.seekTo(ImprovedTube.elements.player.getCurrentTime() - 5);
+	   var distance = Number(ImprovedTube.storage.player_seek_distance) || 10;
+	   ImprovedTube.elements.player.seekTo(ImprovedTube.elements.player.getCurrentTime() - distance);
 	  },
-	  title: 'rewind 5 seconds',
+	  title: 'rewind',
 	 }).classList.remove('it-player-button');
 	}
    }

--- a/js&css/web-accessible/www.youtube.com/shortcuts.js
+++ b/js&css/web-accessible/www.youtube.com/shortcuts.js
@@ -307,13 +307,15 @@ ImprovedTube.shortcutPrevVideo = function () {
 4.7.9 SEEK BACKWARD
 ------------------------------------------------------------------------------*/
 ImprovedTube.shortcutSeekBackward = function () {
-	this.elements.player?.seekBy(-10);
+	var distance = Number(this.storage.player_seek_distance) || 10;
+	this.elements.player?.seekBy(-distance);
 };
 /*------------------------------------------------------------------------------
 4.7.10 SEEK FORWARD
 ------------------------------------------------------------------------------*/
 ImprovedTube.shortcutSeekForward = function () {
-	this.elements.player?.seekBy(10);
+	var distance = Number(this.storage.player_seek_distance) || 10;
+	this.elements.player?.seekBy(distance);
 };
 /*------------------------------------------------------------------------------
 4.7.11 SEEK NEXT CHAPTER

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -1785,6 +1785,16 @@ extension.skeleton.main.layers.section.player.on.click = {
 				component: 'switch',
 				text: 'player_rewind_and_forward_buttons'
 			},
+			player_seek_distance: {
+				storage: 'player_seek_distance',
+				component: 'slider',
+				text: 'seekDistance',
+				textarea: true,
+				min: 1,
+				max: 60,
+				step: 1,
+				value: 10
+			},
 			player_increase_decrease_speed_buttons: {
 				component: 'switch',
 				text: 'playerIncreaseDecreaseSpeedButtons',


### PR DESCRIPTION
Fixes #4132

## Summary

Adds a configurable seek distance setting so users can customize how many seconds to jump when using keyboard shortcuts (J/L) or the rewind/forward player buttons.

## Changes

- **New setting:** Seek distance slider in Player settings, range 1-60s, default 10
- **Shortcuts:** shortcutSeekBackward and shortcutSeekForward now read from player_seek_distance storage
- **Player buttons:** Rewind/Forward buttons use the custom distance instead of hardcoded 5s
- **Localization:** Added seekDistance key to en/messages.json

## How it works

1. User sets their preferred seek distance in the extension menu under Player section
2. All seek operations use that value, both keyboard and buttons
3. Default remains 10 seconds if not configured

This addresses the request for customizable double-tap/seek distance on tablets and all platforms.