### PR TITLE
fix(player): retry auto-fullscreen on play for Firefox

### DIFF
--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -447,6 +447,11 @@ ImprovedTube.playerOnPlay = function () {
 				
 				ImprovedTube.playerLoudnessNormalization();
 				ImprovedTube.playerCinemaModeEnable();
+				// Retry Auto-fullscreen on play: navigate-time toggleFullscreen() is often
+				// blocked by Firefox (no user gesture). Click-to-play keeps activation.
+				if (ImprovedTube.storage.player_autofullscreen === true) {
+					ImprovedTube.playerAutofullscreen();
+				}
 			}
 			return original.apply(this, arguments);
 		}

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -431,13 +431,56 @@ ImprovedTube.playerAds = function (parent) {
 AUTO FULLSCREEN
 ------------------------------------------------------------------------------*/
 ImprovedTube.playerAutofullscreen = function () {
-	if (
-		this.storage.player_autofullscreen === true &&
-		document.documentElement.dataset.pageType === 'video' &&
-		!document.fullscreenElement
-	) {
-		this.elements.player.toggleFullscreen();
+	if (this.storage.player_autofullscreen !== true) {
+		return;
 	}
+	if (document.documentElement.dataset.pageType !== 'video') {
+		return;
+	}
+
+	var player = this.elements.player;
+	if (!player || typeof player.toggleFullscreen !== 'function') {
+		return;
+	}
+
+	// Once per video URL after a successful enter (avoids re-toggling on pause/play).
+	if (this._autofullscreenFor === location.href) {
+		return;
+	}
+
+	var alreadyFullscreen = !!(
+		document.fullscreenElement ||
+		document.webkitFullscreenElement ||
+		document.mozFullScreenElement ||
+		player.classList.contains('ytp-fullscreen') ||
+		(typeof player.isFullscreen === 'function' && player.isFullscreen())
+	);
+
+	if (alreadyFullscreen) {
+		this._autofullscreenFor = location.href;
+		return;
+	}
+
+	try {
+		player.toggleFullscreen();
+	} catch (error) {
+		return;
+	}
+
+	// Firefox often rejects fullscreen without a user gesture (navigate-time call).
+	// Only lock this video if fullscreen actually engaged; otherwise allow retry on play.
+	setTimeout(function () {
+		var playerNow = ImprovedTube.elements.player;
+		var ok = !!(
+			document.fullscreenElement ||
+			document.webkitFullscreenElement ||
+			document.mozFullScreenElement ||
+			(playerNow && playerNow.classList.contains('ytp-fullscreen'))
+		);
+		if (ok) {
+			ImprovedTube._autofullscreenFor = location.href;
+		}
+	}, 250);
 };
 /*------------------------------------------------------------------------------
 QUALITY

--- a/tests/unit/player-autofullscreen.test.js
+++ b/tests/unit/player-autofullscreen.test.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('Auto-fullscreen', () => {
+	let playerContent;
+	let functionsContent;
+
+	beforeAll(() => {
+		playerContent = fs.readFileSync(
+			path.join(__dirname, '../../js&css/web-accessible/www.youtube.com/player.js'),
+			'utf8'
+		);
+		functionsContent = fs.readFileSync(
+			path.join(__dirname, '../../js&css/web-accessible/functions.js'),
+			'utf8'
+		);
+	});
+
+	test('playerAutofullscreen should guard missing player', () => {
+		expect(playerContent).toContain("typeof player.toggleFullscreen !== 'function'");
+	});
+
+	test('playerAutofullscreen should check vendor fullscreen flags', () => {
+		expect(playerContent).toContain('document.mozFullScreenElement');
+		expect(playerContent).toContain('ytp-fullscreen');
+	});
+
+	test('playerAutofullscreen should only lock after successful enter', () => {
+		expect(playerContent).toContain('_autofullscreenFor');
+		expect(playerContent).toContain('ImprovedTube._autofullscreenFor = location.href');
+	});
+
+	test('play path should retry autofullscreen for Firefox gesture policy', () => {
+		expect(functionsContent).toContain('player_autofullscreen');
+		expect(functionsContent).toContain('ImprovedTube.playerAutofullscreen()');
+	});
+});


### PR DESCRIPTION
issue number - #4188 
bug - YouTube doesn't go to full screen automatically

what i did?
Fixed Auto-fullscreen on Firefox. It only ran on page load, so fullscreen was blocked without a user gesture. Now it retries when the video plays (click-to-play), checks if fullscreen already works, and only applies once per video so pause/play doesn’t toggle it again.


Test plan

Enable Player → Auto-fullscreen
Open a watch page in Firefox (logged out OK)
Click play → player enters fullscreen
Pause/play again → stays fullscreen (no re-toggle)
Confirm Chrome still works the same


Thank you