### PR TITLE
fix: show player tooltips above video

### DIFF
--- a/js&css/extension/www.youtube.com/styles.css
+++ b/js&css/extension/www.youtube.com/styles.css
@@ -241,6 +241,7 @@ html[it-player-fit-to-win-button=true][data-page-type=video] #ftw-icon path {
 	border-radius: 2px !important;
 	background-color: rgba(28, 28, 28, .9) !important;
 	text-shadow: 0 0 2px rgb(0, 0, 0, .5) !important;
+	z-index: 10001 !important;
 }
 
 body.no-scroll .it-player-button--tooltip {

--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -790,10 +790,6 @@ ImprovedTube.createPlayerButton = function (options) {
 			tooltip.style.left = leftPos + 'px';
 			tooltip.style.top = rect.top - 8 + 'px';
 
-			if (this.storage && (this.storage.player_cinema_mode_button || this.storage.player_auto_hide_cinema_mode_when_paused || this.storage.player_auto_cinema_mode)) {
-				tooltip.style.zIndex = 10001;
-			} // needed for cinema mode
-
 			function mouseleave() {
 				tooltip.remove();
 


### PR DESCRIPTION
Fixes an issue where ImprovedTube player button tooltips could appear behind the YouTube video player.

The tooltip now has a z-index above the player, and the old conditional z-index code in functions.js was removed since it was not being applied correctly.

Tests:

npm test
npm run lint