### PR TITLE
feat: add option to blur thumbnails

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1428,6 +1428,9 @@
   "squaredThumbnails": {
     "message": "Squared thumbnails"
   },
+  "blurThumbnails": {
+    "message": "Blur thumbnails"
+  },
   "static": {
     "message": "Static"
   },

--- a/js&css/extension/www.youtube.com/general/general.css
+++ b/js&css/extension/www.youtube.com/general/general.css
@@ -91,6 +91,8 @@ html[it-blur-thumbnails='true'] .yt-thumbnail-view-model img,
 html[it-blur-thumbnails='true'] .yt-lockup-view-model-wiz__content-image img,
 html[it-blur-thumbnails='true'] .yt-video-card-view-model__thumbnail,
 html[it-blur-thumbnails='true'] .yt-video-card-view-model__thumbnail img,
+html[it-blur-thumbnails='true'] .ytThumbnailViewModelImage,
+html[it-blur-thumbnails='true'] .ytwTopLandscapeImageLayoutViewModelHostImageHoverOverlayContainer,
 html[it-blur-thumbnails='true'] #img.ytp-cued-thumbnail-overlay-image {
 	filter: blur(10px) !important;
 	transition: filter .2s;
@@ -100,7 +102,8 @@ html[it-blur-thumbnails='true'] ytd-thumbnail:hover img,
 html[it-blur-thumbnails='true'] ytd-playlist-thumbnail:hover img,
 html[it-blur-thumbnails='true'] .yt-thumbnail-view-model:hover img,
 html[it-blur-thumbnails='true'] .yt-lockup-view-model-wiz__content-image:hover img,
-html[it-blur-thumbnails='true'] .yt-video-card-view-model__thumbnail:hover img {
+html[it-blur-thumbnails='true'] .yt-video-card-view-model__thumbnail:hover img,
+html[it-blur-thumbnails='true'] .ytThumbnailViewModelImage:hover {
 	filter: blur(0) !important;
 }
 /*--------------------------------------------------------------

--- a/js&css/extension/www.youtube.com/general/general.css
+++ b/js&css/extension/www.youtube.com/general/general.css
@@ -15,6 +15,7 @@
 # Hide thumbnail icon
 # Hide dots on thumbnails
 # Squared thumbnails
+# Blur thumbnails
 --------------------------------------------------------------*/
 html[it-cursorLighting=true] #below			{opacity:.4; transition:3s;}
 html[it-cursorLighting=true] #below:hover	{opacity:1; transition:.5s;}
@@ -79,6 +80,28 @@ html[it-squared-thumbnails='true'] .yt-lockup-view-model-wiz__content-image .yt-
 	--yt-img-border-radius: 0 !important;
 	--yt-thumbnail-border-radius: 0 !important;
 	border-radius: 0 !important;
+}
+/*--------------------------------------------------------------
+# BLUR THUMBNAILS
+--------------------------------------------------------------*/
+html[it-blur-thumbnails='true'] ytd-thumbnail img,
+html[it-blur-thumbnails='true'] ytd-playlist-thumbnail #thumbnail,
+html[it-blur-thumbnails='true'] ytd-playlist-thumbnail img,
+html[it-blur-thumbnails='true'] .yt-thumbnail-view-model img,
+html[it-blur-thumbnails='true'] .yt-lockup-view-model-wiz__content-image img,
+html[it-blur-thumbnails='true'] .yt-video-card-view-model__thumbnail,
+html[it-blur-thumbnails='true'] .yt-video-card-view-model__thumbnail img,
+html[it-blur-thumbnails='true'] #img.ytp-cued-thumbnail-overlay-image {
+	filter: blur(10px) !important;
+	transition: filter .2s;
+}
+
+html[it-blur-thumbnails='true'] ytd-thumbnail:hover img,
+html[it-blur-thumbnails='true'] ytd-playlist-thumbnail:hover img,
+html[it-blur-thumbnails='true'] .yt-thumbnail-view-model:hover img,
+html[it-blur-thumbnails='true'] .yt-lockup-view-model-wiz__content-image:hover img,
+html[it-blur-thumbnails='true'] .yt-video-card-view-model__thumbnail:hover img {
+	filter: blur(0) !important;
 }
 /*--------------------------------------------------------------
 HIDING STUFF   (display:none !important) (Usually the !important isn't necessary)

--- a/menu/skeleton-parts/general.js
+++ b/menu/skeleton-parts/general.js
@@ -295,6 +295,11 @@ extension.skeleton.main.layers.section.general = {
 					text: 'squaredThumbnails',
 					tags: 'thumbnail square radius rounded corners'
 				},
+				blur_thumbnails: {
+					component: 'switch',
+					text: 'blurThumbnails',
+					tags: 'thumbnail blur privacy hide spoiler'
+				},
 				thumbnails_quality: {
 					component: 'select',
 					text: 'thumbnailsQuality',


### PR DESCRIPTION
## Category
Feature Request

## Problem
Users lack an option to blur YouTube thumbnails to protect privacy, avoid spoilers, or reduce visual distractions. Additionally, previous blur attempts caused a jarring "flash" of the unblurred image when hovering before the video preview loaded.

## Solution
Added a "Blur thumbnails" toggle that blurs static thumbnails but allows preview videos to play normally on hover.

| Before | After |
| :---: | :---: |
| <img width="1919" height="969" alt="screenshot-1784397030441" src="https://github.com/user-attachments/assets/6443ed86-296b-4a7b-a874-86b23cff498b" /> | <img width="1920" height="968" alt="Screenshot 2026-07-18 232146" src="https://github.com/user-attachments/assets/2aa13b0f-f1d0-4d75-9127-bfac74b8e473" /><br><br><img width="1920" height="968" alt="Screenshot 2026-07-18 232256" src="https://github.com/user-attachments/assets/8bd70469-90d1-42c4-8aa6-d952197e69e0" /><br><br><img width="1920" height="968" alt="Untitled design" src="https://github.com/user-attachments/assets/d32984e8-3d95-4928-beca-d192b1d94b81" />|

- Sets `it-blur-thumbnails="true"` on `<html>` when enabled.
- Uses pure CSS `filter: blur(10px)` in `general.css` for thumbnails across home, search, sidebar, and playlists.
- Included updated selectors (`.ytThumbnailViewModelImage`, `.ytwTopLandscapeImageLayoutViewModelHostImageHoverOverlayContainer`) to support modern YouTube DOM layouts and image ads.
- Removed `:hover` CSS unblur rules on the static image to prevent the unblur "flash", allowing the native video preview to overlay smoothly.
- Registered the `blurThumbnails` string in `_locales/en/messages.json`.

## Alternatives
Considered using a JS-created overlay element (like the night-mode `dim` feature). A pure CSS `filter` is simpler, more performant, and perfectly matches the existing `squared_thumbnails` implementation.

## Testing
- Manually tested in Chrome: toggling the switch successfully blurs/un-blurs thumbnails and image ads on the home, search, and sidebar pages.
- Verified that hovering plays the preview video normally without the static image flashing underneath.
- Ran `npm test` — all 88 tests pass successfully.

Closes #4182 