### PR TITLE
fix: playlist quick delete failing silently after YouTube API change

### DIFF
--- a/js&css/web-accessible/www.youtube.com/playlist-complete-playlist.js
+++ b/js&css/web-accessible/www.youtube.com/playlist-complete-playlist.js
@@ -177,10 +177,18 @@ async function removeVideosPersistentlyModify(playlistId, videoIds) {
             body: JSON.stringify({ context, actions })
         });
         if (!res.ok) {
-            const txt = await res.text();
+            const txt = await res.text().catch(() => '');
             console.warn('[ImprovedTube] Playlist modify failed', res.status, txt);
+            return false;
         }
-        return res.ok;
+        // A bare HTTP 200 does not mean the video was removed: when the request
+        // format drifts, YouTube answers 200 without applying the edit. Require a
+        // positive confirmation so the caller can fall back to the native menu.
+        const response = await res.json().catch(() => null);
+        return !!response && !response.error && (
+            response.status === 'STATUS_SUCCEEDED' ||
+            !!response.frameworkUpdates
+        );
     } catch (e) {
         console.warn('[ImprovedTube] Innertube removal failed', e);
         return false;
@@ -201,7 +209,7 @@ async function removeVideosPersistentlyEdit(playlistId, setVideoIds) {
         const hl = cfg.HL || document.documentElement.lang || 'en';
         const gl = cfg.GL || 'US';
         const visitorData = cfg.VISITOR_DATA || '';
-        const context = cfg.INNERTUBE_CONTEXT || {
+        const baseContext = cfg.INNERTUBE_CONTEXT || {
             client: {
                 clientName: 'WEB',
                 clientVersion,
@@ -214,8 +222,12 @@ async function removeVideosPersistentlyEdit(playlistId, setVideoIds) {
             },
             request: { internalExperimentFlags: [], sessionIndex: cfg.SESSION_INDEX ?? 0 }
         };
+        // Clone so we never mutate YouTube's live ytcfg context, and mirror the
+        // current native delete request, which carries adSignalsInfo in the context.
+        const context = { ...baseContext, adSignalsInfo: baseContext.adSignalsInfo || { params: [] } };
         const actions = setVideoIds.map(id => ({ action: 'ACTION_REMOVE_VIDEO', setVideoId: id }));
-        const body = { context, actions, playlistId, params: 'CAFAAQ==' };
+        // YouTube now sends params URL-escaped (the '==' padding becomes '%3D%3D').
+        const body = { context, actions, playlistId, params: 'CAFAAQ%3D%3D' };
         const url = `${location.origin}/youtubei/v1/browse/edit_playlist?prettyPrint=false`;
 
         // Build SAPISIDHASH Authorization header
@@ -251,11 +263,23 @@ async function removeVideosPersistentlyEdit(playlistId, setVideoIds) {
             body: JSON.stringify(body)
         });
         if (!res.ok) {
-            const txt = await res.text();
+            const txt = await res.text().catch(() => '');
             console.warn('[ImprovedTube] edit_playlist failed', res.status, txt);
+            return false;
         }
 
-        const response = await res.json();
+        const response = await res.json().catch(() => null);
+
+        // Only report success when YouTube confirms the edit. A bare HTTP 200 is
+        // not enough: when the request format drifts, YouTube answers 200 without
+        // removing anything, which previously made the row vanish and then reappear
+        // on refresh. Returning false lets the caller fall back to the native menu.
+        const succeeded = !!response && !response.error && (
+            response.status === 'STATUS_SUCCEEDED' ||
+            Array.isArray(response.playlistEditResults) ||
+            !!response.frameworkUpdates ||
+            !!response.newHeader
+        );
 
         if (response?.newHeader?.playlistHeaderRenderer) {
             document.querySelector("ytd-playlist-header-renderer")?.dispatchEvent(
@@ -277,7 +301,7 @@ async function removeVideosPersistentlyEdit(playlistId, setVideoIds) {
             );
         }
 
-        return res.ok;
+        return succeeded;
     } catch (e) {
         console.warn('[ImprovedTube] edit_playlist error', e);
         return false;

--- a/tests/unit/playlist-quick-delete.test.js
+++ b/tests/unit/playlist-quick-delete.test.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('Playlist quick delete button (issue #4227)', () => {
+	let playlistJs;
+
+	beforeAll(() => {
+		playlistJs = fs.readFileSync(
+			path.join(__dirname, '../../js&css/web-accessible/www.youtube.com/playlist-complete-playlist.js'),
+			'utf8'
+		);
+	});
+
+	test('registers the feature with init', () => {
+		const initJs = fs.readFileSync(path.join(__dirname, '../../js&css/web-accessible/init.js'), 'utf8');
+
+		expect(initJs).toContain('ImprovedTube.playlistCompleteInit();');
+		expect(playlistJs).toContain('ImprovedTube.playlistCompleteInit');
+		expect(playlistJs).toContain('ImprovedTube.playlistEnsureQuickButtons');
+	});
+
+	test('mirrors YouTube\'s current delete request (escaped params + adSignalsInfo)', () => {
+		// YouTube now URL-escapes the "==" padding in params and carries
+		// adSignalsInfo in the request context.
+		expect(playlistJs).toContain("params: 'CAFAAQ%3D%3D'");
+		expect(playlistJs).not.toContain("params: 'CAFAAQ=='");
+		expect(playlistJs).toContain('adSignalsInfo');
+	});
+
+	test('does not mutate YouTube\'s live ytcfg context', () => {
+		// The request context is cloned before adSignalsInfo is attached.
+		expect(playlistJs).toContain('const context = { ...baseContext');
+	});
+
+	test('reports success only when YouTube confirms the edit, not on a bare 200', () => {
+		// The old code returned res.ok, so a 200 with no removal looked like
+		// success and the row was removed locally only to reappear on refresh.
+		expect(playlistJs).toContain("response.status === 'STATUS_SUCCEEDED'");
+		expect(playlistJs).toContain('return succeeded;');
+		expect(playlistJs).not.toContain('return res.ok;');
+	});
+
+	test('falls back to the native three-dot menu when the API path fails', () => {
+		// The native "Remove from playlist" menu item still works, so it backs
+		// the direct-API path in the click handler.
+		expect(playlistJs).toContain('ok = await clickMenuRemove(renderer);');
+		expect(playlistJs).toContain('ACTION_REMOVE_VIDEO_FROM');
+		// The fallback runs only after the direct-API removal returns false.
+		expect(playlistJs.indexOf('removeVideosPersistentlyEdit(playlistId'))
+			.toBeLessThan(playlistJs.indexOf('ok = await clickMenuRemove(renderer);'));
+	});
+
+	test('only removes the row after a confirmed deletion', () => {
+		// renderer.remove() is guarded by the success flag from the removal chain.
+		expect(playlistJs).toMatch(/if \(ok\) \{\s*try \{ renderer\.remove\(\);/);
+	});
+});


### PR DESCRIPTION
The quick delete button removed the video from the DOM but never from the playlist, so it reappeared on refresh (issue #4227). Both innertube removal helpers returned `res.ok`, treating any HTTP 200 as success. After YouTube changed its delete request format, the call returns 200 without applying the edit, so this false positive removed the row locally and skipped the reliable native-menu fallback.

- Gate success on an actual confirmation (STATUS_SUCCEEDED / playlistEditResults / frameworkUpdates / newHeader) instead of a bare 200, so a failed edit now falls through to the native three-dot menu removal that still works.
- Mirror YouTube's current edit_playlist request: URL-escape the params padding (CAFAAQ== -> CAFAAQ%3D%3D) and carry adSignalsInfo in a cloned context, without mutating the live ytcfg object.
- Read the response body once (the !res.ok branch previously consumed it with res.text() before res.json()).
- Add unit coverage for the request shape, success gating, and menu fallback.