### PR TITLE
fix(livechat): collapse theatre full-bleed chat container when live chat is hidden (#3664)

### DIFF
--- a/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.css
+++ b/js&css/extension/www.youtube.com/appearance/sidebar/sidebar.css
@@ -160,6 +160,17 @@ html[it-thumbnails-hide='true'] ytd-watch-next-secondary-results-renderer ytd-pl
 html[it-livechat='hidden'] ytd-live-chat-frame#chat {
 	  display: none !important;
 }
+
+/* #3664 - In theatre mode YouTube reparents the live chat into
+   #panels-full-bleed-container. Hiding only ytd-live-chat-frame#chat leaves
+   this container reserving its width, so the theatre player stays offset as
+   if the sidebar were still present. Collapse the container when the live
+   chat is the panel it hosts, while leaving any engagement panel the user
+   explicitly opened (transcript, chapters, ...) untouched. */
+html[it-livechat='hidden'] ytd-watch-flexy[theater] #panels-full-bleed-container:has(ytd-live-chat-frame#chat):not(:has(ytd-engagement-panel-section-list-renderer[visibility='ENGAGEMENT_PANEL_VISIBILITY_EXPANDED'])) {
+	display: none !important;
+}
+
 html[it-livechat='collapsed'] #chat-container:not([it-activated])::before {
 	content: 'Show live chat' !important;
 }

--- a/tests/unit/livechat-theater-offset.test.js
+++ b/tests/unit/livechat-theater-offset.test.js
@@ -1,0 +1,31 @@
+// Test for Issue #3664: Theatre mode stays offset when live chat is hidden
+
+const fs = require('fs');
+const path = require('path');
+
+describe('Hidden live chat + theatre offset (#3664)', () => {
+	let sidebarCssContent;
+
+	beforeAll(() => {
+		const filePath = path.join(__dirname, '../../js&css/extension/www.youtube.com/appearance/sidebar/sidebar.css');
+		sidebarCssContent = fs.readFileSync(filePath, 'utf8');
+	});
+
+	test('should still hide the live chat frame itself when livechat is hidden', () => {
+		expect(sidebarCssContent).toContain("html[it-livechat='hidden'] ytd-live-chat-frame#chat");
+	});
+
+	test('should collapse the theatre full-bleed panel container that hosts the hidden chat', () => {
+		expect(sidebarCssContent).toMatch(
+			/html\[it-livechat='hidden'\] ytd-watch-flexy\[theater\] #panels-full-bleed-container/
+		);
+	});
+
+	test('should keep an explicitly opened engagement panel visible in theatre mode', () => {
+		// The rule must exclude an expanded engagement panel so hiding chat does
+		// not also hide a transcript/chapters panel the user opened.
+		expect(sidebarCssContent).toContain(
+			":not(:has(ytd-engagement-panel-section-list-renderer[visibility='ENGAGEMENT_PANEL_VISIBILITY_EXPANDED']))"
+		);
+	});
+});


### PR DESCRIPTION
## What this fixes

Fixes #3664 — in **theatre mode**, when *Live chat* is set to **Hidden**, the player stays offset to the left as if the sidebar/chat were still there, leaving an empty column on the right.

## Root cause

The existing rule only hides the chat frame itself:

```css
html[it-livechat='hidden'] ytd-live-chat-frame#chat { display: none !important; }
```

In theatre mode YouTube **reparents the live chat into `#panels-full-bleed-container`**. Setting only `#chat` to `display:none` removes the chat contents but the surrounding `#panels-full-bleed-container` keeps reserving its width, so the theatre player never reclaims that space. (This matches the community uBlock workaround `###panels-full-bleed-container` mentioned in the issue.)

A repo-wide search confirms `#panels-full-bleed-container` was not handled anywhere before this change.

## The fix

Collapse `#panels-full-bleed-container` while it is hosting the hidden chat, scoped to theatre mode:

```css
html[it-livechat='hidden'] ytd-watch-flexy[theater] #panels-full-bleed-container:has(ytd-live-chat-frame#chat):not(:has(ytd-engagement-panel-section-list-renderer[visibility='ENGAGEMENT_PANEL_VISIBILITY_EXPANDED'])) {
    display: none !important;
}
```

- Scoped to `ytd-watch-flexy[theater]` so the normal (non-theatre) layout is untouched.
- `:has(ytd-live-chat-frame#chat)` — only act on the container that hosts the chat.
- `:not(:has(...EXPANDED))` — if the user explicitly opens an engagement panel (transcript, chapters, …) in theatre mode, the container stays visible so those panels remain usable.

## Tests

Added `tests/unit/livechat-theater-offset.test.js`, mirroring the existing `hide-sidebar-transcript.test.js` CSS-content style. `npx jest` passes locally.

## How to reproduce / verify

1. Set *Live chat* → **Hidden**
2. Open a live stream, switch to **theatre mode**
3. Before: player is offset with an empty right column. After: player fills the width.
4. Open a transcript/chapters panel in theatre mode → still shows (not affected).

I've verified the rule loads via the manifest content-script CSS and that unit tests pass; a second visual confirmation from anyone on the issue is very welcome.
