### PR TITLE
fix: prevent large playlist handler from interfering with YouTube queue autoplay (Fixes #4228)

### DIFF
--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -382,10 +382,12 @@ ImprovedTube.videoPageUpdate = function () {
 		ImprovedTube.playerControls();
 		
 		// Initialize large playlist handler for playlist videos
-		if (this.getParam(location.href, 'list')) {
+		// Skip queue-type playlists (WL, RD, etc.) to prevent interference
+		var listId = this.getParam(location.href, 'list');
+		if (listId && listId !== 'WL' && listId !== 'RD' && listId.indexOf('RDAMVM') !== 0 && listId.indexOf('OLAK5uy_') !== 0) {
 			ImprovedTube.playlistLargePlaylistHandler();
 		} else {
-			// Cleanup when not on a playlist
+			// Cleanup when not on a playlist or on a queue-type playlist
 			if (typeof ImprovedTube.cleanupPlaylistHandlers === 'function') {
 				ImprovedTube.cleanupPlaylistHandlers();
 			}

--- a/js&css/web-accessible/www.youtube.com/playlist.js
+++ b/js&css/web-accessible/www.youtube.com/playlist.js
@@ -22,8 +22,18 @@ ImprovedTube.playlistUpNextAutoplay = function () {
 // currentIndex and localCurrentIndex to desync at chunk boundaries.
 // This handler keeps them in sync so autoplay continues working.
 // Only runs when playlist_up_next_autoplay is NOT disabled.
+// ⚠️ Skip queue-type playlists (WL=Watch Later, RD=Radio, OLAK5uy_=auto-mix)
+// to prevent interference with YouTube's queue autoplay behavior.
 ImprovedTube.playlistLargePlaylistHandler = function() {
 	if (!this.getParam(location.href, 'list')) return;
+
+	// Skip queue-type playlists — these are not regular user playlists
+	// and the index sync logic can interfere with YouTube's queue autoplay
+	var listId = this.getParam(location.href, 'list');
+	if (listId === 'WL' || listId === 'RD' || listId.indexOf('RDAMVM') === 0 || listId.indexOf('OLAK5uy_') === 0) {
+		this.cleanupPlaylistHandlers();
+		return;
+	}
 
 	// Do not sync indices if the user has disabled playlist autoplay,
 	// because playlistUpNextAutoplay intentionally sets currentIndex


### PR DESCRIPTION
## Fixes #4228

### Problem
When the extension is enabled, YouTube keeps adding random videos to the queue when reaching the end of a queue. Disabling the extension makes the problem go away.

### Root Cause
The `playlistLargePlaylistHandler` was being initialized for all URLs with a `list` parameter, including queue-type playlists (Watch Later `WL`, Radio `RD`, auto-generated mixes). The handler's index-sync logic interferes with YouTube's queue autoplay behavior, causing YouTube to add videos to the queue.

### Fix
- Skip queue-type playlists (`WL`, `RD`, `RDAMVM...`, `OLAK5uy_...`) in `playlistLargePlaylistHandler`
- Skip queue-type playlists when initializing the handler in `initPlayer`
- Queue-type playlists are not regular user playlists and don't need the large playlist index-sync logic

### Changes
- `js&css/web-accessible/www.youtube.com/playlist.js`: Added queue-type check in `playlistLargePlaylistHandler`
- `js&css/web-accessible/functions.js`: Added queue-type check in initPlayer playlist initialization