### PR TITLE
fix: verify native click before marking Watch Later button as added

### DIFF
--- a/js&css/extension/www.youtube.com/general/general.js
+++ b/js&css/extension/www.youtube.com/general/general.js
@@ -367,7 +367,20 @@ extension.features.watchLaterButtons = function (event) {
 			return button;
 		}
 
-		return thumbnail.querySelector('ytd-thumbnail-overlay-toggle-button-renderer button');
+		var fallbackButton = thumbnail.querySelector('ytd-thumbnail-overlay-toggle-button-renderer button');
+
+		if (fallbackButton) {
+			var label = (fallbackButton.getAttribute('aria-label') || '').toLowerCase(),
+				title = (fallbackButton.getAttribute('title') || '').toLowerCase();
+
+			if (
+				label.indexOf('watch later') !== -1 ||
+				title.indexOf('watch later') !== -1 ||
+				(label.indexOf('queue') === -1 && title.indexOf('queue') === -1)
+			) {
+				return fallbackButton;
+			}
+		}
 	}
 
 	function getYtConfigValue(key) {
@@ -415,6 +428,7 @@ extension.features.watchLaterButtons = function (event) {
 		}
 
 		if (!apiKey || !context) {
+			console.warn('[ImprovedTube] Unable to resolve Innertube API key/context for Watch Later button');
 			button.dataset.state = 'unavailable';
 			return;
 		}
@@ -436,6 +450,9 @@ extension.features.watchLaterButtons = function (event) {
 				}]
 			})
 		}).then(function (response) {
+			if (!response.ok) {
+				console.warn('[ImprovedTube] Innertube Watch Later request failed with status:', response.status);
+			}
 			button.dataset.state = response.ok ? 'added' : 'unavailable';
 		}).catch(function () {
 			button.dataset.state = 'unavailable';
@@ -476,8 +493,26 @@ extension.features.watchLaterButtons = function (event) {
 				clickEvent.stopImmediatePropagation();
 
 				if (nativeButton && nativeButton !== this) {
+					var initialAriaPressed = nativeButton.getAttribute('aria-pressed'),
+						initialAriaLabel = nativeButton.getAttribute('aria-label'),
+						buttonRef = this,
+						attempts = 0;
+
 					nativeButton.click();
-					this.dataset.state = 'added';
+
+					(function checkToggle() {
+						var currentAriaPressed = nativeButton.getAttribute('aria-pressed'),
+							currentAriaLabel = nativeButton.getAttribute('aria-label');
+
+						if (currentAriaPressed !== initialAriaPressed || currentAriaLabel !== initialAriaLabel) {
+							buttonRef.dataset.state = 'added';
+						} else if (attempts < 10) {
+							attempts++;
+							setTimeout(checkToggle, 100);
+						} else {
+							addWithInnertube(id, buttonRef);
+						}
+					})();
 				} else {
 					addWithInnertube(id, this);
 				}


### PR DESCRIPTION
## Summary
Fixes #4201 — the thumbnail "Watch Later" button reported success but
didn't actually add the video for some users.

## Changes
- `findNativeWatchLaterButton`: the fallback that queries
  `ytd-thumbnail-overlay-toggle-button-renderer button` now checks the
  matched button's `aria-label`/`title` before returning it, instead
  of blindly returning whatever it finds. It accepts the match if the
  label mentions "watch later," or if it doesn't mention "queue"
  either.
- Click handler: no longer marks the button `added` immediately after
  calling `nativeButton.click()`. It now polls the native button's
  `aria-pressed`/`aria-label` for up to ~1s (10 attempts, 100ms apart)
  to confirm the click actually toggled it. If it didn't toggle in
  that window, falls back to `addWithInnertube` instead of reporting
  a false success.
- `addWithInnertube`: added `console.warn` when the Innertube API
  key/context can't be resolved from the page, and when the
  add-to-playlist request returns a non-OK response (with status
  code), so failures are diagnosable from the browser console — this
  is exactly the info the issue template asks reporters for.

## Testing
- `tests/unit/watch-later-buttons.test.js` — unchanged, still passes
  (asserts presence of `findNativeWatchLaterButton`, `nativeButton.click()`,
  `ACTION_ADD_VIDEO`, `playlistId: 'WL'`, all still present)
- Manually verified on youtube.com: clicking Watch Later on a
  thumbnail now only shows "added" once the native control's
  aria-pressed/aria-label actually changes; if it doesn't, it falls
  back to the Innertube request. Console shows a warning when that
  fallback can't resolve the API key/context or the request fails.

## Note
The fallback's "queue" exclusion is a heuristic, not a strict allowlist —
it accepts any label that doesn't mention "queue," not just ones that
explicitly say "watch later." That's an improvement over the previous
unconditional fallback but isn't airtight; flagging here in case a
reviewer wants it tightened further before merge.