### PR TITLE
Fix enabled switch row spacing

### DIFF
--- a/menu/satus.css
+++ b/menu/satus.css
@@ -2,7 +2,7 @@
 .satus-section--card:hover, .satus-select:hover, .satus-switch:hover,  .satus-switch__content:hover  {transition: background-color 0.08s ease-out !important;}
 
 *[data-value][data-value="false"] {margin-bottom: 0; margin-top: 0; transition: margin 0.14s linear !important;}  
-*[data-value][data-value="true"] {margin-bottom: -4.5px !important; margin-top: -3.5px; transition: margin 0.2s linear !important;}
+*:not(.satus-switch)[data-value][data-value="true"] {margin-bottom: -4.5px !important; margin-top: -3.5px; transition: margin 0.2s linear !important;}
 
 .satus-button--general, .satus-button--appearance, .satus-button--player {
 	margin-left: 9px !important;

--- a/tests/unit/switch-spacing.test.js
+++ b/tests/unit/switch-spacing.test.js
@@ -1,0 +1,12 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('Switch row spacing', () => {
+	test('does not compact enabled switch rows', () => {
+		const css = fs.readFileSync(path.join(__dirname, '../../menu/satus.css'), 'utf8');
+		const compactEnabledRule = css.match(/([^{}]+)\{[^{}]*margin-bottom:\s*-4\.5px[^{}]*margin-top:\s*-3\.5px[^{}]*\}/);
+
+		expect(compactEnabledRule).not.toBeNull();
+		expect(compactEnabledRule[1]).toContain(':not(.satus-switch)');
+	});
+});


### PR DESCRIPTION
## Summary

Keep enabled switch rows at the same height as disabled rows. The negative-margin rule now excludes `.satus-switch` itself while preserving the existing compact behavior for other enabled data-value controls.

Closes #4216.

## Testing

- `npm test -- --runInBand tests/unit/switch-spacing.test.js`
- 21 suites, 89 tests passed
- `git diff --check`

The repository currently has no ESLint configuration discoverable by ESLint 8, so a scoped ESLint invocation exits before linting; no lint result is claimed.

## AI Assistance Disclosure

OpenAI Codex assisted with issue investigation, the CSS change, regression test, and validation. I reviewed the final diff and test results.