### PR TITLE
Fix: Ask (Gemini) panel placement with Comments in Sidebar enabled

### DIFF
--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -275,6 +275,7 @@ ImprovedTube.commentsSidebar = function () { if (ImprovedTube.storage.comments_s
 			state.hasApplied = 2
 		}
 		else { /// <1000
+			restoreAskPanel();
 			if (state.hasApplied == 1) {
 				moveNode(document.getElementById("primary-inner"), document.getElementById("related"));
 				let comments = document.querySelector("#comments");
@@ -317,6 +318,7 @@ ImprovedTube.commentsSidebar = function () { if (ImprovedTube.storage.comments_s
 			moveNode(primaryInner, document.getElementById("related"))
 			moveNode(secondaryInner, document.getElementById("chat-template"));
 			moveNode(secondaryInner, comments);
+			placeAskPanel(secondaryInner, comments);
 		})
 	}
 	function moveNode (parent, child) {
@@ -324,13 +326,35 @@ ImprovedTube.commentsSidebar = function () { if (ImprovedTube.storage.comments_s
 			parent.appendChild(child);
 		}
 	}
+	function placeAskPanel(secondaryInner, comments) {
+		const askPanel = document.querySelector('ytd-engagement-panel-section-list-renderer[target-id="PAyouchat"]');
+		if (!askPanel || !secondaryInner) return;
+		if (comments && comments.parentElement === secondaryInner) {
+			secondaryInner.insertBefore(askPanel, comments);
+		} else if (askPanel.parentElement !== secondaryInner) {
+			secondaryInner.appendChild(askPanel);
+		}
+	}
+	function restoreAskPanel() {
+		const askPanel = document.querySelector('ytd-engagement-panel-section-list-renderer[target-id="PAyouchat"]');
+		const panels = document.getElementById("panels");
+		if (askPanel && panels && askPanel.parentElement !== panels) {
+			panels.appendChild(askPanel);
+		}
+	}
 	function isLayoutApplied (wideLayout) {
 		const secondaryInner = document.getElementById("secondary-inner");
 		const comments = document.querySelector("#comments");
 		const related = document.getElementById("related");
 		const relatedParent = wideLayout ? document.getElementById("columns") : document.getElementById("primary-inner");
+		const askPanel = document.querySelector('ytd-engagement-panel-section-list-renderer[target-id="PAyouchat"]');
 
-		return comments && comments.parentElement === secondaryInner && related && related.parentElement === relatedParent;
+		const askPanelOk = !askPanel || (
+			askPanel.parentElement === secondaryInner &&
+			(!comments || comments.parentElement !== secondaryInner ||
+				!!(askPanel.compareDocumentPosition(comments) & Node.DOCUMENT_POSITION_FOLLOWING))
+		);
+		return comments && comments.parentElement === secondaryInner && related && related.parentElement === relatedParent && askPanelOk;
 	}
 	function scheduleSidebar () {
 		clearTimeout(state.sidebarRetryTimer);


### PR DESCRIPTION
Closes #4206

| Before | After |
| :---: | :---: |
| <img width="1919" height="964" alt="screenshot-1784388001754" src="https://github.com/user-attachments/assets/5e6a1a39-cce8-4470-8608-af230954215a" /> | <img width="1919" height="966" alt="screenshot-1784388175289" src="https://github.com/user-attachments/assets/ecdd316c-27fe-4e8c-b0e6-c16ae0564613" /><br><br><img width="1919" height="968" alt="screenshot-1784388199585" src="https://github.com/user-attachments/assets/c05681cb-3c2a-467e-8b63-0c5e6bd9f671" /> |

## Problem
When the "Comments in Sidebar" setting is enabled, the Ask (Gemini AI) panel gets displaced below the video description instead of staying in the sidebar above the comments section.

## Root cause
The Ask panel renders inside YouTube's native `#panels` container (`ytd-engagement-panel-section-list-renderer[target-id="PAyouchat"]`). The `commentsSidebar()` feature's `initialSetup()` function moves `#panels` wholesale into `primaryInner` (the main content column) to handle live-chat panels — but this also carries the Ask panel along with it, stranding it in the main column instead of the sidebar.

## Fix
- Added a `placeAskPanel()` helper that pins the Ask panel directly above `#comments` inside `secondary-inner`, using `insertBefore` so the ordering is correct regardless of when the panel is rendered relative to other layout moves (this was inconsistent before — sometimes it landed above comments, sometimes below, depending on timing).
- Updated `isLayoutApplied()` to also verify the Ask panel's position and ordering, so the existing `MutationObserver` (`observeLayoutChanges`) automatically re-corrects it if it drifts — e.g. if the panel is opened after the initial layout has already settled.
- Added a `restoreAskPanel()` call in the narrow (<1000px) layout branch, since YouTube hides `#secondary` entirely at that width. Without this, the Ask panel would get stuck inside a hidden ancestor and appear to not open at all. It's now moved back into its native `#panels` container so it opens inline below the video as YouTube intends.

## Testing
- Verified on multiple videos at all three breakpoints (<1000px, 1000–1952px, >1952px)
- Verified opening the Ask panel both before and after the sidebar layout settles
- Verified toggling fullscreen/theater mode doesn't break placement
- Verified narrow → wide → narrow cycling doesn't orphan or duplicate the panel
- Verified the panel opens correctly natively when width is <1000px