### PR TITLE
Hide Safari AirPlay button with Play on TV setting

### DIFF
--- a/js&css/extension/www.youtube.com/appearance/player/player.css
+++ b/js&css/extension/www.youtube.com/appearance/player/player.css
@@ -241,6 +241,7 @@ html[it-player-miniplayer-button=true] .ytp-miniplayer-button,
 html[it-player-view-button=true] .ytp-size-button,
 html[it-player-screen-button=true] .ytp-fullscreen-button,
 html[it-player-remote-button=true] .ytp-remote-button,
+html[it-player-remote-button=true] .ytp-airplay-button,
 html[it-player-chaptertitle-button=true] .ytp-chapter-container {
 	display: none !important;
 }

--- a/tests/unit/player-remote-button.test.js
+++ b/tests/unit/player-remote-button.test.js
@@ -1,0 +1,21 @@
+// Regression test for Issue #3364: Play on TV should also hide Safari's AirPlay button
+
+const fs = require('fs');
+const path = require('path');
+
+describe('Player Remote Button (#3364)', () => {
+	let playerCssContent;
+
+	beforeAll(() => {
+		const filePath = path.join(__dirname, '../../js&css/extension/www.youtube.com/appearance/player/player.css');
+		playerCssContent = fs.readFileSync(filePath, 'utf8');
+	});
+
+	test('should hide remote and AirPlay buttons with the Play on TV setting', () => {
+		const controlsRule = playerCssContent.match(/html\[it-player-play-button=true\][\s\S]*?\{\s*display: none !important;\s*\}/);
+
+		expect(controlsRule).not.toBeNull();
+		expect(controlsRule[0]).toContain('html[it-player-remote-button=true] .ytp-remote-button');
+		expect(controlsRule[0]).toContain('html[it-player-remote-button=true] .ytp-airplay-button');
+	});
+});


### PR DESCRIPTION
## Summary
- hide Safari's `.ytp-airplay-button` when the Play on TV button setting is enabled
- add a focused regression test covering both remote-play selectors

## Testing
- Source-level selector assertion passed.
- `npm test -- --runInBand tests/unit/player-remote-button.test.js` could not run in this sandbox: `zsh:1: operation not permitted: npm`.

---
AI assistance was used. This change was reviewed by Northset, and I accept responsibility for this submission.

<!-- northset-receipt:M-1001:start -->
### Verification

[Northset proof-of-pass receipt M-1001](https://northset-oss.github.io/verification-pilot/receipts/M-1001/)  
Contributor self-run; not maintainer verification.
<!-- northset-receipt:M-1001:end -->
