### PR TITLE
fix: remove deprecated background.scripts from manifest v3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,8 +17,7 @@
     }
   },
   "background": {
-    "service_worker": "background.js",
-    "scripts": ["background.js"]
+    "service_worker": "background.js"
   },
   "action": {
     "default_popup": "menu/index.html",


### PR DESCRIPTION
## Summary

Remove deprecated `background.scripts` from the Manifest V3 configuration.

## Changes

- Removed `background.scripts` from `manifest.json`
- Kept `background.service_worker` unchanged

## Reason

Manifest V3 does not support `background.scripts`.

The extension showed the warning:

`background.scripts requires manifest version of 2 or lower`

during local testing in Microsoft Edge.

## Testing

- Loaded extension as unpacked extension in Edge
- Reloaded extension after the change
- Verified the warning no longer appears