### PR TITLE
Show watched sections of a video on the seek bar

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1395,6 +1395,9 @@
   "showRemainingDuration": {
     "message": "Show video remaining duration"
   },
+  "showWatchedSectionsOnSeekBar": {
+    "message": "Show watched sections on the seek bar"
+  },
   "showVersion": {
     "message": "Show version"
   },

--- a/js&css/web-accessible/core.js
+++ b/js&css/web-accessible/core.js
@@ -483,6 +483,10 @@ document.addEventListener('it-message-from-extension', function () {
 					ImprovedTube.playerHideProgressPreview();
 					break
 
+				case 'playerWatchedSegments':
+					ImprovedTube.watchedSegments.init();
+					break
+
 				case 'playerHideControls':
 					ImprovedTube.playerControls();
 					break

--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -484,8 +484,8 @@ ImprovedTube.initPlayer = function () {
 		ImprovedTube.playerHamburgerButton();
 		ImprovedTube.playerControls();
 		ImprovedTube.playerHideProgressPreview();
-		ImprovedTube.watchedSegments.init();
 		ImprovedTube.expandDescription();
+		if (ImprovedTube.storage.player_watched_segments === true) {ImprovedTube.watchedSegments.init();}
 		setTimeout(function () { ImprovedTube.forcedTheaterMode(); }, 150);
 		if (location.href.indexOf('/embed/') === -1) { ImprovedTube.miniPlayer(); }
 		if (ImprovedTube.storage.disable_auto_dubbing === true) { ImprovedTube.disableAutoDubbing(); }
@@ -532,7 +532,7 @@ ImprovedTube.playerOnTimeUpdate = function () {
 };
 
 ImprovedTube.playerOnLoadedMetadata = function () {
-	ImprovedTube.watchedSegments.init();
+	if (ImprovedTube.storage.player_watched_segments === true) {ImprovedTube.watchedSegments.init();}
 	setTimeout(function () { ImprovedTube.playerSize(); }, 100);
 	setTimeout(function () { if (ImprovedTube.elements.panels) { ImprovedTube.transcript(ImprovedTube.elements.panels); ImprovedTube.chapters(ImprovedTube.elements.panels); } }, 250);
 };

--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -484,6 +484,7 @@ ImprovedTube.initPlayer = function () {
 		ImprovedTube.playerHamburgerButton();
 		ImprovedTube.playerControls();
 		ImprovedTube.playerHideProgressPreview();
+		ImprovedTube.watchedSegments.init();
 		ImprovedTube.expandDescription();
 		setTimeout(function () { ImprovedTube.forcedTheaterMode(); }, 150);
 		if (location.href.indexOf('/embed/') === -1) { ImprovedTube.miniPlayer(); }
@@ -531,6 +532,7 @@ ImprovedTube.playerOnTimeUpdate = function () {
 };
 
 ImprovedTube.playerOnLoadedMetadata = function () {
+	ImprovedTube.watchedSegments.init();
 	setTimeout(function () { ImprovedTube.playerSize(); }, 100);
 	setTimeout(function () { if (ImprovedTube.elements.panels) { ImprovedTube.transcript(ImprovedTube.elements.panels); ImprovedTube.chapters(ImprovedTube.elements.panels); } }, 250);
 };

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -3089,21 +3089,41 @@ ImprovedTube.watchedSegments = {
 			return;
 		}
 
-		var video = this.video();
-
-		if (!video) { return; }
-
 		this.injectStyles();
-		this.attach(video);
-		this.load(this.currentVideoId());
 
 		var self = this;
 
 		clearInterval(this.render_timer);
 
-		this.render_timer = setInterval(function () { self.render(); }, this.RENDER_DELAY);
+		// The player is not always complete yet, so the tick picks it up later.
+		this.render_timer = setInterval(function () { self.tick(); }, this.RENDER_DELAY);
 
+		this.tick();
+	},
+
+	tick: function () {
+		if (!this.enabled()) {
+			this.disable();
+
+			return;
+		}
+
+		var video = this.video();
+
+		if (!video) { return; }
+
+		this.attach(video);
+		this.syncVideoId();
 		this.render();
+	},
+
+	// An empty id means the player kept going outside a watch page.
+	syncVideoId: function () {
+		var video_id = this.currentVideoId();
+
+		if (video_id && video_id !== this.video_id) {
+			this.load(video_id);
+		}
 	},
 
 	disable: function () {
@@ -3189,12 +3209,7 @@ ImprovedTube.watchedSegments = {
 			return;
 		}
 
-		var video_id = this.currentVideoId();
-
-		// An empty id means the player kept going outside a watch page.
-		if (video_id && video_id !== this.video_id) {
-			this.load(video_id);
-		}
+		this.syncVideoId();
 
 		var previous = this.last_time,
 			time = video.currentTime;
@@ -3334,12 +3349,6 @@ ImprovedTube.watchedSegments = {
 	# RENDERING
 	--------------------------------------------------------------*/
 	render: function () {
-		if (!this.enabled()) {
-			this.disable();
-
-			return;
-		}
-
 		var player = ImprovedTube.elements.player,
 			bar = player && player.querySelector('.ytp-progress-bar'),
 			duration = this.duration();

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -3028,3 +3028,394 @@ ImprovedTube.playerAutoContinueWatching = function () {
 		});
 	}
 };
+
+/*------------------------------------------------------------------------------
+WATCHED SECTIONS ON THE SEEK BAR
+--------------------------------------------------------------------------------
+	Records which parts of a video were actually played and paints them on the
+	progress bar, so scattered sections of long videos or streams stay visible.
+	The layer is inserted below YouTube's own bars, which keeps the played and
+	the buffered progress untouched.
+------------------------------------------------------------------------------*/
+ImprovedTube.watchedSegments = {
+	STORAGE_KEY: 'watched_segments',
+	MAX_VIDEOS: 200,
+	MERGE_GAP: 1,
+	RENDER_DELAY: 1000,
+	SAVE_DELAY: 5000,
+
+	attached_video: null,
+	dirty: false,
+	handlers: null,
+	last_time: null,
+	render_timer: null,
+	save_timer: null,
+	segments: [],
+	video_id: '',
+
+	enabled: function () {
+		return ImprovedTube.storage.player_watched_segments === true;
+	},
+
+	video: function () {
+		return ImprovedTube.elements.video || document.querySelector('#movie_player video');
+	},
+
+	duration: function () {
+		var video = this.video(),
+			duration = video && video.duration;
+
+		return typeof duration === 'number' && isFinite(duration) && duration > 0 ? duration : 0;
+	},
+
+	currentVideoId: function () {
+		var match = ImprovedTube.regex.video_id.exec(location.href);
+
+		return match ? match[1] : '';
+	},
+
+	adShowing: function () {
+		var player = ImprovedTube.elements.player;
+
+		return !!player && /ad-showing|ad-interrupting/.test(player.className);
+	},
+
+	init: function () {
+		var page_type = document.documentElement.dataset.pageType;
+
+		if (!this.enabled() || (page_type !== 'video' && page_type !== 'embed')) {
+			this.disable();
+
+			return;
+		}
+
+		var video = this.video();
+
+		if (!video) { return; }
+
+		this.injectStyles();
+		this.attach(video);
+		this.load(this.currentVideoId());
+
+		var self = this;
+
+		clearInterval(this.render_timer);
+
+		this.render_timer = setInterval(function () { self.render(); }, this.RENDER_DELAY);
+
+		this.render();
+	},
+
+	disable: function () {
+		clearInterval(this.render_timer);
+
+		this.render_timer = null;
+
+		this.save();
+		this.detach();
+		this.clear();
+
+		ImprovedTube.elements.buttons['it-watched-segments-styles']?.remove();
+
+		delete ImprovedTube.elements.buttons['it-watched-segments-styles'];
+	},
+
+	injectStyles: function () {
+		if (ImprovedTube.elements.buttons['it-watched-segments-styles']) { return; }
+
+		var style = document.createElement('style');
+
+		style.id = 'it-watched-segments-styles';
+		style.textContent = '.it-watched-segments{position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none}'
+			+ '.it-watched-segment{position:absolute;top:0;height:100%;background:var(--it-watched-segment-color,rgba(62,166,255,.85))}';
+
+		ImprovedTube.elements.buttons['it-watched-segments-styles'] = style;
+
+		(document.head || document.documentElement).appendChild(style);
+	},
+
+	attach: function (video) {
+		if (this.attached_video === video) { return; }
+
+		var self = this;
+
+		if (!this.handlers) {
+			this.handlers = {
+				timeupdate: function () { self.track(); },
+				seeking: function () { self.last_time = null; },
+				pause: function () { self.last_time = null; self.save(); },
+				ended: function () { self.last_time = null; self.save(); }
+			};
+
+			window.addEventListener('pagehide', function () { self.save(); });
+			document.addEventListener('visibilitychange', function () {
+				if (document.visibilityState === 'hidden') { self.save(); }
+			});
+		}
+
+		this.detach();
+
+		for (var type in this.handlers) {
+			video.addEventListener(type, this.handlers[type]);
+		}
+
+		this.attached_video = video;
+	},
+
+	detach: function () {
+		if (!this.attached_video || !this.handlers) { return; }
+
+		for (var type in this.handlers) {
+			this.attached_video.removeEventListener(type, this.handlers[type]);
+		}
+
+		this.attached_video = null;
+	},
+
+	/*--------------------------------------------------------------
+	# TRACKING
+	----------------------------------------------------------------
+		Only the distance between two consecutive time updates counts
+		as watched, so seeking, ads and paused players add nothing.
+	--------------------------------------------------------------*/
+	track: function () {
+		if (!this.enabled()) { return; }
+
+		var video = this.attached_video;
+
+		if (!video || !this.duration() || this.adShowing()) {
+			this.last_time = null;
+
+			return;
+		}
+
+		var video_id = this.currentVideoId();
+
+		// An empty id means the player kept going outside a watch page.
+		if (video_id && video_id !== this.video_id) {
+			this.load(video_id);
+		}
+
+		var previous = this.last_time,
+			time = video.currentTime;
+
+		this.last_time = time;
+
+		if (previous === null || video.paused || video.seeking) { return; }
+
+		var step = time - previous,
+			limit = 5 * Math.max(1, video.playbackRate || 1);
+
+		if (step <= 0 || step > limit) { return; }
+
+		if (this.add(previous, time)) {
+			this.dirty = true;
+
+			this.scheduleSave();
+		}
+	},
+
+	add: function (start, end) {
+		var segments = this.segments,
+			gap = this.MERGE_GAP,
+			from = Math.max(0, Math.round(start * 10) / 10),
+			to = Math.max(from, Math.round(end * 10) / 10),
+			first = 0,
+			last = 0;
+
+		while (first < segments.length && segments[first][1] + gap < from) {
+			first++;
+		}
+
+		last = first;
+
+		while (last < segments.length && segments[last][0] - gap <= to) {
+			from = Math.min(from, segments[last][0]);
+			to = Math.max(to, segments[last][1]);
+			last++;
+		}
+
+		if (last === first + 1 && segments[first][0] === from && segments[first][1] === to) { return false; }
+
+		segments.splice(first, last - first, [from, to]);
+
+		return true;
+	},
+
+	sanitize: function (segments) {
+		var result = [];
+
+		if (!Array.isArray(segments)) { return result; }
+
+		for (var i = 0, l = segments.length; i < l; i++) {
+			var segment = segments[i];
+
+			if (!Array.isArray(segment) || segment.length !== 2) { continue; }
+
+			var from = Number(segment[0]),
+				to = Number(segment[1]);
+
+			if (!isFinite(from) || !isFinite(to) || from < 0 || to <= from) { continue; }
+
+			result.push([from, to]);
+		}
+
+		result.sort(function (a, b) { return a[0] - b[0]; });
+
+		return result;
+	},
+
+	/*--------------------------------------------------------------
+	# STORAGE
+	--------------------------------------------------------------*/
+	load: function (video_id) {
+		if (video_id === this.video_id) { return; }
+
+		this.save();
+
+		var store = ImprovedTube.storage[this.STORAGE_KEY],
+			entry = store && typeof store === 'object' ? store[video_id] : null;
+
+		this.video_id = video_id;
+		this.last_time = null;
+		this.dirty = false;
+		this.segments = this.sanitize(entry && entry.s);
+	},
+
+	scheduleSave: function () {
+		if (this.save_timer) { return; }
+
+		var self = this;
+
+		this.save_timer = setTimeout(function () { self.save(); }, this.SAVE_DELAY);
+	},
+
+	save: function () {
+		clearTimeout(this.save_timer);
+
+		this.save_timer = null;
+
+		if (!this.dirty || !this.video_id) { return; }
+
+		this.dirty = false;
+
+		var store = ImprovedTube.storage[this.STORAGE_KEY];
+
+		if (!store || typeof store !== 'object') {
+			store = {};
+
+			ImprovedTube.storage[this.STORAGE_KEY] = store;
+		}
+
+		if (this.segments.length) {
+			store[this.video_id] = { u: Date.now(), s: this.segments };
+		} else {
+			delete store[this.video_id];
+		}
+
+		var ids = Object.keys(store);
+
+		if (ids.length > this.MAX_VIDEOS) {
+			ids.sort(function (a, b) { return ((store[a] && store[a].u) || 0) - ((store[b] && store[b].u) || 0); });
+
+			for (var i = 0, l = ids.length - this.MAX_VIDEOS; i < l; i++) {
+				delete store[ids[i]];
+			}
+		}
+
+		ImprovedTube.messages.send({
+			action: 'set',
+			key: this.STORAGE_KEY,
+			value: store
+		});
+	},
+
+	/*--------------------------------------------------------------
+	# RENDERING
+	--------------------------------------------------------------*/
+	render: function () {
+		if (!this.enabled()) {
+			this.disable();
+
+			return;
+		}
+
+		var player = ImprovedTube.elements.player,
+			bar = player && player.querySelector('.ytp-progress-bar'),
+			duration = this.duration();
+
+		// While an ad runs the bar shows the ad, not the video.
+		if (!bar || !duration || !this.segments.length || this.adShowing()) {
+			this.clear();
+
+			return;
+		}
+
+		var bar_rect = bar.getBoundingClientRect();
+
+		if (!bar_rect.width) { return; }
+
+		// One list per chapter, so every chapter maps to its own slice of the video.
+		var lists = bar.querySelectorAll('.ytp-progress-list');
+
+		if (!lists.length) {
+			this.paint(bar, bar_rect, duration);
+		} else {
+			for (var i = 0, l = lists.length; i < l; i++) {
+				this.paint(lists[i], bar_rect, duration);
+			}
+		}
+	},
+
+	paint: function (list, bar_rect, duration) {
+		var rect = list.getBoundingClientRect();
+
+		if (!rect.width) { return; }
+
+		var layer = list.querySelector(':scope > .it-watched-segments');
+
+		if (!layer) {
+			layer = document.createElement('div');
+			layer.className = 'it-watched-segments';
+
+			list.insertBefore(layer, list.firstChild);
+		}
+
+		var from = (rect.left - bar_rect.left) / bar_rect.width * duration,
+			span = rect.width / bar_rect.width * duration,
+			count = 0;
+
+		for (var i = 0, l = this.segments.length; i < l; i++) {
+			var start = Math.max(this.segments[i][0], from),
+				end = Math.min(this.segments[i][1], from + span);
+
+			if (end <= start) { continue; }
+
+			var element = layer.children[count];
+
+			if (!element) {
+				element = document.createElement('div');
+				element.className = 'it-watched-segment';
+
+				layer.appendChild(element);
+			}
+
+			element.style.left = (start - from) / span * 100 + '%';
+			element.style.width = (end - start) / span * 100 + '%';
+
+			count++;
+		}
+
+		while (layer.children.length > count) {
+			layer.lastChild.remove();
+		}
+	},
+
+	clear: function () {
+		var layers = document.querySelectorAll('.it-watched-segments');
+
+		for (var i = 0, l = layers.length; i < l; i++) {
+			layers[i].remove();
+		}
+	}
+};

--- a/menu/skeleton-parts/appearance.js
+++ b/menu/skeleton-parts/appearance.js
@@ -257,6 +257,12 @@ extension.skeleton.main.layers.section.appearance.on.click.player = {
 					text: 'hideProgressBarPreview',
 					storage: 'player_hide_progress_preview',
 				},
+				player_watched_segments: {
+					component: 'switch',
+					text: 'showWatchedSectionsOnSeekBar',
+					storage: 'player_watched_segments',
+					tags: 'progress,seek,bar,history,watched',
+				},
 				player_hide_controls_options: {
 					component: "button",
 					text: "hidePlayerControlsBarButtons",

--- a/tests/unit/watched-segments.test.js
+++ b/tests/unit/watched-segments.test.js
@@ -1,0 +1,418 @@
+// Test for Issue #4261: Display watched sections of the video on the seek bar
+
+const fs = require('fs');
+const path = require('path');
+
+const playerPath = path.join(__dirname, '../../js&css/web-accessible/www.youtube.com/player.js');
+const playerContent = fs.readFileSync(playerPath, 'utf8');
+
+// Extracts the `ImprovedTube.watchedSegments = { ... }` literal so its logic can
+// be exercised without loading the whole player script.
+function extractObjectLiteral (source, declaration) {
+	const start = source.indexOf(declaration);
+
+	if (start === -1) {
+		throw new Error('Declaration not found: ' + declaration);
+	}
+
+	let index = source.indexOf('{', start),
+		depth = 0,
+		quote = '';
+
+	for (let i = index; i < source.length; i++) {
+		const character = source[i];
+
+		if (quote) {
+			if (character === '\\') {
+				i++;
+			} else if (character === quote) {
+				quote = '';
+			}
+			continue;
+		}
+
+		if (character === '\'' || character === '"' || character === '`') {
+			quote = character;
+		} else if (character === '/' && source[i + 1] === '*') {
+			i = source.indexOf('*/', i) + 1;
+		} else if (character === '/' && source[i + 1] === '/') {
+			i = source.indexOf('\n', i);
+		} else if (character === '{') {
+			depth++;
+		} else if (character === '}') {
+			depth--;
+
+			if (depth === 0) {
+				return source.slice(index, i + 1);
+			}
+		}
+	}
+
+	throw new Error('Unbalanced braces in: ' + declaration);
+}
+
+function fakeElement (rect) {
+	return {
+		className: '',
+		style: {},
+		children: [],
+		parent: null,
+		rect: rect || { left: 0, right: 0, width: 0 },
+		getBoundingClientRect () { return this.rect; },
+		querySelector (selector) {
+			return this.children.find(function (child) {
+				return selector.endsWith('.' + child.className);
+			}) || null;
+		},
+		insertBefore (child) { child.parent = this; this.children.unshift(child); return child; },
+		appendChild (child) { child.parent = this; this.children.push(child); return child; },
+		remove () {
+			const index = this.parent ? this.parent.children.indexOf(this) : -1;
+
+			if (index !== -1) { this.parent.children.splice(index, 1); }
+		},
+		get firstChild () { return this.children[0] || null; },
+		get lastChild () { return this.children[this.children.length - 1] || null; }
+	};
+}
+
+const features = [];
+
+afterEach(() => {
+	while (features.length) {
+		clearTimeout(features.pop().save_timer);
+	}
+});
+
+function createFeature () {
+	const sent = [];
+	const ImprovedTube = {
+		elements: { buttons: {}, player: null, video: null },
+		messages: { send: function (message) { sent.push(message); } },
+		regex: { video_id: /(?:[?&]v=|embed\/|shorts\/)([^&?]{11})/ },
+		storage: { player_watched_segments: true }
+	};
+
+	global.location = { href: 'https://www.youtube.com/watch?v=abcdefghijk' };
+	global.document = {
+		createElement: function () { return fakeElement(); },
+		querySelectorAll: function () { return []; },
+		querySelector: function () { return null; },
+		documentElement: { dataset: { pageType: 'video' } }
+	};
+
+	const literal = extractObjectLiteral(playerContent, 'ImprovedTube.watchedSegments =');
+	const feature = new Function('ImprovedTube', 'return ' + literal + ';')(ImprovedTube);
+
+	features.push(feature);
+
+	return { feature, ImprovedTube, sent };
+}
+
+describe('Watched sections on the seek bar (#4261)', () => {
+	describe('segment merging', () => {
+		test('merges consecutive playback into a single segment', () => {
+			const { feature } = createFeature();
+
+			expect(feature.add(10, 10.5)).toBe(true);
+			feature.add(10.5, 11);
+			feature.add(11, 12.4);
+
+			expect(feature.segments).toEqual([[10, 12.4]]);
+		});
+
+		test('keeps sections apart until the gap between them is closed', () => {
+			const { feature } = createFeature();
+
+			feature.add(0, 30);
+			feature.add(120, 150);
+
+			expect(feature.segments).toEqual([[0, 30], [120, 150]]);
+
+			feature.add(30, 120);
+
+			expect(feature.segments).toEqual([[0, 150]]);
+		});
+
+		test('inserts a later section behind an earlier one', () => {
+			const { feature } = createFeature();
+
+			feature.add(300, 360);
+			feature.add(60, 90);
+
+			expect(feature.segments).toEqual([[60, 90], [300, 360]]);
+		});
+
+		test('reports no change when a section is already covered', () => {
+			const { feature } = createFeature();
+
+			feature.add(0, 60);
+
+			expect(feature.add(20, 30)).toBe(false);
+			expect(feature.segments).toEqual([[0, 60]]);
+		});
+	});
+
+	describe('stored data', () => {
+		test('drops malformed entries and sorts what is left', () => {
+			const { feature } = createFeature();
+
+			expect(feature.sanitize([[30, 20], ['a', 5], [10, 20], null, [40], [-5, 5], [5, 8]]))
+				.toEqual([[5, 8], [10, 20]]);
+			expect(feature.sanitize(undefined)).toEqual([]);
+		});
+
+		test('saves the current video and keeps the most recent videos only', () => {
+			const { feature, ImprovedTube, sent } = createFeature();
+
+			feature.MAX_VIDEOS = 2;
+			ImprovedTube.storage.watched_segments = {
+				old: { u: 1, s: [[0, 5]] },
+				recent: { u: 2, s: [[0, 5]] }
+			};
+
+			feature.video_id = 'abcdefghijk';
+			feature.segments = [[0, 42]];
+			feature.dirty = true;
+			feature.save();
+
+			expect(sent).toHaveLength(1);
+			expect(sent[0].action).toBe('set');
+			expect(sent[0].key).toBe('watched_segments');
+			expect(Object.keys(sent[0].value).sort()).toEqual(['abcdefghijk', 'recent']);
+			expect(sent[0].value.abcdefghijk.s).toEqual([[0, 42]]);
+		});
+
+		test('does not write when nothing changed', () => {
+			const { feature, sent } = createFeature();
+
+			feature.video_id = 'abcdefghijk';
+			feature.segments = [[0, 42]];
+			feature.dirty = false;
+			feature.save();
+
+			expect(sent).toHaveLength(0);
+		});
+
+		test('loads the sections of the video that is about to play', () => {
+			const { feature, ImprovedTube } = createFeature();
+
+			ImprovedTube.storage.watched_segments = {
+				abcdefghijk: { u: 1, s: [[0, 30], [90, 120]] }
+			};
+
+			feature.load('abcdefghijk');
+
+			expect(feature.segments).toEqual([[0, 30], [90, 120]]);
+			expect(feature.last_time).toBeNull();
+		});
+	});
+
+	describe('tracking', () => {
+		function play (times, overrides) {
+			const { feature, ImprovedTube } = createFeature();
+			const video = Object.assign({
+				currentTime: 0,
+				duration: 600,
+				paused: false,
+				playbackRate: 1,
+				seeking: false
+			}, overrides);
+
+			ImprovedTube.elements.video = video;
+			ImprovedTube.elements.player = { className: 'html5-video-player' };
+			feature.attached_video = video;
+			feature.video_id = 'abcdefghijk';
+
+			times.forEach(function (time) {
+				video.currentTime = time;
+				feature.track();
+			});
+
+			return { feature, video, ImprovedTube };
+		}
+
+		test('records the time that was actually played', () => {
+			const { feature } = play([10, 10.25, 10.5, 10.75]);
+
+			expect(feature.segments).toEqual([[10, 10.8]]);
+		});
+
+		test('does not fill in the part that was skipped over', () => {
+			const { feature } = play([10, 10.5, 400, 400.5]);
+
+			expect(feature.segments).toEqual([[10, 10.5], [400, 400.5]]);
+		});
+
+		test('records nothing while the player is paused', () => {
+			const { feature } = play([10, 10.5], { paused: true });
+
+			expect(feature.segments).toEqual([]);
+		});
+
+		test('records nothing while an ad is showing', () => {
+			const { feature, ImprovedTube } = createFeature();
+			const video = { currentTime: 0, duration: 600, paused: false, playbackRate: 1, seeking: false };
+
+			ImprovedTube.elements.video = video;
+			ImprovedTube.elements.player = { className: 'html5-video-player ad-showing' };
+			feature.attached_video = video;
+			feature.video_id = 'abcdefghijk';
+
+			[10, 10.5].forEach(function (time) {
+				video.currentTime = time;
+				feature.track();
+			});
+
+			expect(feature.segments).toEqual([]);
+		});
+
+		test('records nothing for streams without a known duration', () => {
+			const { feature } = play([10, 10.5], { duration: Infinity });
+
+			expect(feature.segments).toEqual([]);
+		});
+
+		test('keeps recording when the player outlives the watch page', () => {
+			const { feature } = play([10, 10.5]);
+
+			global.location.href = 'https://www.youtube.com/';
+
+			feature.attached_video.currentTime = 11;
+			feature.track();
+
+			expect(feature.video_id).toBe('abcdefghijk');
+			expect(feature.segments).toEqual([[10, 11]]);
+		});
+
+		test('allows bigger steps on faster playback', () => {
+			const { feature } = play([10, 16], { playbackRate: 2 });
+
+			expect(feature.segments).toEqual([[10, 16]]);
+		});
+	});
+
+	describe('rendering', () => {
+		test('places sections relative to the chapter they fall into', () => {
+			const { feature } = createFeature();
+
+			feature.segments = [[300, 450]];
+
+			// Second half of a 600 second video, drawn on the second of two chapters.
+			const chapter = fakeElement({ left: 100, right: 200, width: 100 });
+
+			feature.paint(chapter, { left: 0, right: 200, width: 200 }, 600);
+
+			const layer = chapter.children[0];
+
+			expect(layer.className).toBe('it-watched-segments');
+			expect(layer.children).toHaveLength(1);
+			expect(layer.children[0].className).toBe('it-watched-segment');
+			expect(layer.children[0].style.left).toBe('0%');
+			expect(layer.children[0].style.width).toBe('50%');
+		});
+
+		test('clips sections to the chapter and reuses the drawn elements', () => {
+			const { feature } = createFeature();
+
+			feature.segments = [[0, 450], [500, 550]];
+
+			const chapter = fakeElement({ left: 100, right: 200, width: 100 });
+			const bar = { left: 0, right: 200, width: 200 };
+
+			feature.paint(chapter, bar, 600);
+
+			const layer = chapter.children[0];
+
+			expect(chapter.children).toHaveLength(1);
+			expect(layer.children).toHaveLength(2);
+			expect(layer.children[0].style.left).toBe('0%');
+			expect(layer.children[0].style.width).toBe('50%');
+			expect(parseFloat(layer.children[1].style.left)).toBeCloseTo(200 / 3, 6);
+
+			feature.segments = [[300, 360]];
+			feature.paint(chapter, bar, 600);
+
+			expect(chapter.children).toHaveLength(1);
+			expect(layer.children).toHaveLength(1);
+			expect(layer.children[0].style.width).toBe('20%');
+		});
+
+		test('leaves the bar alone while an ad is showing', () => {
+			const { feature, ImprovedTube } = createFeature();
+
+			const chapter = fakeElement({ left: 0, right: 200, width: 200 });
+			const bar = fakeElement({ left: 0, right: 200, width: 200 });
+
+			chapter.className = 'ytp-progress-list';
+			bar.children.push(chapter);
+
+			ImprovedTube.elements.video = { duration: 600 };
+			ImprovedTube.elements.player = {
+				className: 'html5-video-player ad-showing',
+				querySelector: function () { return bar; }
+			};
+			bar.querySelectorAll = function () { return [chapter]; };
+
+			feature.segments = [[0, 300]];
+			feature.render();
+
+			expect(chapter.children).toHaveLength(0);
+
+			ImprovedTube.elements.player.className = 'html5-video-player';
+
+			feature.render();
+
+			expect(chapter.children).toHaveLength(1);
+			expect(chapter.children[0].children[0].style.width).toBe('50%');
+		});
+
+		test('draws nothing on a chapter that was never watched', () => {
+			const { feature } = createFeature();
+
+			feature.segments = [[0, 100]];
+
+			const chapter = fakeElement({ left: 100, right: 200, width: 100 });
+
+			feature.paint(chapter, { left: 0, right: 200, width: 200 }, 600);
+
+			expect(chapter.children[0].children).toHaveLength(0);
+		});
+	});
+
+	describe('wiring', () => {
+		test('the feature is initialised with the player', () => {
+			const functionsContent = fs.readFileSync(
+				path.join(__dirname, '../../js&css/web-accessible/functions.js'),
+				'utf8'
+			);
+
+			expect(functionsContent).toContain('ImprovedTube.watchedSegments.init()');
+		});
+
+		test('switching the setting takes effect without a reload', () => {
+			const coreContent = fs.readFileSync(
+				path.join(__dirname, '../../js&css/web-accessible/core.js'),
+				'utf8'
+			);
+
+			expect(coreContent).toContain("case 'playerWatchedSegments':");
+			expect(coreContent).toContain('ImprovedTube.watchedSegments.init()');
+		});
+
+		test('the setting is exposed in the menu and translated', () => {
+			const menuContent = fs.readFileSync(
+				path.join(__dirname, '../../menu/skeleton-parts/appearance.js'),
+				'utf8'
+			);
+			const messages = JSON.parse(fs.readFileSync(
+				path.join(__dirname, '../../_locales/en/messages.json'),
+				'utf8'
+			));
+
+			expect(menuContent).toContain('player_watched_segments');
+			expect(menuContent).toContain('showWatchedSectionsOnSeekBar');
+			expect(messages.showWatchedSectionsOnSeekBar).toBeDefined();
+		});
+	});
+});

--- a/tests/unit/watched-segments.test.js
+++ b/tests/unit/watched-segments.test.js
@@ -94,11 +94,14 @@ function createFeature () {
 	};
 
 	global.location = { href: 'https://www.youtube.com/watch?v=abcdefghijk' };
+	global.window = { addEventListener: function () {} };
 	global.document = {
+		addEventListener: function () {},
 		createElement: function () { return fakeElement(); },
 		querySelectorAll: function () { return []; },
 		querySelector: function () { return null; },
-		documentElement: { dataset: { pageType: 'video' } }
+		documentElement: { dataset: { pageType: 'video' } },
+		head: fakeElement()
 	};
 
 	const literal = extractObjectLiteral(playerContent, 'ImprovedTube.watchedSegments =');
@@ -377,6 +380,78 @@ describe('Watched sections on the seek bar (#4261)', () => {
 			feature.paint(chapter, { left: 0, right: 200, width: 200 }, 600);
 
 			expect(chapter.children[0].children).toHaveLength(0);
+		});
+	});
+
+	describe('start up', () => {
+		function buildPlayer (ImprovedTube) {
+			const chapter = fakeElement({ left: 0, right: 200, width: 200 });
+			const bar = fakeElement({ left: 0, right: 200, width: 200 });
+
+			chapter.className = 'ytp-progress-list';
+			bar.children.push(chapter);
+			bar.querySelectorAll = function () { return [chapter]; };
+
+			ImprovedTube.elements.player = {
+				className: 'html5-video-player',
+				querySelector: function () { return bar; }
+			};
+
+			return chapter;
+		}
+
+		test('waits for a player that is not complete yet', () => {
+			const { feature, ImprovedTube } = createFeature();
+
+			ImprovedTube.storage.watched_segments = { abcdefghijk: { u: 1, s: [[0, 300]] } };
+
+			const chapter = buildPlayer(ImprovedTube);
+
+			feature.init();
+
+			expect(feature.render_timer).not.toBeNull();
+			expect(feature.attached_video).toBeNull();
+			expect(chapter.children).toHaveLength(0);
+
+			// The video element shows up on a later tick.
+			ImprovedTube.elements.video = {
+				duration: 600,
+				addEventListener: function () {},
+				removeEventListener: function () {}
+			};
+
+			feature.tick();
+
+			expect(feature.attached_video).toBe(ImprovedTube.elements.video);
+			expect(feature.video_id).toBe('abcdefghijk');
+			expect(chapter.children[0].children[0].style.width).toBe('50%');
+
+			clearInterval(feature.render_timer);
+		});
+
+		test('stops itself when the setting is switched off', () => {
+			const { feature, ImprovedTube } = createFeature();
+
+			buildPlayer(ImprovedTube);
+			feature.init();
+
+			expect(feature.render_timer).not.toBeNull();
+
+			ImprovedTube.storage.player_watched_segments = false;
+			feature.tick();
+
+			expect(feature.render_timer).toBeNull();
+			expect(ImprovedTube.elements.buttons['it-watched-segments-styles']).toBeUndefined();
+		});
+
+		test('does not start on pages that are not a video', () => {
+			const { feature, ImprovedTube } = createFeature();
+
+			global.document.documentElement.dataset.pageType = 'home';
+			buildPlayer(ImprovedTube);
+			feature.init();
+
+			expect(feature.render_timer).toBeNull();
 		});
 	});
 


### PR DESCRIPTION
Records the parts of a video that were actually played and paints them on the progress bar, so scattered sections of long videos and streams stay visible across sessions.

Playback is merged into ranges per video; seeking, ads, a paused player and streams without a known duration add nothing. The ranges of the 200 most recently watched videos are kept in extension storage.

The ranges are drawn per chapter below YouTube's own bars, which leaves the played and the buffered progress untouched. The feature is off by default and switchable under Appearance > Player.

Closes #4261