### PR TITLE
Fix: Show playback speed slider in settings menu

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1083,6 +1083,9 @@
   "playbackSpeedButton": {
     "message": "Playback speed button"
   },
+  "preferredSpeed": {
+    "message": "Preferred speed"
+  },
   "playbackSpeedHotkey": {
     "message": "Playback speed hotkeys"
   },

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -1684,17 +1684,16 @@ extension.skeleton.main.layers.section.player.on.click = {
 			text: 'playbackSpeedButton',
 			storage: 'player_playback_speed_button_b',
 			id: 'player_playback_speed_button_b',
-			children: [{
-				id: 'player_custom_playback_speed',
-				storage: 'player_custom_playback_speed',
-				component: 'slider',
-				text: 'preferredSpeed',
-				min: 0.25,
-				max: 4,
-				step: 0.05,
-				text: true,
-				value: 1.25
-			}]
+		},
+		player_playback_speed_button_b_slider: {
+			id: 'player_custom_playback_speed',
+			storage: 'player_custom_playback_speed',
+			component: 'slider',
+			text: 'preferredSpeed',
+			min: 0.25,
+			max: 4,
+			step: 0.05,
+			value: 1.25
 		},
 		
 		player_cinema_mode_button: {

--- a/menu/styles/sub-options.css
+++ b/menu/styles/sub-options.css
@@ -27,6 +27,7 @@ NESTED (CONDITIONAL) SWITCHES
 /* #player_repeat_button:not([data-value=true]) + .satus-switch, */
 #player_screenshot_button:not([data-value=true]) + .satus-switch,
 #player_screenshot_button:not([data-value=true]) + .satus-switch + .satus-select,
+#player_playback_speed_button_b:not([data-value=true]) + .satus-slider,
 /*-COPY VIDEO FULL URL-*/
 #copy-video-id:not([data-value=true]) + .satus-switch,
 /*-COPY PLAYLIST VIDEO FULL URL-*/
@@ -75,6 +76,7 @@ NIGHT MODE
 #player_auto_cinema_mode +.satus-switch,
 #player_screenshot_button[data-value=true] + .satus-switch,
 #player_screenshot_button[data-value=true] + .satus-switch + .satus-select,
+#player_playback_speed_button_b[data-value=true] + .satus-slider,
 /*-COPY VIDEO FULL URL-*/
 #copy-video-id[data-value=true] + .satus-switch,
 /*-COPY PLAYLIST VIDEO FULL URL-*/


### PR DESCRIPTION
## Summary

This PR fixes the preferred playback speed slider so it is shown in the settings menu when the Playback speed button toggle is enabled.

## Changes

- Moved the `player_custom_playback_speed` slider out of the `player_playback_speed_button_b` switch `children` definition so it can be rendered as a separate menu item.
- Added menu CSS rules that show or hide the slider based on the `player_playback_speed_button_b` toggle state.
- Added the missing English locale entry for the slider label, `preferredSpeed`.

## Why

The preferred speed slider was defined under the Playback speed button switch, but it was not appearing in the menu.

Other conditional controls in this menu are rendered as adjacent items and then shown or hidden with CSS based on the related toggle state. This PR follows that existing menu pattern so the slider appears when the Playback speed button 
toggle is enabled.

## Screenshots

Before, the `player_playback_speed_button_b` menu entry (specifically the lower/second one) existed, but its preferred speed slider was not shown.

<!-- before screenshot -->
<img width="302" height="479" alt="image" src="https://github.com/user-attachments/assets/9080b8ff-42a8-4e54-8926-7b1ef6b23073" />


After this change, the preferred speed slider follows the
`player_playback_speed_button_b` (lower/second one) toggle state.

| Toggle off | Toggle on |
|---|---|
| <!-- after off screenshot --> <img width="302" height="479" alt="image" src="https://github.com/user-attachments/assets/f8a8df78-38c7-4a99-aed2-23c4998ae467" /> | <!-- after on screenshot --> <img width="302" height="479" alt="image" src="https://github.com/user-attachments/assets/abfc26c3-e55b-40a3-b32d-c96f790849d3" />  |

## Testing

- Verified that the preferred speed slider is hidden when the Playback speed button toggle is disabled.
- Verified that the preferred speed slider is shown when the Playback speed button toggle is enabled.
- Verified that the slider label is displayed as `Preferred speed`.

## Notes

The current `master` branch has both Playback Speed Button paths:

- Runtime functions:
  - `playerPlaybackSpeedButton()`
  - `playerPlaybackSpeedButtonB()`
- Menu definitions:
  - `player_playback_speed_button`
  - `player_playback_speed_button_b`

This PR only updates the existing `player_playback_speed_button_b` menu path so its preferred speed slider is rendered and shown correctly. It does not remove or consolidate the duplicate runtime functions or menu items.

I used AI assistance only for translating this PR description. I made the code changes and performed the testing myself.
