### PR TITLE
feat: add configurable double-tap seek with ytp-seek visual feedback

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,10 +1,8 @@
 {
-  "dontShortenTitles": {
-    "message": "Full Video Titles (don't shorten)"
-  },
-  "preferredDubbingLanguage": {
-    "message": "Preferred dubbing language"
-  },
+  "dontShortenTitles": { 	"message": "Full Video Titles (don't shorten)" },
+	 "preferredDubbingLanguage": {
+		"message": "Preferred dubbing language"
+	},
   "hideSuggestedAction": {
     "message": "Hide Suggested Action 'View products'"
   },
@@ -1508,8 +1506,8 @@
   "thumbnails": {
     "message": "Thumbnails"
   },
-  "thumbnailGrayscale": {
-    "message": "Thumbnail Grayscale"
+  "thumbnailGrayscale":{
+    "message":"Thumbnail Grayscale"
   },
   "thumbnailSize": {
     "message": "Thumbnail Size"
@@ -1710,7 +1708,7 @@
     "message": "Channel Whitelisted for Smart Speed!"
   },
   "autoVideoRecovery": {
-    "message": "Auto video recovery"
+  "message": "Auto video recovery"
   },
   "doubleTapSeek": {
     "message": "Double-tap seek"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,8 +1,10 @@
 {
-  "dontShortenTitles": { 	"message": "Full Video Titles (don't shorten)" },
-	 "preferredDubbingLanguage": {
-		"message": "Preferred dubbing language"
-	},
+  "dontShortenTitles": {
+    "message": "Full Video Titles (don't shorten)"
+  },
+  "preferredDubbingLanguage": {
+    "message": "Preferred dubbing language"
+  },
   "hideSuggestedAction": {
     "message": "Hide Suggested Action 'View products'"
   },
@@ -1506,8 +1508,8 @@
   "thumbnails": {
     "message": "Thumbnails"
   },
-  "thumbnailGrayscale":{
-    "message":"Thumbnail Grayscale"
+  "thumbnailGrayscale": {
+    "message": "Thumbnail Grayscale"
   },
   "thumbnailSize": {
     "message": "Thumbnail Size"
@@ -1708,6 +1710,33 @@
     "message": "Channel Whitelisted for Smart Speed!"
   },
   "autoVideoRecovery": {
-  "message": "Auto video recovery"
+    "message": "Auto video recovery"
+  },
+  "doubleTapSeek": {
+    "message": "Double-tap seek"
+  },
+  "mode": {
+    "message": "Mode"
+  },
+  "defaultBehavior": {
+    "message": "Default (YouTube native)"
+  },
+  "fixedDistance": {
+    "message": "Fixed distance"
+  },
+  "progressiveDistance": {
+    "message": "Progressive distance"
+  },
+  "seekDistance": {
+    "message": "Seek distance (seconds)"
+  },
+  "doubleTapDistance": {
+    "message": "Double-tap distance (seconds)"
+  },
+  "tripleTapDistance": {
+    "message": "Triple-tap distance (seconds)"
+  },
+  "quadrupleTapDistance": {
+    "message": "Quadruple-tap distance (seconds)"
   }
 }

--- a/js&css/web-accessible/www.youtube.com/shortcuts.js
+++ b/js&css/web-accessible/www.youtube.com/shortcuts.js
@@ -41,7 +41,7 @@ ImprovedTube.shortcutsInit = function () {
 		if (potentialShortcut['keys'].size || potentialShortcut['wheel']) listening[camelName] = potentialShortcut;
 	}
 	// initialize 'listeners' only if there are actual shortcuts active
-	if (Object.keys(listening).length) {
+	if (Object.keys(listening).length || this.storage.player_double_tap_seek_mode) {
 		for (const [name, handler] of Object.entries(this.shortcutsListeners)) {
 			// only one listener per handle
 			if (!listeners[name]) {
@@ -167,6 +167,43 @@ ImprovedTube.shortcutsListeners = {
 		ImprovedTube.input.pressed.alt = false;
 		ImprovedTube.input.pressed.ctrl = false;
 		ImprovedTube.input.pressed.shift = false;
+	},
+	/*-----------------------------------------------------------------------------
+	4.7.0T TOUCH INPUT - Double-tap seek
+	-----------------------------------------------------------------------------*/
+	touchend: function (event) {
+		const mode = ImprovedTube.storage.player_double_tap_seek_mode;
+		if (!mode || mode === 'default') return;
+		const player = ImprovedTube.elements.player;
+		if (!player) return;
+		const path = event.composedPath ? event.composedPath() : [];
+		if (!path.includes(player) && !(ImprovedTube.elements.video && path.includes(ImprovedTube.elements.video))) return;
+		const touch = event.changedTouches[0];
+		if (!touch) return;
+		const rect = player.getBoundingClientRect();
+		const x = touch.clientX - rect.left;
+		const isInLeftHalf = x < rect.width / 2;
+		const direction = isInLeftHalf ? -1 : 1;
+		const now = Date.now();
+		if (!ImprovedTube.input.touch) {
+			ImprovedTube.input.touch = { lastTap: 0, count: 0, direction: 0, timer: null };
+		}
+		const ts = ImprovedTube.input.touch;
+		if (ts.direction !== direction || now - ts.lastTap > 500) {
+			ts.count = 1;
+			ts.direction = direction;
+		} else {
+			ts.count++;
+		}
+		ts.lastTap = now;
+		event.preventDefault();
+		event.stopPropagation();
+		if (ts.timer) clearTimeout(ts.timer);
+		const count = ts.count;
+		ts.timer = setTimeout(function () {
+			ImprovedTube.doubleTapSeek(direction, count);
+			ts.count = 0;
+		}, 300);
 	}
 };
 /*--- jump To Key Scene ----*/
@@ -735,4 +772,48 @@ ImprovedTube.shortcutSmartSpeed = function () {
     } else if (ImprovedTube.storage.smart_speed === true) { if(ImprovedTube.heatmap) { ImprovedTube.heatmap.isEnabled = false; document.querySelector("video").playbackRate = 1.0; } 
     }
 	this.storage.smart_speed = !this.storage.smart_speed;
+};
+
+
+/*-----------------------------------------------------------------------------
+4.7.34 DOUBLE-TAP SEEK
+-----------------------------------------------------------------------------*/
+ImprovedTube.doubleTapSeek = function (direction, tapCount) {
+	const player = this.elements.player;
+	if (!player || !player.getCurrentTime || !player.seekTo) return;
+	const mode = this.storage.player_double_tap_seek_mode || 'default';
+	let seekAmount = 0;
+	if (mode === 'fixed') {
+		seekAmount = Number(this.storage.player_double_tap_seek_fixed_distance) || 10;
+	} else if (mode === 'progressive') {
+		const d2 = Number(this.storage.player_double_tap_seek_distance_2) || 10;
+		const d3 = Number(this.storage.player_double_tap_seek_distance_3) || 30;
+		const d4 = Number(this.storage.player_double_tap_seek_distance_4) || 60;
+		if (tapCount <= 2) seekAmount = d2;
+		else if (tapCount === 3) seekAmount = d3;
+		else seekAmount = d4;
+	}
+	if (seekAmount <= 0) return;
+	const currentTime = player.getCurrentTime();
+	const duration = player.getDuration ? player.getDuration() : Infinity;
+	const newTime = Math.max(0, Math.min(duration, currentTime + direction * seekAmount));
+	player.seekTo(newTime, true);
+	const seekClass = direction > 0 ? 'ytp-seek-forward-bump' : 'ytp-seek-backward-bump';
+	player.classList.add(seekClass);
+	const doubletapUi = player.querySelector('.ytp-doubletap-ui');
+	if (doubletapUi) {
+		doubletapUi.classList.add('ytp-doubletap-ui-show');
+		const icon = doubletapUi.querySelector('.ytp-doubletap-ui-label-icon');
+		if (icon) {
+			icon.classList.remove('ytp-doubletap-ui-label-icon-forward', 'ytp-doubletap-ui-label-icon-backward');
+			icon.classList.add(direction > 0 ? 'ytp-doubletap-ui-label-icon-forward' : 'ytp-doubletap-ui-label-icon-backward');
+		}
+	}
+	setTimeout(function () {
+		player.classList.remove(seekClass);
+		if (doubletapUi) {
+			doubletapUi.classList.remove('ytp-doubletap-ui-show');
+		}
+	}, 500);
+	this.showStatus((direction > 0 ? '+' : '') + (direction * seekAmount) + 's');
 };

--- a/js&css/web-accessible/www.youtube.com/shortcuts.js
+++ b/js&css/web-accessible/www.youtube.com/shortcuts.js
@@ -169,7 +169,7 @@ ImprovedTube.shortcutsListeners = {
 		ImprovedTube.input.pressed.shift = false;
 	},
 	/*-----------------------------------------------------------------------------
-	4.7.0T TOUCH INPUT - Double-tap seek
+	TOUCH INPUT - Double-tap seek
 	-----------------------------------------------------------------------------*/
 	touchend: function (event) {
 		const mode = ImprovedTube.storage.player_double_tap_seek_mode;
@@ -776,7 +776,7 @@ ImprovedTube.shortcutSmartSpeed = function () {
 
 
 /*-----------------------------------------------------------------------------
-4.7.34 DOUBLE-TAP SEEK
+DOUBLE-TAP SEEK
 -----------------------------------------------------------------------------*/
 ImprovedTube.doubleTapSeek = function (direction, tapCount) {
 	const player = this.elements.player;

--- a/js&css/web-accessible/www.youtube.com/shortcuts.js
+++ b/js&css/web-accessible/www.youtube.com/shortcuts.js
@@ -178,6 +178,9 @@ ImprovedTube.shortcutsListeners = {
 		if (!player) return;
 		const path = event.composedPath ? event.composedPath() : [];
 		if (!path.includes(player) && !(ImprovedTube.elements.video && path.includes(ImprovedTube.elements.video))) return;
+		// Don't intercept taps on player controls (play/pause, fullscreen, settings, etc.)
+		const target = event.target;
+		if (target && target.closest && target.closest('.ytp-chrome-bottom, .ytp-chrome-top, .ytp-settings-menu, .ytp-popup, .ytp-button, button, a')) return;
 		const touch = event.changedTouches[0];
 		if (!touch) return;
 		const rect = player.getBoundingClientRect();

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -158,6 +158,45 @@ extension.skeleton.main.layers.section.player.on.click = {
 				}
 			}
 		},
+		double_tap_seek: {
+			component: 'button',
+			text: 'doubleTapSeek',
+			on: {
+				click: {
+					component: 'section',
+					variant: 'card',
+					player_double_tap_seek_mode: {
+						component: 'select',
+						text: 'mode',
+						options: [
+							{ value: 'default', text: 'defaultBehavior' },
+							{ value: 'fixed', text: 'fixedDistance' },
+							{ value: 'progressive', text: 'progressiveDistance' }
+						]
+					},
+					player_double_tap_seek_fixed_distance: {
+						component: 'slider',
+						text: 'seekDistance',
+						min: 1, max: 60, step: 1, value: 10
+					},
+					player_double_tap_seek_distance_2: {
+						component: 'slider',
+						text: 'doubleTapDistance',
+						min: 1, max: 60, step: 1, value: 10
+					},
+					player_double_tap_seek_distance_3: {
+						component: 'slider',
+						text: 'tripleTapDistance',
+						min: 1, max: 120, step: 1, value: 30
+					},
+					player_double_tap_seek_distance_4: {
+						component: 'slider',
+						text: 'quadrupleTapDistance',
+						min: 1, max: 180, step: 1, value: 60
+					}
+				}
+			}
+		},
 		player_forced_volume: {
 			component: 'switch',
 			text: 'forcedVolume',

--- a/tests/unit/double-tap-seek.test.js
+++ b/tests/unit/double-tap-seek.test.js
@@ -1,0 +1,97 @@
+/**
+ * Tests for double-tap seek feature
+ */
+
+global.ImprovedTube = {
+    storage: {},
+    elements: { player: null, video: null },
+    input: {},
+    showStatus: jest.fn(),
+    doubleTapSeek: null
+};
+
+const shortcutsCode = require('fs').readFileSync(
+    require('path').join(__dirname, '../../js&css/web-accessible/www.youtube.com/shortcuts.js'),
+    'utf-8'
+);
+
+const match = shortcutsCode.match(/ImprovedTube\.doubleTapSeek\s*=\s*function[\s\S]*?\n};/);
+if (match) {
+    eval(match[0]);
+}
+
+describe('Double-tap seek', () => {
+    let mockPlayer;
+
+    beforeEach(() => {
+        mockPlayer = {
+            getCurrentTime: jest.fn(() => 100),
+            getDuration: jest.fn(() => 300),
+            seekTo: jest.fn(),
+            classList: { add: jest.fn(), remove: jest.fn(), contains: jest.fn() },
+            querySelector: jest.fn(() => null)
+        };
+        ImprovedTube.elements.player = mockPlayer;
+        ImprovedTube.showStatus.mockClear();
+    });
+
+    test('should seek by fixed distance in fixed mode', () => {
+        ImprovedTube.storage.player_double_tap_seek_mode = 'fixed';
+        ImprovedTube.storage.player_double_tap_seek_fixed_distance = 5;
+        ImprovedTube.doubleTapSeek(1, 2);
+        expect(mockPlayer.seekTo).toHaveBeenCalledWith(105, true);
+        expect(mockPlayer.classList.add).toHaveBeenCalledWith('ytp-seek-forward-bump');
+    });
+
+    test('should seek backward correctly', () => {
+        ImprovedTube.storage.player_double_tap_seek_mode = 'fixed';
+        ImprovedTube.storage.player_double_tap_seek_fixed_distance = 5;
+        ImprovedTube.doubleTapSeek(-1, 2);
+        expect(mockPlayer.seekTo).toHaveBeenCalledWith(95, true);
+        expect(mockPlayer.classList.add).toHaveBeenCalledWith('ytp-seek-backward-bump');
+    });
+
+    test('should use progressive distances', () => {
+        ImprovedTube.storage.player_double_tap_seek_mode = 'progressive';
+        ImprovedTube.storage.player_double_tap_seek_distance_2 = 10;
+        ImprovedTube.storage.player_double_tap_seek_distance_3 = 30;
+        ImprovedTube.storage.player_double_tap_seek_distance_4 = 60;
+        ImprovedTube.doubleTapSeek(1, 2);
+        expect(mockPlayer.seekTo).toHaveBeenCalledWith(110, true);
+        mockPlayer.getCurrentTime.mockReturnValue(100);
+        ImprovedTube.doubleTapSeek(1, 3);
+        expect(mockPlayer.seekTo).toHaveBeenCalledWith(130, true);
+        mockPlayer.getCurrentTime.mockReturnValue(100);
+        ImprovedTube.doubleTapSeek(1, 4);
+        expect(mockPlayer.seekTo).toHaveBeenCalledWith(160, true);
+    });
+
+    test('should not seek when mode is default', () => {
+        ImprovedTube.storage.player_double_tap_seek_mode = 'default';
+        ImprovedTube.doubleTapSeek(1, 2);
+        expect(mockPlayer.seekTo).not.toHaveBeenCalled();
+    });
+
+    test('should not seek below 0', () => {
+        ImprovedTube.storage.player_double_tap_seek_mode = 'fixed';
+        ImprovedTube.storage.player_double_tap_seek_fixed_distance = 200;
+        mockPlayer.getCurrentTime.mockReturnValue(50);
+        ImprovedTube.doubleTapSeek(-1, 2);
+        expect(mockPlayer.seekTo).toHaveBeenCalledWith(0, true);
+    });
+
+    test('should not seek beyond duration', () => {
+        ImprovedTube.storage.player_double_tap_seek_mode = 'fixed';
+        ImprovedTube.storage.player_double_tap_seek_fixed_distance = 200;
+        mockPlayer.getCurrentTime.mockReturnValue(250);
+        ImprovedTube.doubleTapSeek(1, 2);
+        expect(mockPlayer.seekTo).toHaveBeenCalledWith(300, true);
+    });
+
+    test('should toggle ytp-seek visual classes', () => {
+        ImprovedTube.storage.player_double_tap_seek_mode = 'fixed';
+        ImprovedTube.storage.player_double_tap_seek_fixed_distance = 10;
+        ImprovedTube.doubleTapSeek(1, 2);
+        expect(mockPlayer.classList.add).toHaveBeenCalledWith('ytp-seek-forward-bump');
+    });
+});

--- a/tests/unit/double-tap-seek.test.js
+++ b/tests/unit/double-tap-seek.test.js
@@ -1,6 +1,4 @@
-/**
- * Tests for double-tap seek feature
- */
+// double-tap seek tests
 
 global.ImprovedTube = {
     storage: {},
@@ -10,15 +8,18 @@ global.ImprovedTube = {
     doubleTapSeek: null
 };
 
-const shortcutsCode = require('fs').readFileSync(
-    require('path').join(__dirname, '../../js&css/web-accessible/www.youtube.com/shortcuts.js'),
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+// Extract doubleTapSeek from shortcuts.js (it's not exported as a module)
+const shortcutsCode = fs.readFileSync(
+    path.join(__dirname, '../../js&css/web-accessible/www.youtube.com/shortcuts.js'),
     'utf-8'
 );
-
-const match = shortcutsCode.match(/ImprovedTube\.doubleTapSeek\s*=\s*function[\s\S]*?\n};/);
-if (match) {
-    eval(match[0]);
-}
+const fnMatch = shortcutsCode.match(/ImprovedTube\.doubleTapSeek\s*=\s*function[\s\S]*?\n};/);
+if (!fnMatch) throw new Error('doubleTapSeek not found in shortcuts.js');
+vm.runInThisContext(fnMatch[0]);
 
 describe('Double-tap seek', () => {
     let mockPlayer;
@@ -35,7 +36,7 @@ describe('Double-tap seek', () => {
         ImprovedTube.showStatus.mockClear();
     });
 
-    test('should seek by fixed distance in fixed mode', () => {
+    test('fixed mode seeks by configured distance', () => {
         ImprovedTube.storage.player_double_tap_seek_mode = 'fixed';
         ImprovedTube.storage.player_double_tap_seek_fixed_distance = 5;
         ImprovedTube.doubleTapSeek(1, 2);
@@ -43,7 +44,7 @@ describe('Double-tap seek', () => {
         expect(mockPlayer.classList.add).toHaveBeenCalledWith('ytp-seek-forward-bump');
     });
 
-    test('should seek backward correctly', () => {
+    test('backward seek clamps and adds correct class', () => {
         ImprovedTube.storage.player_double_tap_seek_mode = 'fixed';
         ImprovedTube.storage.player_double_tap_seek_fixed_distance = 5;
         ImprovedTube.doubleTapSeek(-1, 2);
@@ -51,7 +52,7 @@ describe('Double-tap seek', () => {
         expect(mockPlayer.classList.add).toHaveBeenCalledWith('ytp-seek-backward-bump');
     });
 
-    test('should use progressive distances', () => {
+    test('progressive mode uses escalating distances', () => {
         ImprovedTube.storage.player_double_tap_seek_mode = 'progressive';
         ImprovedTube.storage.player_double_tap_seek_distance_2 = 10;
         ImprovedTube.storage.player_double_tap_seek_distance_3 = 30;
@@ -66,13 +67,13 @@ describe('Double-tap seek', () => {
         expect(mockPlayer.seekTo).toHaveBeenCalledWith(160, true);
     });
 
-    test('should not seek when mode is default', () => {
+    test('default mode is a no-op', () => {
         ImprovedTube.storage.player_double_tap_seek_mode = 'default';
         ImprovedTube.doubleTapSeek(1, 2);
         expect(mockPlayer.seekTo).not.toHaveBeenCalled();
     });
 
-    test('should not seek below 0', () => {
+    test('clamps to 0 when seeking before start', () => {
         ImprovedTube.storage.player_double_tap_seek_mode = 'fixed';
         ImprovedTube.storage.player_double_tap_seek_fixed_distance = 200;
         mockPlayer.getCurrentTime.mockReturnValue(50);
@@ -80,7 +81,7 @@ describe('Double-tap seek', () => {
         expect(mockPlayer.seekTo).toHaveBeenCalledWith(0, true);
     });
 
-    test('should not seek beyond duration', () => {
+    test('clamps to duration when seeking past end', () => {
         ImprovedTube.storage.player_double_tap_seek_mode = 'fixed';
         ImprovedTube.storage.player_double_tap_seek_fixed_distance = 200;
         mockPlayer.getCurrentTime.mockReturnValue(250);
@@ -88,7 +89,7 @@ describe('Double-tap seek', () => {
         expect(mockPlayer.seekTo).toHaveBeenCalledWith(300, true);
     });
 
-    test('should toggle ytp-seek visual classes', () => {
+    test('toggles ytp-seek visual feedback classes', () => {
         ImprovedTube.storage.player_double_tap_seek_mode = 'fixed';
         ImprovedTube.storage.player_double_tap_seek_fixed_distance = 10;
         ImprovedTube.doubleTapSeek(1, 2);


### PR DESCRIPTION
## Summary

Implements configurable double-tap seek distances for touch devices, addressing issue #4132.

This PR follows the maintainer's guidance from the issue discussion:
- **Touch inputs added to `shortcuts.js`** - the `touchend` listener is integrated into the existing `shortcutsListeners` system
- **`ytp-seek-*` visual classes modified through the DOM** - toggles `ytp-seek-forward-bump` / `ytp-seek-backward-bump` on the player element, and triggers YouTube's `ytp-doubletap-ui` overlay
- **Uses `player.seekTo()`** - as the maintainer specified, not `seekBy()`
- **`event.preventDefault()` + `event.stopPropagation()`** - prevents YouTube's default double-tap behavior when custom mode is active

## Features

Three seek modes (as requested in the issue):

1. **Default** - YouTube's native behavior (no interception)
2. **Fixed distance** - user-configurable seek distance (1-60 seconds), same amount every tap
3. **Progressive distance** - separate distances for double-tap, triple-tap, and quadruple-tap

## Changes

| File | Change |
|------|--------|
| `shortcuts.js` | Add `touchend` listener to `shortcutsListeners`, `doubleTapSeek()` function, modify `shortcutsInit()` |
| `menu/skeleton-parts/player.js` | Add Double-tap seek section with mode selector and distance sliders |
| `_locales/en/messages.json` | Add i18n labels for new settings |
| `tests/unit/double-tap-seek.test.js` | Jest tests for seek logic, boundary checks, progressive mode, visual feedback |

/claim #4132