### PR TITLE
fix: apply thumbnail size setting to playlist video thumbnails in search results (Fixes #4248) [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/js&css/extension/www.youtube.com/styles.css
+++ b/js&css/extension/www.youtube.com/styles.css
@@ -2290,6 +2290,28 @@ html[it-thumbnail-size="xx-small"] ytd-video-renderer ytd-thumbnail {
     min-width: 120px !important;
 }
 
+/* Thumbnail sizes: Playlist Search Results */
+html[it-thumbnail-size="large"] ytd-playlist-video-renderer ytd-thumbnail {
+    max-width: 420px !important;
+    min-width: 360px !important;
+}
+html[it-thumbnail-size="medium"] ytd-playlist-video-renderer ytd-thumbnail {
+    max-width: 320px !important;
+    min-width: 280px !important;
+}
+html[it-thumbnail-size="small"] ytd-playlist-video-renderer ytd-thumbnail {
+    max-width: 260px !important;
+    min-width: 240px !important;
+}
+html[it-thumbnail-size="x-small"] ytd-playlist-video-renderer ytd-thumbnail {
+    max-width: 180px !important;
+    min-width: 160px !important;
+}
+html[it-thumbnail-size="xx-small"] ytd-playlist-video-renderer ytd-thumbnail {
+    max-width: 140px !important;
+    min-width: 120px !important;
+}
+
 /* Thumbnail sizes: Video Player Sidebar (Related Videos) */
 html[it-thumbnail-size="large"] ytd-compact-video-renderer ytd-thumbnail {
     width: 200px !important;


### PR DESCRIPTION
## What this PR fixes

When the user sets a custom thumbnail size (Large / Medium / Small / x-small / xx-small) in ImprovedTube settings, the CSS only applied to `ytd-video-renderer` (regular search results) and `ytd-compact-video-renderer` (sidebar). Playlist video results in search use `ytd-playlist-video-renderer`, which was not targeted, so playlist thumbnails always remained at the default YouTube size.

## Change

Added 5 new CSS rules in `js&css/extension/www.youtube.com/styles.css` to apply the same `max-width` / `min-width` values to `ytd-playlist-video-renderer ytd-thumbnail` for each thumbnail size setting.

## How to test

1. Install/load the extension from this branch
2. Go to YouTube search and search for something that returns both video and playlist results
3. Set Thumbnail Size to Small (or any non-default value)
4. Before: playlist video thumbnails stay at default size
5. After: playlist video thumbnails match the selected size

Fixes #4248