### PR TITLE
fix(comments): let clicks through the thread hitbox when avatars are hidden

### DIFF
--- a/js&css/extension/www.youtube.com/appearance/comments/comments.css
+++ b/js&css/extension/www.youtube.com/appearance/comments/comments.css
@@ -19,6 +19,14 @@ html[it-hide-author-avatars='true'] ytd-comments #author-thumbnail,
 html[it-hide-author-avatars='true'] ytd-comments #creator-thumbnail,
 html[it-hide-author-avatars='true'] ytd-comments #hearted-thumbnail 
 {display: none !important;}
+
+/* Hiding the avatar collapses the 36px column, but YouTube's .thread-hitbox is
+   absolutely positioned at left:0 with that same width, so it ends up covering
+   the comment's like and "read more" buttons. Let clicks through: the column it
+   was there to cover no longer exists. */
+html[it-hide-author-avatars='true'] ytd-comments ytd-comment-thread-renderer .thread-hitbox {
+	pointer-events: none !important;
+}
 /*--------------------------------------------------------------
 # SQUARED USER IMAGES
 --------------------------------------------------------------*/


### PR DESCRIPTION
Resolves #4291

## What

With `appearance > comments > hide author avatars` enabled, the comment's like button and the "read more" expander stop responding to clicks.

Hiding `#author-thumbnail` collapses the 36px avatar column, but YouTube's `.thread-hitbox` is a direct child of `ytd-comment-thread-renderer`, absolutely positioned at `left: 0` with `width: 36px`. Once the column collapses, the comment body slides under it and the hitbox intercepts the clicks.

The fix disables pointer events on that element under this feature only. The hitbox exists to make the avatar column clickable for the reply chain — that column is gone once the feature is on, so there is nothing left for it to cover.

```css
html[it-hide-author-avatars='true'] ytd-comments ytd-comment-thread-renderer .thread-hitbox {
	pointer-events: none !important;
}
```

## How it was verified

Measured on a real YouTube watch page by injecting this repo's existing rule verbatim (`#author-thumbnail, #creator-thumbnail, #hearted-thumbnail { display: none !important }`), then probing `document.elementFromPoint()` at the centre of the like button:

| State | Element on top at the like button | Clickable |
| --- | --- | --- |
| Avatars visible (baseline) | `div.ytSpecTouchFeedbackShapeFill` | yes |
| Avatars hidden — the bug | **`div.thread-hitbox`** | **no** |
| Avatars hidden + this fix | `div.ytSpecTouchFeedbackShapeFill` | yes |
| Avatars visible + this fix | `div.ytSpecTouchFeedbackShapeFill` | yes |

The last row is the regression check: the rule is scoped to `html[it-hide-author-avatars='true']`, so default behaviour is untouched.

Geometry that explains it, from the same page: `#author-thumbnail` is `x=16 w=36`, `#main` starts at `x=68`. With the avatars rule applied `#main` moves to `x=16` and the like button to `x=8`, while `.thread-hitbox` stays at `x=16 w=36` — directly over it.

## Notes

- Reported on Firefox; I verified on Chromium. The cause is layout rather than engine-specific, but a Firefox confirmation would be worth having.
- I checked this against the live DOM rather than with the extension loaded, by applying the extension's own CSS rule. That reproduces the same stacking, but it is not the same as a full end-to-end run with the extension installed.
- Trade-off worth a maintainer's opinion: clicking the hitbox to collapse a reply chain no longer works while avatars are hidden. Hiding it outright (`display: none`) would be equivalent for clicks. If you'd rather keep the affordance, the alternative is re-positioning the hitbox instead of disabling it — happy to switch.

> [!NOTE]
> AI model used — `claude-opus-5`, reasoning effort `high`. I read and verified every line before submitting.