### PR TITLE
fix: include category chip bar in cursorLighting dimming rules (Fixes #4240)

### DIFF
--- a/js&css/extension/www.youtube.com/general/general.css
+++ b/js&css/extension/www.youtube.com/general/general.css
@@ -43,8 +43,12 @@ html[it-cursorLighting=true] ytd-guide-entry-renderer:hover,   /*ytd-watch-next-
 html[it-cursorLighting=true] #donation-shelf:hover,
 html[it-cursorLighting=true] ytd-ad-slot-renderer:hover,
 html[it-cursorLighting=true] #player-ads:hover			{opacity:1; transition:.3s}
+html[it-cursorLighting=true] ytd-feed-filter-chip-bar-renderer,
+html[it-cursorLighting=true] #chips-wrapper,
 html[it-cursorLighting=true] ytd-two-column-browse-results-renderer,
 html[it-cursorLighting=true] ytd-search			{opacity:.7; transition:5s;}
+html[it-cursorLighting=true] ytd-feed-filter-chip-bar-renderer:hover,
+html[it-cursorLighting=true] #chips-wrapper:hover,
 html[it-cursorLighting=true] ytd-two-column-browse-results-renderer:hover,
 html[it-cursorLighting=true] ytd-search:hover	{opacity:1; transition:3s}
 html[it-cursorLighting=true]:not([data-page-type=video]) #guide-content,


### PR DESCRIPTION
## Description
Fixes #4240

When the `cursorLighting` feature ("Dim YouTube's Pages, except what I mouse-over!") is enabled, the homepage category chip bar (`ytd-feed-filter-chip-bar-renderer`) was not included in the dimming CSS selectors.

This caused the chip bar to appear blank/invisible while the rest of the page dimmed, and hovering over it did not restore visibility.

## Changes
- Added `ytd-feed-filter-chip-bar-renderer` and `#chips-wrapper` to the `cursorLighting` dimmed element selectors (opacity: 0.7)
- Added corresponding hover selectors to restore full opacity (opacity: 1) on hover

## Testing
- Verified the CSS selectors match the YouTube homepage DOM structure
- The chip bar will now dim consistently with other page elements and undim on hover