### PR TITLE
fix: prevent tooltips from overflowing viewport

### DIFF
--- a/js&css/extension/www.youtube.com/styles.css
+++ b/js&css/extension/www.youtube.com/styles.css
@@ -235,7 +235,7 @@ html[it-player-fit-to-win-button=true][data-page-type=video] #ftw-icon path {
 	line-height: 15px !important;
 	position: fixed !important;
 	padding: 5px 9px;
-	transform: translate(-50%, -150%) !important;
+	transform: translate(0, -150%) !important;
 	pointer-events: none !important;
 	color: #eee !important;
 	border-radius: 2px !important;
@@ -247,7 +247,7 @@ body.no-scroll .it-player-button--tooltip {
 	font-size: 20px !important;
 	line-height: 22px !important;
 	padding: 8px 9px !important;
-	transform: translate(-50%, -75%) !important;
+	transform: translate(0, -75%) !important;
 }
 
 /*------------------------------------------------------------------------------

--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -752,27 +752,42 @@ ImprovedTube.createIconButton = function (options) {
 };
 
 ImprovedTube.createPlayerButton = function (options) {
-	var controls = options.position == "right" ? this.elements.player_right_controls : this.elements.player_left_controls;
+	const controls = options.position == "right" ? this.elements.player_right_controls : this.elements.player_left_controls;
 	if (controls) {
-		var button = document.createElement('button');
+		const button = document.createElement('button');
 
 		button.className = 'ytp-button it-player-button';
 
 		button.dataset.title = options.title;
 
 		button.addEventListener('mouseover', function () {
-			var tooltip = document.createElement('div'),
+			const tooltip = document.createElement('div'),
 				rect = this.getBoundingClientRect();
 
 			tooltip.className = 'it-player-button--tooltip';
+			tooltip.textContent = this.dataset.title;
 
-			tooltip.style.left = rect.left + rect.width / 2 + 'px';
+			document.body.appendChild(tooltip);
+
+			const tooltipWidth = tooltip.offsetWidth || tooltip.getBoundingClientRect().width;
+			const centerX = rect.left + (rect.width / 2);
+			let leftPos = centerX - (tooltipWidth / 2);
+			const margin = 10;
+			const viewportWidth = window.innerWidth;
+
+			if (leftPos < margin) {
+				leftPos = margin;
+			} else if (leftPos + tooltipWidth > viewportWidth - margin) {
+				leftPos = viewportWidth - tooltipWidth - margin;
+			}
+
+			tooltip.style.left = leftPos + 'px';
 			tooltip.style.top = rect.top - 8 + 'px';
 
-			tooltip.textContent = this.dataset.title;
 			if (this.storage && (this.storage.player_cinema_mode_button || this.storage.player_auto_hide_cinema_mode_when_paused || this.storage.player_auto_cinema_mode)) {
 				tooltip.style.zIndex = 10001;
 			} // needed for cinema mode
+
 			function mouseleave() {
 				tooltip.remove();
 
@@ -780,8 +795,6 @@ ImprovedTube.createPlayerButton = function (options) {
 			}
 
 			this.addEventListener('mouseleave', mouseleave);
-
-			document.body.appendChild(tooltip);
 		});
 
 		if (options.id) {


### PR DESCRIPTION
## Summary
This PR improves the positioning of ImprovedTube player button tooltips, ensuring they remain fully visible within the viewport, particularly near the screen's left and right edges.

## Changes
- Append the tooltip to the DOM before measuring its width.
- Calculate the tooltip's horizontal position relative to the player button center.
- Clamp the computed horizontal position to keep the tooltip within viewport boundaries (with a small safety margin).
- Apply absolute positioning for both normal and `body.no-scroll` player modes based on the calculated coordinates.

## Why
Previously, tooltip positioning relied on `translateX(-50%)`. This caused tooltips near the screen edges to overflow the viewport and resulted in truncated labels for longer text.

The updated logic measures the rendered tooltip width and clamps its horizontal position, keeping the tooltip within the viewport while preserving the intended vertical placement.


## Testing
- Manually verified tooltip placement on YouTube player controls near both the left and right viewport edges.
- before:   
   <img width="394" height="107" alt="image" src="https://github.com/user-attachments/assets/4ea9af22-ae65-4579-9c9f-ba016e322ce7" />
- after:   
  <img width="394" height="107" alt="image" src="https://github.com/user-attachments/assets/fb6c003d-d693-4efc-82f1-92a5c476bc07" />
