### PR TITLE
fix: hide members-first videos

### DIFF
--- a/js&css/extension/www.youtube.com/general/general.css
+++ b/js&css/extension/www.youtube.com/general/general.css
@@ -155,6 +155,9 @@ html[it-remove-member-only='true'] ytd-rich-item-renderer:has(.badge-style-type-
 html[it-remove-member-only='true'] ytd-rich-item-renderer:has(badge-shape.yt-badge-shape--membership),
 html[it-remove-member-only='true'] yt-lockup-view-model:has(badge-shape.yt-badge-shape--membership),
 html[it-remove-member-only='true'] yt-lockup-view-model:has(.yt-badge-shape--commerce),
+html[it-remove-member-only='true'] ytd-grid-video-renderer:has(badge-shape.ytBadgeShapeCommerce),
+html[it-remove-member-only='true'] ytd-rich-item-renderer:has(badge-shape.ytBadgeShapeCommerce),
+html[it-remove-member-only='true'] yt-lockup-view-model:has(badge-shape.ytBadgeShapeCommerce),
 /*--------------------------------------------------------------
 # REMOVE CONTEXT BUTTONS ON SHORTS
 --------------------------------------------------------------*/

--- a/js&css/extension/www.youtube.com/general/general.js
+++ b/js&css/extension/www.youtube.com/general/general.js
@@ -1138,7 +1138,10 @@ extension.features.removeMemberOnly = function () {
 			}
 			ytd-grid-video-renderer:has(badge-shape.yt-badge-shape--membership),
 			ytd-rich-item-renderer:has(badge-shape.yt-badge-shape--membership),
-			yt-lockup-view-model:has(badge-shape.yt-badge-shape--membership) {
+			yt-lockup-view-model:has(badge-shape.yt-badge-shape--membership),
+			ytd-grid-video-renderer:has(badge-shape.ytBadgeShapeCommerce),
+			ytd-rich-item-renderer:has(badge-shape.ytBadgeShapeCommerce),
+			yt-lockup-view-model:has(badge-shape.ytBadgeShapeCommerce) {
 				display: none !important;
 			}
 		`;

--- a/tests/unit/member-only-hiding.test.js
+++ b/tests/unit/member-only-hiding.test.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 
-describe('Member-only video hiding (#3862)', () => {
+describe('Membership video hiding (#3862, #4223)', () => {
 	let generalCssContent;
 	let generalJsContent;
 
@@ -32,5 +32,20 @@ describe('Member-only video hiding (#3862)', () => {
 		expect(generalJsContent).toContain(
 			'yt-lockup-view-model:has(badge-shape.yt-badge-shape--membership)'
 		);
+	});
+
+	test('static and runtime CSS target the current members-first commerce badge', () => {
+		const selectors = [
+			'ytd-grid-video-renderer:has(badge-shape.ytBadgeShapeCommerce)',
+			'ytd-rich-item-renderer:has(badge-shape.ytBadgeShapeCommerce)',
+			'yt-lockup-view-model:has(badge-shape.ytBadgeShapeCommerce)'
+		];
+
+		for (const selector of selectors) {
+			expect(generalCssContent).toContain(
+				`html[it-remove-member-only='true'] ${selector}`
+			);
+			expect(generalJsContent).toContain(selector);
+		}
 	});
 });


### PR DESCRIPTION
## Summary

- recognize YouTube's current `ytBadgeShapeCommerce` badge for members-first videos
- hide matching grid, rich-feed, and lockup cards in both static and runtime CSS
- add regression coverage for all supported card types

Fixes #4223

## Testing

- `npm test` — 20 suites passed, 89 tests passed
- ESLint 9 check for `tests/unit/member-only-hiding.test.js`
- `git diff --check`
- manually verified that three members-first cards are hidden on YouTube
