### PR TITLE
fix: prevent toggle switches from shrinking when set to 'on' (Fixes #4216)

### DIFF
--- a/menu/satus.css
+++ b/menu/satus.css
@@ -4,6 +4,12 @@
 *[data-value][data-value="false"] {margin-bottom: 0; margin-top: 0; transition: margin 0.14s linear !important;}  
 *[data-value][data-value="true"] {margin-bottom: -4.5px !important; margin-top: -3.5px; transition: margin 0.2s linear !important;}
 
+/* Prevent toggle switches from being shrunk by the universal data-value rule */
+.satus-switch[data-value] {
+    margin-bottom: 0 !important;
+    margin-top: 0 !important;
+}
+
 .satus-button--general, .satus-button--appearance, .satus-button--player {
 	margin-left: 9px !important;
 	margin-right: -18px !important;


### PR DESCRIPTION
## Bug Description

When any toggle in the settings menu is set to "on", the corresponding menu entry becomes narrower. This is a visual regression that affects all toggle switches in the extension's settings UI.

## Root Cause

The universal CSS selector `*[data-value][data-value="true"]` in `menu/satus.css` applies negative margins (`margin-bottom: -4.5px` and `margin-top: -3.5px`) to **all** elements with `data-value="true"`. Toggle switches ( elements) also use the `data-value` attribute to indicate their on/off state. When a toggle is turned on, the negative margins compress the switch vertically, which in turn makes the entire menu entry row appear narrower.

## Fix

Added a more specific CSS rule:
```css
.satus-switch[data-value] {
    margin-bottom: 0 !important;
    margin-top: 0 !important;
}
```

This overrides the universal selector's negative margins specifically for toggle switch elements, preventing them from being shrunk while preserving the original behavior for other elements that use `data-value`.

## Testing

- [x] Tested with toggle switches in settings (on/off states)
- [x] Verified no visual change for other `data-value` elements
- [x] Works in both light and dark themes