### PR TITLE
feat: add Volume Boost player button (addresses #4146)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1110,6 +1110,9 @@
   "player_rotate_button": {
     "message": "Rotate video"
   },
+  "player_volume_boost_button": {
+    "message": "Volume Boost button"
+  },
   "playerAutoPipOutside": {
     "message": "Auto-PiP only outside source Tab"
   },
@@ -1295,6 +1298,9 @@
   },
   "rotate": {
     "message": "Rotate"
+  },
+  "volumeBoost": {
+    "message": "Volume Boost"
   },
   "save": {
     "message": "Save"

--- a/js&css/web-accessible/core.js
+++ b/js&css/web-accessible/core.js
@@ -348,6 +348,15 @@ document.addEventListener('it-message-from-extension', function () {
 					}
 					break
 
+				case 'playerVolumeBoostButton':
+					if (ImprovedTube.storage.player_volume_boost_button === false) {
+						ImprovedTube.elements.buttons['it-volume-boost-button']?.remove();
+						if (ImprovedTube.volumeBoostGain) {
+							ImprovedTube.volumeBoostGain.gain.value = 1;
+						}
+					}
+					break
+
 				case 'playerFitToWinButton':
 					if (ImprovedTube.storage.player_fit_to_win_button === false) {
 						ImprovedTube.elements.buttons['it-fit-to-win-player-button']?.remove();

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -1095,6 +1095,55 @@ ImprovedTube.playerRotateButton = function () {
 };
 
 /*------------------------------------------------------------------------------
+VOLUME BOOST BUTTON
+------------------------------------------------------------------------------*/
+ImprovedTube.playerVolumeBoostButton = function () {
+	if (this.storage.player_volume_boost_button === true) {
+		var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg'),
+			path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+
+		svg.setAttributeNS(null, 'viewBox', '0 0 24 24');
+		path.setAttributeNS(null, 'd', 'M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z');
+
+		svg.appendChild(path);
+
+		var button = this.createPlayerButton({
+			id: 'it-volume-boost-button',
+			child: svg,
+			opacity: 0.5,
+			onclick: function () {
+				// ponytail: Web Audio API gain node. Ceiling: clipping at very high gain (>4x). Upgrade: add compressor node.
+				var video = ImprovedTube.elements.video;
+				if (!video) return;
+
+				if (!ImprovedTube.volumeBoostContext) {
+					var AudioContext = window.AudioContext || window.webkitAudioContext;
+					ImprovedTube.volumeBoostContext = new AudioContext();
+					ImprovedTube.volumeBoostSource = ImprovedTube.volumeBoostContext.createMediaElementSource(video);
+					ImprovedTube.volumeBoostGain = ImprovedTube.volumeBoostContext.createGain();
+					ImprovedTube.volumeBoostSource.connect(ImprovedTube.volumeBoostGain);
+					ImprovedTube.volumeBoostGain.connect(ImprovedTube.volumeBoostContext.destination);
+				}
+
+				var gain = ImprovedTube.volumeBoostGain.gain;
+				var current = gain.value;
+
+				// Cycle: 1x → 2x → 3x → 1x
+				var next = current >= 3 ? 1 : current + 1;
+				gain.value = next;
+
+				var btn = ImprovedTube.elements.buttons['it-volume-boost-button'];
+				if (btn) {
+					btn.style.opacity = next > 1 ? '1' : '0.5';
+					btn.dataset.title = 'Volume Boost (' + next + 'x)';
+				}
+			},
+			title: 'Volume Boost (1x)'
+		});
+	}
+};
+
+/*------------------------------------------------------------------------------
 PLAYBACK SPEED BUTTON
 ------------------------------------------------------------------------------*/
 ImprovedTube.playerPlaybackSpeedButton = function () {

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -1722,6 +1722,10 @@ extension.skeleton.main.layers.section.player.on.click = {
 			component: 'switch',
 			text: 'rotate'
 		},
+		player_volume_boost_button: {
+			component: 'switch',
+			text: 'volumeBoost'
+		},
 		player_hamburger_button: {
 			component: 'switch',
 			text: 'Hamburger_Menu'


### PR DESCRIPTION
## Summary

Adds a **Volume Boost** button to the player controls that amplifies audio beyond 100% using the Web Audio API (GainNode).

## Changes

- New player button: click cycles through 1x -> 2x -> 3x -> 1x amplification
- Button opacity indicates active state (dim = 1x, bright = boosted)
- Gain resets to 1x when feature is disabled in settings
- Toggle available under Player section in extension menu
- Uses standard Web Audio API: AudioContext + GainNode (no dependencies)

## How it works

1. User enables 'Volume Boost' in Player settings
2. A speaker icon button appears in the player controls
3. Clicking it cycles the audio gain: 1x (normal) -> 2x -> 3x -> back to 1x
4. Useful for quiet videos, podcasts, or when device volume is maxed out

## Testing

- Tested on YouTube watch pages with various volume levels
- AudioContext is created lazily on first click (avoids autoplay policy issues)
- Works alongside existing volume slider (boost multiplies the slider value)

## References

Addresses the 'Volume Boost' item from issue #4146 (Player buttons to be added).
Also related to #1382 and the Volume Boost section in the issue's specification.