### PR TITLE
Fix player controls options menu redirect

### DIFF
--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -1814,7 +1814,7 @@ extension.skeleton.main.layers.section.player.on.click = {
 			component: "button",
 			text: "hidePlayerControlsBarButtons",
 			on: {
-				click: 'main.layers.section.appearance.on.click.player.on.click.player_hide_controls_options.on.click'
+				click: 'main.layers.section.appearance.on.click.player.on.click.section_1.player_hide_controls_options.on.click'
 			}
 		}
 	}

--- a/tests/unit/player-controls-menu.test.js
+++ b/tests/unit/player-controls-menu.test.js
@@ -1,0 +1,35 @@
+global.extension = {
+	skeleton: {
+		main: {
+			layers: {
+				section: {}
+			}
+		}
+	}
+};
+
+global.satus = {
+	storage: {
+		onchanged: jest.fn()
+	}
+};
+
+require('../../menu/skeleton-parts/appearance.js');
+require('../../menu/skeleton-parts/player.js');
+
+describe('Player controls menu redirect (#4215)', () => {
+	test('opens the shared hide-controls options section', () => {
+		const playerSection = extension.skeleton.main.layers.section.player.on.click;
+		const redirect = playerSection.section_2.player_hide_controls_options.on.click;
+		const target = redirect
+			.split('.')
+			.reduce((skeleton, key) => skeleton[key], extension.skeleton);
+
+		expect(target).toBe(
+			extension.skeleton.main.layers.section.appearance.on.click.player.on.click
+				.section_1.player_hide_controls_options.on.click
+		);
+		expect(target.component).toBe('section');
+		expect(target.player_play_button.component).toBe('switch');
+	});
+});


### PR DESCRIPTION
## Summary

- correct the Player menu redirect to include the missing `section_1` skeleton layer
- add a regression test that resolves the real redirect and verifies it opens the shared hide-controls options section

Fixes #4215

## Testing

- rebased onto current `master` (`55e3f681`); the stable patch ID is unchanged and the branch is 0 behind / 1 ahead
- `npx jest tests/unit/player-controls-menu.test.js --runInBand` (1 passed)
- `npx --yes -p node@20 -c 'node --version && npm test -- --runInBand'` (Node 20.20.2; 24 suites, 110 tests passed)
- `ESLINT_USE_FLAT_CONFIG=true npx eslint --config tests/eslint_rules.config.mjs tests/unit/player-controls-menu.test.js`
- `python3 build.py -chromium-stable` from `build/`; archive integrity verified with `unzip -t`
- `python3 build/build.py -firefox`; archive integrity verified with `unzip -t`
- `git diff --check upstream/master...HEAD`

The repository-wide ESLint baseline is unchanged between `master` and this branch at 2,774 errors and 535 warnings. The existing `menu/skeleton-parts/player.js` baseline is likewise unchanged at 17 errors and 60 warnings.

## AI disclosure

This pull request was implemented and validated with assistance from OpenAI Codex. The issue selection, repository policies, competing work, code path, regression coverage, and generated diff were independently checked before submission.
