### PR TITLE
fix: resolve subtitles not enabled until reload race condition (#4192)

### DIFF
--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -273,7 +273,7 @@ ImprovedTube.playerSubtitles = function (attempt = 0) {
 		} else if (attempt < 10) {
 			setTimeout(() => {
 				ImprovedTube.playerSubtitles(attempt + 1);
-			}, 200);
+			}, 200 + 30 * attempt);
 		}
 	}
 };

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -255,19 +255,25 @@ window.addEventListener('load', () => {  setTimeout(() => { clearInterval(waitFo
 /*------------------------------------------------------------------------------
 SUBTITLES
 ------------------------------------------------------------------------------*/
-ImprovedTube.playerSubtitles = function () {
+ImprovedTube.playerSubtitles = function (attempt = 0) {
 	const player = this.elements.player;
 
-	if (player && player.isSubtitlesOn && player.toggleSubtitles && player.toggleSubtitlesOn) {
-		switch (this.storage.player_subtitles) {
-			case true:
-			case 'enabled':
-				player.toggleSubtitlesOn();
-				break
+	if (player) {
+		if (player.isSubtitlesOn && player.toggleSubtitles && player.toggleSubtitlesOn) {
+			switch (this.storage.player_subtitles) {
+				case true:
+				case 'enabled':
+					player.toggleSubtitlesOn();
+					break
 
-			case 'disabled':
-				if (player.isSubtitlesOn()) { player.toggleSubtitles(); }
-				break
+				case 'disabled':
+					if (player.isSubtitlesOn()) { player.toggleSubtitles(); }
+					break
+			}
+		} else if (attempt < 10) {
+			setTimeout(() => {
+				ImprovedTube.playerSubtitles(attempt + 1);
+			}, 200);
 		}
 	}
 };


### PR DESCRIPTION
## Summary
Fixes #4192 — subtitles set to "enabled" only took effect after Ctrl-R, not on 
normal page/video load.

## Changes
`ImprovedTube.playerSubtitles` previously bailed out silently if `player.isSubtitlesOn`
/ `toggleSubtitles` / `toggleSubtitlesOn` weren't yet attached to the player element 
(these attach asynchronously, slightly after `#movie_player` itself appears in the DOM). 
Since nothing retried the call, subtitles never got enabled unless the timing happened 
to line up — which a hard reload made more likely. Added a small bounded retry 
(up to 10 attempts, 200ms apart via setTimeout) so it applies the setting once the API 
is actually ready, without touching any other subtitle-related function.

## Testing
- Enabled subtitles in settings, loaded a fresh YouTube video without reloading the tab 
  — subtitles now turn on automatically.
- Verified navigating between videos (SPA nav) still respects the setting.
- Verified 'disabled' behavior is unaffected.
- Verified no infinite retry loop if the player element never gains the API methods 
  (caps out at 10 attempts / 2s).