### PR TITLE
feat: Support playback speed and volume shortcuts for shorts

### DIFF
--- a/js&css/web-accessible/functions.js
+++ b/js&css/web-accessible/functions.js
@@ -845,7 +845,8 @@ ImprovedTube.showStatus = function (value) {
 
 	ImprovedTube.status_timer = setTimeout(function () { ImprovedTube.elements.status.remove(); }, 500);
 
-	this.elements.player.appendChild(this.elements.status);
+	const player = (document.documentElement.dataset.pageType === 'shorts') ? this.elements.shorts_player : this.elements.player;
+	player.appendChild(this.elements.status);
 };
 
 ImprovedTube.videoId = (url = document.URL) => url.match(ImprovedTube.regex.video_id)?.[1] || new URL(url).searchParams.get('v') || movie_player?.getVideoData?.().video_id || (console.log('No VIDEO ID URL MATCH match: Regex & url are:', ImprovedTube.regex.video_id, url), undefined);

--- a/js&css/web-accessible/www.youtube.com/player.js
+++ b/js&css/web-accessible/www.youtube.com/player.js
@@ -81,8 +81,9 @@ ImprovedTube.playerAutoPip = function () {
 PLAYBACK SPEED
 ------------------------------------------------------------------------------*/
 ImprovedTube.playbackSpeed = function (newSpeed) {
-	const video = this.elements.video,
-		player = this.elements.player,
+	const [player, video] = (document.documentElement.dataset.pageType === 'shorts')
+		? [this.elements.shorts_player, this.elements.shorts_player?.querySelector('video')]
+		: [this.elements.player, this.elements.video],
 		speed = video?.playbackRate ? Number(video.playbackRate.toFixed(2)) : (player?.getPlaybackRate ? Number(player.getPlaybackRate().toFixed(2)) : null);
 
 	if (!speed) {

--- a/js&css/web-accessible/www.youtube.com/shortcuts.js
+++ b/js&css/web-accessible/www.youtube.com/shortcuts.js
@@ -375,7 +375,7 @@ ImprovedTube.shortcutSeekPreviousChapter = function () {
 4.7.13 INCREASE VOLUME
 ------------------------------------------------------------------------------*/
 ImprovedTube.shortcutIncreaseVolume = function (decrease) {
-	const player = this.elements.player,
+	const player = (document.documentElement.dataset.pageType === 'shorts') ? this.elements.shorts_player : this.elements.player,
 		value = Number(this.storage.shortcuts_volume_step) || 5,
 		direction = decrease ? 'Decrease' : 'Increase';
 


### PR DESCRIPTION
## Summary

This PR adds support for keyboard shortcuts for playback speed and volume on YouTube Shorts.

Ref: #4306

## Changes

Previously, keyboard shortcuts for volume and playback speed were scoped primarily to regular watch pages, failing to recognize or apply to YouTube Shorts players.

- Updated volume and playback speed shortcut handlers to correctly detect and resolve the Shorts player and video elements when `dataset.pageType === 'shorts'`.
- Ensured shortcuts operate seamlessly on both standard watch pages and YouTube Shorts.

## Testing

- Verified that volume increase/decrease keyboard shortcuts work correctly on Shorts.
- Verified that playback speed increase/decrease/reset keyboard shortcuts work correctly on Shorts.
- Verified that standard player functionality continues to work correctly without regressions.

## Notes

I used AI assistance only for translating this PR description. I made the code changes and performed the testing myself.
