### PR TITLE
fix(general): restore classic thumbnail metadata under renamed YouTube classes

### DIFF
--- a/js&css/extension/www.youtube.com/general/general.css
+++ b/js&css/extension/www.youtube.com/general/general.css
@@ -616,6 +616,11 @@ html[it-larger-thumbnail-metadata='true'] .yt-content-metadata-view-model-wiz__d
   The hyphenated selectors stay for surfaces still served the old
   markup. Target the leading icon by name rather than every icon in
   the row, so the channel verified badge keeps rendering.
+
+  camelCase names observed on watch and results pages, 2026-08.
+  YouTube renames these every few months, so if the play triangle
+  reappears, read the row markup first and add the new name here
+  rather than widening this to every icon in the row.
 --------------------------------------------------------------*/
 html[it-classic-thumbnail-metadata='true'] .yt-content-metadata-view-model-wiz__metadata-row .yt-content-metadata-view-model-wiz__metadata-icon,
 html[it-classic-thumbnail-metadata='true'] .yt-content-metadata-view-model-wiz__metadata-row yt-icon,

--- a/js&css/extension/www.youtube.com/general/general.css
+++ b/js&css/extension/www.youtube.com/general/general.css
@@ -610,11 +610,18 @@ html[it-larger-thumbnail-metadata='true'] .yt-content-metadata-view-model-wiz__d
   Hides the play-triangle icon that YouTube inserted in front of
   the view count on thumbnails. The accompanying JS expands the
   shortened time-ago text and restores the interpunct delimiter.
+
+  YouTube renamed these view-model classes from the hyphenated
+  "-wiz__" form to camelCase, which is why the last selector exists.
+  The hyphenated selectors stay for surfaces still served the old
+  markup. Target the leading icon by name rather than every icon in
+  the row, so the channel verified badge keeps rendering.
 --------------------------------------------------------------*/
 html[it-classic-thumbnail-metadata='true'] .yt-content-metadata-view-model-wiz__metadata-row .yt-content-metadata-view-model-wiz__metadata-icon,
 html[it-classic-thumbnail-metadata='true'] .yt-content-metadata-view-model-wiz__metadata-row yt-icon,
 html[it-classic-thumbnail-metadata='true'] .yt-content-metadata-view-model-wiz__metadata-text > svg,
-html[it-classic-thumbnail-metadata='true'] .yt-content-metadata-view-model-wiz__metadata-text > yt-icon {
+html[it-classic-thumbnail-metadata='true'] .yt-content-metadata-view-model-wiz__metadata-text > yt-icon,
+html[it-classic-thumbnail-metadata='true'] .ytContentMetadataViewModelMetadataRow .ytContentMetadataViewModelLeadingIcon {
 	display: none !important;
 }
 


### PR DESCRIPTION
## Summary

Restores the **Classic thumbnail metadata** feature on the watch page sidebar. Closes #4278.

YouTube renamed its content metadata view-model classes from the hyphenated `yt-content-metadata-view-model-wiz__*` form to camelCase. The rule in `general.css` still targeted the old names, so the play-triangle icon in front of the view count came back.

## Root cause, measured on a live watch page

Counted in the console on `youtube.com/watch`:

| Selector the CSS targeted | Matches | Current equivalent | Matches |
| --- | --- | --- | --- |
| `.yt-content-metadata-view-model-wiz__metadata-row` | **0** | `.ytContentMetadataViewModelMetadataRow` | 11 |
| `.yt-content-metadata-view-model-wiz__metadata-text` | **0** | `.ytContentMetadataViewModelMetadataText` | 12 |
| `.yt-content-metadata-view-model-wiz__metadata-icon` | **0** | `.ytContentMetadataViewModelLeadingIcon` | 4 |

Every one of the 4 leading icons sits directly inside a metadata row, and the row it belongs to reads `18M 5y ago`, which is the views and age row from the report.

## The fix

One added selector. The old selectors stay, so any surface still served the previous markup keeps working.

```css
html[it-classic-thumbnail-metadata='true'] .ytContentMetadataViewModelMetadataRow .ytContentMetadataViewModelLeadingIcon
```

It targets the leading icon by name rather than every icon in the row. The channel verified badge is a separate `.ytAttributedStringImageElement` inside the metadata text, so it is not hidden.

## Verification

Applied the exact rule to a live watch page and measured `getComputedStyle` before and after:

- 4 leading icons: `flex` to `none`
- 3 verified badges: `inline-flex` to `inline-flex`, unchanged

To reproduce, paste this in the console on a watch page:

```js
document.documentElement.setAttribute('it-classic-thumbnail-metadata', 'true');
const s = document.createElement('style');
s.textContent = "html[it-classic-thumbnail-metadata='true'] .ytContentMetadataViewModelMetadataRow .ytContentMetadataViewModelLeadingIcon{display:none !important}";
document.head.appendChild(s);
```

`npx jest` passes: 24 suites, 113 tests.

## What I could not check

The home feed did not render for me while signed out, so I confirmed the watch page only. Keeping the old selectors means that surface cannot regress either way.

The block comment above the rule mentions accompanying JS that expands the shortened time-ago text and restores the interpunct delimiter. I found no such JS in the repo, so `1mo ago` stays short and the delimiter stays absent. That looks like a separate gap and I left it out of this change.

---
<table><tr>
<td><img src="https://github.com/rascal-sl.png?size=48" width="40" height="40" /></td>
<td><strong>Tisankan Jeyakumar</strong><br/>
<img src="https://img.shields.io/badge/Developed-Verified-2ea44f?style=flat-square&logo=github&logoColor=white" alt="Developed and verified" /></td>
</tr></table>
