### PR TITLE
chore(locales): prune obsolete keys, remove duplicate in ja, and trim trailing whitespace

### DIFF
--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -224,14 +224,8 @@
     "columns": {
       "message": "Επιπλέον στήλη πλαϊνής μπάρας"
     },
-    "comment": {
-      "message": "Σχόλιο"
-    },
     "comments": {
       "message": "Σχόλια"
-    },
-    "community": {
-      "message": "Κοινότητα"
     },
     "compact_spacing": {
       "message": "Συμπαγής Διάταξη"
@@ -353,9 +347,6 @@
     "doNotChange": {
       "message": "Να μην αλλάξει"
     },
-    "Download": {
-      "message": "Λήψη"
-    },
     "draggable": {
       "message": "Μετακινήσιμο με σύρση"
     },
@@ -406,9 +397,6 @@
     },
     "fitToWindow": {
       "message": "Προσαρμογή στο παράθυρο"
-    },
-    "Focus": {
-      "message": "Εστίαση"
     },
     "flash": {
       "message": "Flash"
@@ -541,9 +529,6 @@
     },
     "hideHomePageShorts": {
       "message": "Απόκρυψη Shorts από την αρχική σελίδα"
-    },
-    "hide_Labels": {
-      "message": "Απόκρυψη ετικετών"
     },
     "hideMore": {
       "message": "Απόκρυψη περισσότερων"
@@ -722,9 +707,6 @@
     "markWatchedVideos": {
       "message": "Επισήμανση βίντεο που προβλήθηκαν"
     },
-    "maxWidthWithinThePage": {
-      "message": "Μέγ. πλάτος εντός της σελίδας"
-    },
     "medium": {
       "message": "Μεσαία"
     },
@@ -842,12 +824,6 @@
     "player_auto_hide_cinema_mode_when_paused": {
       "message": "Αυτόματη απόκρυψη λειτουργίας κινηματογράφου κατά την παύση"
     },
-    "player_autoplay_disable": {
-      "message": "Απενεργοποίηση αυτόματης αναπαραγωγής"
-    },
-    "player_auplayer_SDR": {
-      "message": "Αυτόματη επαναλαμβανόμενη λειτουργία SDR"
-    },
     "player_cinema_mode_button": {
       "message": "Κουμπί λειτουργίας κινηματογράφου"
     },
@@ -919,9 +895,6 @@
     },
     "remote": {
       "message": "Παίξε στην TV"
-    },
-    "remove": {
-      "message": "Αφαίρεση"
     },
     "removeBlackBars": {
       "message": "Κατάργηση μαύρων μπαρών"
@@ -1020,9 +993,6 @@
     },
     "shortcut_screenshot": {
       "message": "Στιγμιότυπο οθόνης"
-    },
-    "shorts": {
-      "message": "Shorts"
     },
     "showCardsOnMouseHover": {
       "message": "Εμφάνιση καρτών όταν ο κέρσορας είναι από πάνω"
@@ -1134,9 +1104,6 @@
     },
     "timeTo": {
       "message": "Χρόνος έως"
-    },
-    "Titles": {
-      "message": "Τίτλοι"
     },
     "todayAt": {
       "message": "Σήμερα στις"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -710,7 +710,7 @@
   },
   "hideLastframe": {
     "message": "Hide ended video (last frame)"
-  },  
+  },
   "hideFeaturedContent": {
     "message": "Hide featured content"
   },

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1613,9 +1613,6 @@
   "muteThumbnailPreviews": {
     "message": "サムネイルプレビューを消音"
   },
-  "displayDayOfTheWeak": {
-    "message": "曜日を表示"
-  },
   "playlistQuality": {
     "message": "プレイリスト再生時の画質"
   },

--- a/_locales/pt_PT/messages.json
+++ b/_locales/pt_PT/messages.json
@@ -215,9 +215,6 @@
     "confirmationBeforeClosing": {
         "message": "Confirmar antes de encerrar"
     },
-    "Cores": {
-        "message": "Núcleos"
-    },
     "cropChapterTitles": {
         "message": "ReCortar títulos do capítulos"
     },
@@ -829,9 +826,6 @@
     },
     "remote": {
         "message": "Assistir na TV"
-    },
-    "removeHomePageShorts": {
-        "message": "Remover Shorts da página inicial"
     },
     "removeRelatedSearchResults": {
         "message": "Remove resultados relacionado com a pesquisa"

--- a/_locales/zh/messages.json
+++ b/_locales/zh/messages.json
@@ -50,9 +50,6 @@
     "bug": {
         "message": "問題"
     },
-    "Buttons": {
-        "message": "按鈕"
-    },
     "cancel": {
         "message": "取消"
     },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -598,9 +598,6 @@
     "hiddenOnVideoPage": {
         "message": "在视频页面隐藏"
     },
-    "hideAiSummaries": {
-        "message": "隐藏 AI 摘要"
-    },
     "hide_author_avatars": {
         "message": "隐藏作者头像"
     },
@@ -738,9 +735,6 @@
     },
     "hideWatchedVideos": {
         "message": "隐藏已观看的视频"
-    },
-    "hideYouTubeLogo": {
-        "message": "隐藏 YouTube 徽标"
     },
     "high": {
         "message": "高"
@@ -1464,12 +1458,6 @@
     },
     "tryToReloadThePage": {
         "message": "请尝试重新加载页面"
-    },
-    "turnOff": {
-        "message": "关闭"
-    },
-    "turnOn": {
-        "message": "开启"
     },
     "type": {
         "message": "类型"

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -1,1568 +1,1556 @@
 {
     "about": {
-        "message": "關於" 
+        "message": "關於"
     },
     "shortsAlwaysShowButtons": {
-        "message": "Shorts 總是顯示控制按鈕" 
+        "message": "Shorts 總是顯示控制按鈕"
     },
     "shortsAlwaysShowCaptions": {
-        "message": "字幕按鈕" 
+        "message": "字幕按鈕"
     },
     "shortsAlwaysShowFullscreen": {
-        "message": "全螢幕按鈕" 
+        "message": "全螢幕按鈕"
     },
     "accept": {
-        "message": "接受" 
+        "message": "接受"
     },
     "activate": {
-        "message": "啟用" 
+        "message": "啟用"
     },
     "activateCaptions": {
-        "message": "啟用字幕" 
+        "message": "啟用字幕"
     },
     "activated": {
-        "message": "已啟用" 
+        "message": "已啟用"
     },
     "activatedFeatures": {
-        "message": "已啟用功能" 
+        "message": "已啟用功能"
     },
     "activateFitToWindow": {
-        "message": "適合視窗" 
+        "message": "適合視窗"
     },
     "activateFullscreen": {
-        "message": "啟用全螢幕" 
+        "message": "啟用全螢幕"
     },
     "activeFeatures": {
-        "message": "已啟用功能" 
+        "message": "已啟用功能"
     },
     "addScrollToTop": {
-        "message": "新增「回到頂端」按鈕" 
+        "message": "新增「回到頂端」按鈕"
     },
     "ads": {
-        "message": "影片廣告" 
+        "message": "影片廣告"
     },
     "all": {
-        "message": "全部" 
+        "message": "全部"
     },
     "allow": {
-        "message": "允許" 
+        "message": "允許"
     },
     "Allow_auto_generate": {
-        "message": "允許自動產生" 
+        "message": "允許自動產生"
     },
     "allow60fps": {
-        "message": "允許 60 FPS" 
+        "message": "允許 60 FPS"
     },
     "allYourSettingsWillBeErasedAndCanTBeRecovered": {
-        "message": "您的所有設定都會被刪除且無法還原" 
+        "message": "您的所有設定都會被刪除且無法還原"
     },
     "allYourShortcutsWillBeErasedAndCanTBeRecovered": {
-        "message": "您的所有快速鍵都會被刪除且無法還原" 
+        "message": "您的所有快速鍵都會被刪除且無法還原"
     },
     "always": {
-        "message": "一律" 
+        "message": "一律"
     },
     "alwaysActive": {
-        "message": "一律啟用" 
+        "message": "一律啟用"
     },
     "alwaysShowProgressBar": {
-        "message": "一律顯示進度列" 
+        "message": "一律顯示進度列"
     },
     "amber": {
-        "message": "琥珀色" 
+        "message": "琥珀色"
     },
     "ambientLighting": {
-        "message": "微光模式" 
+        "message": "微光模式"
     },
     "analytics": {
-        "message": "資料分析" 
+        "message": "資料分析"
     },
     "analyzer": {
-        "message": "觀看分析" 
+        "message": "觀看分析"
     },
     "animations": {
-        "message": "動畫" 
+        "message": "動畫"
     },
     "appearance": {
-        "message": "外觀" 
+        "message": "外觀"
     },
     "areYouSureYouWantToExportTheData": {
-        "message": "您確定要匯出資料嗎？" 
+        "message": "您確定要匯出資料嗎？"
     },
     "areYouSureYouWantToImportTheData": {
-        "message": "您確定要匯入資料嗎？" 
+        "message": "您確定要匯入資料嗎？"
     },
     "areYouSureYouWantToSyncTheData": {
-        "message": "您確定要同步目前設定嗎？" 
+        "message": "您確定要同步目前設定嗎？"
     },
     "ask": {
-        "message": "詢問 Gemini" 
+        "message": "詢問 Gemini"
     },
     "atHistory": {
-        "message": "「觀看紀錄」頁面也套用" 
+        "message": "「觀看紀錄」頁面也套用"
     },
     "atSubscriptions": {
-        "message": "「訂閱內容」頁面也套用" 
+        "message": "「訂閱內容」頁面也套用"
     },
     "atTrending": {
-        "message": "「發燒影片」頁面也套用" 
+        "message": "「發燒影片」頁面也套用"
     },
     "audio": {
-        "message": "音訊" 
+        "message": "音訊"
     },
     "audioFormats": {
-        "message": "音訊格式" 
+        "message": "音訊格式"
     },
     "auto": {
-        "message": "自動" 
+        "message": "自動"
     },
     "Auto_PiP_picture_in_picture": {
-        "message": "自動子母畫面" 
+        "message": "自動子母畫面"
     },
     "autoFullscreen": {
-        "message": "自動全螢幕" 
+        "message": "自動全螢幕"
     },
     "autopauseWhenSwitchingTabs": {
-        "message": "切換分頁時暫停播放" 
+        "message": "切換分頁時暫停播放"
     },
     "autoPictureInPicture": {
-        "message": "自動子母畫面" 
+        "message": "自動子母畫面"
     },
     "autoplay": {
-        "message": "自動播放" 
+        "message": "自動播放"
     },
     "autoplayDisable": {
-        "message": "強制停用自動播放" 
+        "message": "強制停用自動播放"
     },
     "autoPlayNextShort": {
-        "message": "自動播放 Shorts" 
+        "message": "自動播放 Shorts"
     },
     "avoidAv1": {
-        "message": "避免 AV1 編碼" 
+        "message": "避免 AV1 編碼"
     },
     "avoidAv1Vp8Vp9": {
-        "message": "避免 AV1、VP8 與 VP9 編碼" 
+        "message": "避免 AV1、VP8 與 VP9 編碼"
     },
     "avoidAv1Vp9": {
-        "message": "避免 AV1 與 VP9 編碼" 
+        "message": "避免 AV1 與 VP9 編碼"
     },
     "avoidCpuRenderingWhenPossible": {
-        "message": "盡可能避免 CPU 算圖" 
+        "message": "盡可能避免 CPU 算圖"
     },
     "backgroundColor": {
-        "message": "背景顏色" 
+        "message": "背景顏色"
     },
     "backgroundOpacity": {
-        "message": "背景不透明度" 
+        "message": "背景不透明度"
     },
     "backupAndReset": {
-        "message": "備份與重設" 
+        "message": "備份與重設"
     },
     "baseOnSystemColorScheme": {
-        "message": "使用系統配色方案" 
+        "message": "使用系統配色方案"
     },
     "belowPlayer": {
-        "message": "於播放器下方" 
+        "message": "於播放器下方"
     },
     "bitness": {
-        "message": "系統位元數" 
+        "message": "系統位元數"
     },
     "black": {
-        "message": "黑色" 
+        "message": "黑色"
     },
     "block_Codec_Alert_h264": {
-        "message": "您需要啟用 H.264 或 VP9 編碼才能播放 YouTube 影片" 
+        "message": "您需要啟用 H.264 或 VP9 編碼才能播放 YouTube 影片"
     },
     "block_Codec_Alert_VP9": {
-        "message": "您需要啟用 VP9 或 H.264 編碼才能播放 YouTube 影片" 
+        "message": "您需要啟用 VP9 或 H.264 編碼才能播放 YouTube 影片"
     },
     "blockAll": {
-        "message": "封鎖所有" 
+        "message": "封鎖所有"
     },
     "blockAv1": {
-        "message": "停用 AV1 編碼" 
+        "message": "停用 AV1 編碼"
     },
     "blockH264": {
-        "message": "停用 H.264 編碼" 
+        "message": "停用 H.264 編碼"
     },
     "blocklist": {
-        "message": "黑名單" 
+        "message": "黑名單"
     },
     "blockMusic": {
-        "message": "播放音樂時跳過" 
+        "message": "播放音樂時跳過"
     },
     "blockVp8": {
-        "message": "停用 VP8 編碼" 
+        "message": "停用 VP8 編碼"
     },
     "blockVp9": {
-        "message": "停用 VP9 編碼" 
+        "message": "停用 VP9 編碼"
     },
     "blue": {
-        "message": "藍色" 
+        "message": "藍色"
     },
     "blueGray": {
-        "message": "藍灰色" 
+        "message": "藍灰色"
     },
     "bluelight": {
-        "message": "藍光" 
+        "message": "藍光"
     },
     "bottomLeft": {
-        "message": "左下" 
+        "message": "左下"
     },
     "bottomRight": {
-        "message": "右下" 
+        "message": "右下"
     },
     "brightness": {
-        "message": "亮度" 
+        "message": "亮度"
     },
     "brown": {
-        "message": "棕色" 
+        "message": "棕色"
     },
     "browser": {
-        "message": "瀏覽器" 
+        "message": "瀏覽器"
     },
     "browserAccountSync": {
-        "message": "同步「瀏覽器帳戶」" 
+        "message": "同步「瀏覽器帳戶」"
     },
     "browserVersion": {
-        "message": "瀏覽器版本" 
+        "message": "瀏覽器版本"
     },
     "bubbles": {
-        "message": "泡泡" 
+        "message": "泡泡"
     },
     "bulkDeleteByProgress": {
-        "message": "依觀看進度批次刪除影片" 
+        "message": "依觀看進度批次刪除影片"
     },
     "buttons": {
-        "message": "按鈕" 
+        "message": "按鈕"
     },
     "cancel": {
-        "message": "取消" 
+        "message": "取消"
     },
     "categories": {
-        "message": "類別" 
+        "message": "類別"
     },
     "categoryRefreshButton": {
-        "message": "新增類別重新整理按鈕" 
+        "message": "新增類別重新整理按鈕"
     },
     "changeThumbnailsPerRow": {
-        "message": "每行縮圖數量" 
+        "message": "每行縮圖數量"
     },
     "channel": {
-        "message": "頻道" 
+        "message": "頻道"
     },
     "channels": {
-        "message": "頻道" 
+        "message": "頻道"
     },
     "chapters": {
-        "message": "章節" 
+        "message": "章節"
     },
     "chapterTitle": {
-        "message": "章節標題" 
+        "message": "章節標題"
     },
     "characterEdgeStyle": {
-        "message": "字元邊緣樣式" 
+        "message": "字元邊緣樣式"
     },
     "cinemaMode": {
-        "message": "劇院模式" 
+        "message": "劇院模式"
     },
     "clickableLinksInDescription": {
-        "message": "按滑鼠右鍵複製影片說明中的連結" 
+        "message": "按滑鼠右鍵複製影片說明中的連結"
     },
     "clip": {
-        "message": "剪輯" 
+        "message": "剪輯"
     },
     "clipboard": {
-        "message": "剪貼簿" 
+        "message": "剪貼簿"
     },
     "codecH264": {
-        "message": "強制使用 H.264 編碼" 
+        "message": "強制使用 H.264 編碼"
     },
     "codecs": {
-        "message": "編碼" 
+        "message": "編碼"
     },
     "collapsed": {
-        "message": "折疊" 
+        "message": "折疊"
     },
     "collapseOfSubscriptionSections": {
-        "message": "折疊訂閱區塊" 
+        "message": "折疊訂閱區塊"
     },
     "columns": {
-        "message": "額外側邊欄直列「如果視窗夠寬，可避免移動相關影片」" 
+        "message": "額外側邊欄直列「如果視窗夠寬，可避免移動相關影片」"
     },
     "comments": {
-        "message": "留言" 
+        "message": "留言"
     },
     "compact_spacing": {
-        "message": "密集間距" 
+        "message": "密集間距"
     },
     "compactTheme": {
-        "message": "密集主題" 
+        "message": "密集主題"
     },
     "confirmationBeforeClosing": {
-        "message": "關閉頁面前確認" 
+        "message": "關閉頁面前確認"
     },
     "copyVideoId": {
-        "message": "複製影片 ID" 
+        "message": "複製影片 ID"
     },
     "copyVideoUrl": {
-        "message": "複製影片完整網址" 
+        "message": "複製影片完整網址"
     },
     "cores": {
-        "message": "核心數" 
+        "message": "核心數"
     },
     "cropChapterTitles": {
-        "message": "裁切章節標題" 
+        "message": "裁切章節標題"
     },
     "Currently_requiring_a_YouTube_API_key": {
-        "message": "「目前需要 Youtube API 金鑰：」" 
+        "message": "「目前需要 Youtube API 金鑰：」"
     },
     "cursorLighting": {
-        "message": "滑鼠聚光燈「在目前頁面上模糊滑鼠所在位置以外的其他元素」" 
+        "message": "滑鼠聚光燈「在目前頁面上模糊滑鼠所在位置以外的其他元素」"
     },
     "custom": {
-        "message": "自訂" 
+        "message": "自訂"
     },
     "customCss": {
-        "message": "自訂 CSS" 
+        "message": "自訂 CSS"
     },
     "customJs": {
-        "message": "自訂 JS" 
+        "message": "自訂 JS"
     },
     "customMiniPlayer": {
-        "message": "自訂迷你播放器" 
+        "message": "自訂迷你播放器"
     },
     "cyan": {
-        "message": "青色" 
+        "message": "青色"
     },
     "dark": {
-        "message": "深色" 
+        "message": "深色"
     },
     "darkTheme": {
-        "message": "深色主題" 
+        "message": "深色主題"
     },
     "dateAndTime": {
-        "message": "日期與時間" 
+        "message": "日期與時間"
     },
     "dawn": {
-        "message": "黎明" 
+        "message": "黎明"
     },
     "decreasePlaybackSpeed": {
-        "message": "降低播放速度" 
+        "message": "降低播放速度"
     },
     "decreaseVolume": {
-        "message": "降低音量" 
+        "message": "降低音量"
     },
     "deepOrange": {
-        "message": "深橙色" 
+        "message": "深橙色"
     },
     "deepPurple": {
-        "message": "深紫色" 
+        "message": "深紫色"
     },
     "default": {
-        "message": "預設" 
+        "message": "預設"
     },
     "default_CC": {
-        "message": "預設" 
+        "message": "預設"
     },
     "default_theme": {
-        "message": "預設" 
+        "message": "預設"
     },
     "defaultChannelTab": {
-        "message": "預設頻道分頁" 
+        "message": "預設頻道分頁"
     },
     "defaultContentCountry": {
-        "message": "預設顯示內容的地區" 
+        "message": "預設顯示內容的地區"
     },
     "defaultPlaybackSpeed": {
-        "message": "預設播放速度" 
+        "message": "預設播放速度"
     },
     "deleteWatchedVideos": {
-        "message": "刪除已觀看的影片" 
+        "message": "刪除已觀看的影片"
     },
     "deleteYoutubeCookies": {
-        "message": "清除 YouTube 的 Cookie" 
+        "message": "清除 YouTube 的 Cookie"
     },
     "depressed": {
-        "message": "按下" 
+        "message": "按下"
     },
     "description": {
-        "message": "說明" 
+        "message": "說明"
     },
     "description_ext": {
-        "message": "YouTube，整潔又智慧？讓 YouTube 更強大！賦予它強大的功能，只篩選您想要的影片，並呈現您喜愛的介面風格" 
+        "message": "YouTube，整潔又智慧？讓 YouTube 更強大！賦予它強大的功能，只篩選您想要的影片，並呈現您喜愛的介面風格"
     },
     "desert": {
-        "message": "沙漠" 
+        "message": "沙漠"
     },
     "details": {
-        "message": "詳細資訊" 
+        "message": "詳細資訊"
     },
     "developerOptions": {
-        "message": "開發人員選項" 
+        "message": "開發人員選項"
     },
     "device": {
-        "message": "裝置" 
+        "message": "裝置"
     },
     "dim": {
-        "message": "背景昏暗度" 
+        "message": "背景昏暗度"
     },
     "disableAutoDubbing": {
-        "message": "停用自動配音" 
+        "message": "停用自動配音"
     },
     "disabled": {
-        "message": "停用" 
+        "message": "停用"
     },
     "disableLikesAnimation": {
-        "message": "停用按讚動畫" 
+        "message": "停用按讚動畫"
     },
     "disableThumbnailPlayback": {
-        "message": "停用滑鼠懸停縮圖時預覽影片" 
+        "message": "停用滑鼠懸停縮圖時預覽影片"
     },
     "dislike": {
-        "message": "不喜歡" 
+        "message": "不喜歡"
     },
     "dislikingAVideoAddsItToBlocklist": {
-        "message": "將「不喜歡」的影片自動加入黑名單" 
+        "message": "將「不喜歡」的影片自動加入黑名單"
     },
     "displayDayOfTheWeak": {
-        "message": "顯示星期幾" 
+        "message": "顯示星期幾"
     },
     "donate": {
-        "message": "捐贈" 
+        "message": "捐贈"
     },
     "doNotChange": {
-        "message": "不變更" 
+        "message": "不變更"
     },
     "download": {
-        "message": "下載" 
+        "message": "下載"
     },
     "draggable": {
-        "message": "可拖曳" 
+        "message": "可拖曳"
     },
     "dropShadow": {
-        "message": "陰影效果" 
+        "message": "陰影效果"
     },
     "durationWithSpeed": {
-        "message": "根據播放速度顯示剩餘時間" 
+        "message": "根據播放速度顯示剩餘時間"
     },
     "embedded_Hide_Share": {
-        "message": "內嵌影片隱藏「分享」" 
+        "message": "內嵌影片隱藏「分享」"
     },
     "Embedded_YouTube": {
-        "message": "內嵌 YouTube" 
+        "message": "內嵌 YouTube"
     },
     "empty": {
-        "message": "空白" 
+        "message": "空白"
     },
     "enabled": {
-        "message": "啟用" 
+        "message": "啟用"
     },
     "enabledForced": {
-        "message": "強制啟用" 
+        "message": "強制啟用"
     },
     "enterPassword": {
-        "message": "請輸入您的四位數密碼" 
+        "message": "請輸入您的四位數密碼"
     },
     "exact": {
-        "message": "準確日期/時間" 
+        "message": "準確日期/時間"
     },
     "excludeShortsInPlayAll": {
-        "message": "使用「全部播放」時排除 Shorts" 
+        "message": "使用「全部播放」時排除 Shorts"
     },
     "expanded": {
-        "message": "展開" 
+        "message": "展開"
     },
     "exportSettings": {
-        "message": "匯出設定" 
+        "message": "匯出設定"
     },
     "extension": {
-        "message": "擴充功能" 
+        "message": "擴充功能"
     },
     "ExtraButtons": {
-        "message": "額外按鈕" 
+        "message": "額外按鈕"
     },
     "extraButtonsBelowThePlayer": {
-        "message": "播放器下方的額外按鈕" 
+        "message": "播放器下方的額外按鈕"
     },
     "extraRightControlButtons": {
-        "message": "播放器內部的額外按鈕" 
+        "message": "播放器內部的額外按鈕"
     },
     "Feature_not_yet_available": {
-        "message": "功能暫不可用" 
+        "message": "功能暫不可用"
     },
     "file": {
-        "message": "檔案" 
+        "message": "檔案"
     },
     "filters": {
-        "message": "濾鏡" 
+        "message": "濾鏡"
     },
     "fitToWindow": {
-        "message": "適合視窗" 
+        "message": "適合視窗"
     },
     "flash": {
-        "message": "是否使用 Flash" 
+        "message": "是否使用 Flash"
     },
     "font": {
-        "message": "字型" 
+        "message": "字型"
     },
     "fontColor": {
-        "message": "字型顏色" 
+        "message": "字型顏色"
     },
     "fontFamily": {
-        "message": "字型" 
+        "message": "字型"
     },
     "fontOpacity": {
-        "message": "字型不透明度" 
+        "message": "字型不透明度"
     },
     "fontSize": {
-        "message": "字型大小" 
+        "message": "字型大小"
     },
     "footer": {
-        "message": "頁尾" 
+        "message": "頁尾"
     },
     "forcedPlaybackSpeed": {
-        "message": "強制播放速度" 
+        "message": "強制播放速度"
     },
     "forcedPlaybackSpeedMusic": {
-        "message": "音樂也強制套用播放速度" 
+        "message": "音樂也強制套用播放速度"
     },
     "forcedPlayVideoFromTheBeginning": {
-        "message": "強制從頭播放" 
+        "message": "強制從頭播放"
     },
     "forcedTheaterMode": {
-        "message": "強制劇院模式" 
+        "message": "強制劇院模式"
     },
     "forcedVolume": {
-        "message": "強制播放音量" 
+        "message": "強制播放音量"
     },
     "forceSDR": {
-        "message": "強制使用標準動態範圍 (SDR)" 
+        "message": "強制使用標準動態範圍 (SDR)"
     },
     "foundABug": {
-        "message": "遇到問題了嗎？" 
+        "message": "遇到問題了嗎？"
     },
     "fullScreenQuality": {
-        "message": "全螢幕畫質" 
+        "message": "全螢幕畫質"
     },
     "fullscreenReturn": {
-        "message": "全螢幕返回" 
+        "message": "全螢幕返回"
     },
     "fullWindow": {
-        "message": "全螢幕視窗" 
+        "message": "全螢幕視窗"
     },
     "general": {
-        "message": "一般" 
+        "message": "一般"
     },
     "geoPreference": {
-        "message": "地區偏好" 
+        "message": "地區偏好"
     },
     "googleApiKey": {
-        "message": "Google API 金鑰" 
+        "message": "Google API 金鑰"
     },
     "goToSearchBox": {
-        "message": "移至搜尋框" 
+        "message": "移至搜尋框"
     },
     "GPUnotindatabase": {
-        "message": "GPU 不在資料庫內" 
+        "message": "GPU 不在資料庫內"
     },
     "green": {
-        "message": "綠色" 
+        "message": "綠色"
     },
     "grey": {
-        "message": "灰色" 
+        "message": "灰色"
     },
     "halfTransparent": {
-        "message": "半透明" 
+        "message": "半透明"
     },
     "Hamburger_Menu": {
-        "message": "漢堡選單" 
+        "message": "漢堡選單"
     },
     "hardwareInformation": {
-        "message": "硬體資訊" 
+        "message": "硬體資訊"
     },
     "hd": {
-        "message": "高畫質 (HD)" 
+        "message": "高畫質 (HD)"
     },
     "hdThumbnail": {
-        "message": "高畫質縮圖" 
+        "message": "高畫質縮圖"
     },
     "header": {
-        "message": "頁首" 
+        "message": "頁首"
     },
     "hidden": {
-        "message": "隱藏" 
+        "message": "隱藏"
     },
     "hiddenOnVideoPage": {
-        "message": "在影片頁面隱藏" 
-    },
-    "hideAiSummaries": {
-        "message": "隱藏 AI 摘要" 
+        "message": "在影片頁面隱藏"
     },
     "hide_author_avatars": {
-        "message": "隱藏作者圖示" 
+        "message": "隱藏作者圖示"
     },
     "hide_labels": {
-        "message": "隱藏名稱" 
+        "message": "隱藏名稱"
     },
     "Hide_Pause_Overlay": {
-        "message": "隱藏暫停疊加層" 
+        "message": "隱藏暫停疊加層"
     },
     "Hide_Shorts_remixing_this_video": {
-        "message": "隱藏重新混音此影片的 Shorts" 
+        "message": "隱藏重新混音此影片的 Shorts"
     },
     "Hide_sidebar": {
-        "message": "隱藏側邊欄" 
+        "message": "隱藏側邊欄"
     },
     "Hide_the_tabs_only": {
-        "message": "僅隱藏分頁" 
+        "message": "僅隱藏分頁"
     },
     "Hide_YouTube_Logo": {
-        "message": "隱藏 YouTube 標誌" 
+        "message": "隱藏 YouTube 標誌"
     },
     "hideAISummary": {
-        "message": "隱藏 AI 摘要" 
+        "message": "隱藏 AI 摘要"
     },
     "hideAnimatedThumbnails": {
-        "message": "隱藏動態縮圖" 
+        "message": "隱藏動態縮圖"
     },
     "hideAnnotations": {
-        "message": "隱藏影片註解" 
+        "message": "隱藏影片註解"
     },
     "hideBannerAds": {
-        "message": "隱藏橫幅廣告「可能會被 YouTube 阻擋」" 
+        "message": "隱藏橫幅廣告「可能會被 YouTube 阻擋」"
     },
     "hideCards": {
-        "message": "隱藏資訊卡" 
+        "message": "隱藏資訊卡"
     },
     "hideCategories": {
-        "message": "隱藏類別" 
+        "message": "隱藏類別"
     },
     "hideCommentsCount": {
-        "message": "隱藏留言數量" 
+        "message": "隱藏留言數量"
     },
     "hideCountryCode": {
-        "message": "隱藏國家地區代碼" 
+        "message": "隱藏國家地區代碼"
     },
     "hideDate": {
-        "message": "隱藏日期" 
+        "message": "隱藏日期"
     },
     "hideDetailButton": {
-        "message": "隱藏詳細資訊按鈕" 
+        "message": "隱藏詳細資訊按鈕"
     },
     "hideDetails": {
-        "message": "隱藏詳細資訊" 
+        "message": "隱藏詳細資訊"
     },
     "hideEndscreen": {
-        "message": "隱藏片尾畫面" 
+        "message": "隱藏片尾畫面"
     },
     "hideFeaturedContent": {
-        "message": "隱藏精選影片" 
+        "message": "隱藏精選影片"
     },
     "hideFooter": {
-        "message": "隱藏頁尾" 
+        "message": "隱藏頁尾"
     },
     "hideGradientBottom": {
-        "message": "隱藏底部漸層" 
+        "message": "隱藏底部漸層"
     },
     "hideHomePageShorts": {
-        "message": "隱藏首頁的 Shorts" 
+        "message": "隱藏首頁的 Shorts"
     },
     "hideIncludesPaidPromotion": {
-        "message": "隱藏「包含付費宣傳內容」提示" 
+        "message": "隱藏「包含付費宣傳內容」提示"
     },
     "hideLogo": {
-        "message": "隱藏標誌" 
+        "message": "隱藏標誌"
     },
     "hideMore": {
-        "message": "隱藏「...」(更多)" 
+        "message": "隱藏「...」(更多)"
     },
     "hidePauseOverlay": {
-        "message": "隱藏暫停疊加層" 
+        "message": "隱藏暫停疊加層"
     },
     "hidePlayerControlsBar": {
-        "message": "隱藏播放器控制列" 
+        "message": "隱藏播放器控制列"
     },
     "hidePlayerControlsBarButtons": {
-        "message": "隱藏播放控制按鈕" 
+        "message": "隱藏播放控制按鈕"
     },
     "hidePlayerControlsBarOptions": {
-        "message": "隱藏播放控制選項" 
+        "message": "隱藏播放控制選項"
     },
     "hidePlaylist": {
-        "message": "隱藏播放清單" 
+        "message": "隱藏播放清單"
     },
     "hideProgressBarPreview": {
-        "message": "隱藏進度列預覽" 
+        "message": "隱藏進度列預覽"
     },
     "hideReport": {
-        "message": "隱藏「檢舉」" 
+        "message": "隱藏「檢舉」"
     },
     "hideRightButtons": {
-        "message": "隱藏右側按鈕" 
+        "message": "隱藏右側按鈕"
     },
     "hideScrollForDetails": {
-        "message": "隱藏「向下捲動即可檢視詳細資訊」" 
+        "message": "隱藏「向下捲動即可檢視詳細資訊」"
     },
     "hideSkipOverlay": {
-        "message": "隱藏略過按鈕" 
+        "message": "隱藏略過按鈕"
     },
     "hideSponsoredVideosOnHome": {
-        "message": "隱藏首頁的贊助影片" 
+        "message": "隱藏首頁的贊助影片"
     },
     "hideThumbnailDots": {
-        "message": "隱藏縮圖上的「⫶」(更多動作) 按鈕" 
+        "message": "隱藏縮圖上的「⫶」(更多動作) 按鈕"
     },
     "hideThumbnailIcon": {
-        "message": "隱藏縮圖上的作者圖示" 
+        "message": "隱藏縮圖上的作者圖示"
     },
     "hideThumbnailOverlay": {
-        "message": "隱藏縮圖上的按鈕" 
+        "message": "隱藏縮圖上的按鈕"
     },
     "hideThumbnails": {
-        "message": "隱藏縮圖" 
+        "message": "隱藏縮圖"
     },
     "hideTopLoadingBar": {
-        "message": "隱藏頂部載入進度列" 
+        "message": "隱藏頂部載入進度列"
     },
     "hideVideoTitleFullScreen": {
-        "message": "全螢幕模式隱藏影片標題" 
+        "message": "全螢幕模式隱藏影片標題"
     },
     "hideViewsCount": {
-        "message": "隱藏觀看次數" 
+        "message": "隱藏觀看次數"
     },
     "hideVoiceSearchButton": {
-        "message": "隱藏語音搜尋按鈕" 
+        "message": "隱藏語音搜尋按鈕"
     },
     "hideWatchedVideos": {
-        "message": "隱藏已觀看的影片" 
-    },
-    "hideYouTubeLogo": {
-        "message": "隱藏 YouTube 標誌" 
+        "message": "隱藏已觀看的影片"
     },
     "high": {
-        "message": "高" 
+        "message": "高"
     },
     "history": {
-        "message": "觀看紀錄" 
+        "message": "觀看紀錄"
     },
     "home": {
-        "message": "首頁" 
+        "message": "首頁"
     },
     "homeScreen": {
-        "message": "主畫面" 
+        "message": "主畫面"
     },
     "hover": {
-        "message": "滑鼠暫留時顯示" 
+        "message": "滑鼠暫留時顯示"
     },
     "hoverOnVideoPage": {
-        "message": "於影片頁面滑鼠懸停時顯示" 
+        "message": "於影片頁面滑鼠懸停時顯示"
     },
     "howLongAgoTheVideoWasUploaded": {
-        "message": "顯示影片上傳時間" 
+        "message": "顯示影片上傳時間"
     },
     "icons": {
-        "message": "圖示" 
+        "message": "圖示"
     },
     "iconsOnly": {
-        "message": "僅圖示" 
+        "message": "僅圖示"
     },
     "importSettings": {
-        "message": "匯入設定" 
+        "message": "匯入設定"
     },
     "improvedtubeButtons": {
-        "message": "ImprovedTube 按鈕" 
+        "message": "ImprovedTube 按鈕"
     },
     "improvedtubeIconOnYoutube": {
-        "message": "於 YouTube 上顯示 ImprovedTube 圖示" 
+        "message": "於 YouTube 上顯示 ImprovedTube 圖示"
     },
     "improvedtubeLanguage": {
-        "message": "ImprovedTube 語言" 
+        "message": "ImprovedTube 語言"
     },
     "improvedTubeSidePanel": {
-        "message": "ImprovedTube 瀏覽器側邊欄" 
+        "message": "ImprovedTube 瀏覽器側邊欄"
     },
     "improvedtubeVersion": {
-        "message": "ImprovedTube 版本" 
+        "message": "ImprovedTube 版本"
     },
     "improveLogo": {
-        "message": "改進 YouTube 圖示" 
+        "message": "改進 YouTube 圖示"
     },
     "increasePlaybackSpeed": {
-        "message": "加快播放速度" 
+        "message": "加快播放速度"
     },
     "increaseVolume": {
-        "message": "提高音量" 
+        "message": "提高音量"
     },
     "indigo": {
-        "message": "靛青色" 
+        "message": "靛青色"
     },
     "items": {
-        "message": "專案" 
+        "message": "專案"
     },
     "join": {
-        "message": "加入" 
+        "message": "加入"
     },
     "keyScene": {
-        "message": "⚡跳至「最多人重播」" 
+        "message": "⚡跳至「最多人重播」"
     },
     "language": {
-        "message": "語言" 
+        "message": "語言"
     },
     "language_closed_caption": {
-        "message": "字幕預設語言" 
+        "message": "字幕預設語言"
     },
     "languages": {
-        "message": "語言" 
+        "message": "語言"
     },
     "lastWatchedFormat": {
-        "message": "時間格式" 
+        "message": "時間格式"
     },
     "lastWatchedOverlayPosition": {
-        "message": "疊加層位置" 
+        "message": "疊加層位置"
     },
     "layerAnimationScale": {
-        "message": "圖層動畫縮放" 
+        "message": "圖層動畫縮放"
     },
     "layout": {
-        "message": "版面配置" 
+        "message": "版面配置"
     },
     "Left_Side_Menu": {
-        "message": "左側選單" 
+        "message": "左側選單"
     },
     "legacyYoutube": {
-        "message": "舊版 YouTube" 
+        "message": "舊版 YouTube"
     },
     "library": {
-        "message": "媒體庫" 
+        "message": "媒體庫"
     },
     "light": {
-        "message": "淺色" 
+        "message": "淺色"
     },
     "lightBlue": {
-        "message": "淺藍色" 
+        "message": "淺藍色"
     },
     "lightGreen": {
-        "message": "淺綠色" 
+        "message": "淺綠色"
     },
     "like": {
-        "message": "喜歡" 
+        "message": "喜歡"
     },
     "liked": {
-        "message": "已按讚" 
+        "message": "已按讚"
     },
     "likes": {
-        "message": "喜歡" 
+        "message": "喜歡"
     },
     "lime": {
-        "message": "萊姆色" 
+        "message": "萊姆色"
     },
     "limitPageWidth": {
-        "message": "限制頁面寬度" 
+        "message": "限制頁面寬度"
     },
     "list": {
-        "message": "清單" 
+        "message": "清單"
     },
     "liveChat": {
-        "message": "直播聊天室" 
+        "message": "直播聊天室"
     },
     "liveChatType": {
-        "message": "直播聊天室類型" 
+        "message": "直播聊天室類型"
     },
     "location": {
-        "message": "地區" 
+        "message": "地區"
     },
     "loop": {
-        "message": "🔁循環播放" 
+        "message": "🔁循環播放"
     },
     "loudnessNormalization": {
-        "message": "響度標準化" 
+        "message": "響度標準化"
     },
     "low": {
-        "message": "低" 
+        "message": "低"
     },
     "markWatchedVideos": {
-        "message": "標記已觀看影片" 
+        "message": "標記已觀看影片"
     },
     "medium": {
-        "message": "中" 
+        "message": "中"
     },
     "mixer": {
-        "message": "混音器" 
+        "message": "混音器"
     },
     "more": {
-        "message": "更多" 
+        "message": "更多"
     },
     "mostViewedChannels": {
-        "message": "最常觀看的頻道" 
+        "message": "最常觀看的頻道"
     },
     "moveSidebarLeft": {
-        "message": "移至左側" 
+        "message": "移至左側"
     },
     "moveThumbnailsRight": {
-        "message": "縮圖移至右側" 
+        "message": "縮圖移至右側"
     },
     "My_specs": {
-        "message": "自訂配備" 
+        "message": "自訂配備"
     },
     "myColors": {
-        "message": "自訂主色" 
+        "message": "自訂主色"
     },
     "name": {
-        "message": "名稱" 
+        "message": "名稱"
     },
     "nativeMiniPlayer": {
-        "message": "原生迷你播放器" 
+        "message": "原生迷你播放器"
     },
     "new": {
-        "message": "新" 
+        "message": "新"
     },
     "nextVideo": {
-        "message": "下一部影片" 
+        "message": "下一部影片"
     },
     "night": {
-        "message": "夜晚" 
+        "message": "夜晚"
     },
     "nightMode": {
-        "message": "深色主題" 
+        "message": "深色主題"
     },
     "noActiveFeatures": {
-        "message": "無已啟用功能" 
+        "message": "無已啟用功能"
     },
     "none": {
-        "message": "無" 
+        "message": "無"
     },
     "noOpenVideoTabs": {
-        "message": "無已開啟的影片分頁" 
+        "message": "無已開啟的影片分頁"
     },
     "normal": {
-        "message": "一般" 
+        "message": "一般"
     },
     "Not_optimal": {
-        "message": "非最佳" 
+        "message": "非最佳"
     },
     "off": {
-        "message": "關閉" 
+        "message": "關閉"
     },
     "ok": {
-        "message": "確定" 
+        "message": "確定"
     },
     "old": {
-        "message": "舊" 
+        "message": "舊"
     },
     "onAllVideos": {
-        "message": "不進行封鎖" 
+        "message": "不進行封鎖"
     },
     "onlyActiveOnYoutube": {
-        "message": "僅在 YouTube 上啟用" 
+        "message": "僅在 YouTube 上啟用"
     },
     "onlyOnePlayerInstancePlaying": {
-        "message": "同時間僅限播放單一影片" 
+        "message": "同時間僅限播放單一影片"
     },
     "onSmallCreators": {
-        "message": "除小眾 YouTube 頻道外，封鎖所有" 
+        "message": "除小眾 YouTube 頻道外，封鎖所有"
     },
     "onSubscribedChannels": {
-        "message": "除已訂閱頻道外，封鎖所有" 
+        "message": "除已訂閱頻道外，封鎖所有"
     },
     "openPopupPlayer": {
-        "message": "在新視窗中開啟影片或播放清單" 
+        "message": "在新視窗中開啟影片或播放清單"
     },
     "Optimal": {
-        "message": "最佳" 
+        "message": "最佳"
     },
     "optimizeCodecForHardwareAcceleration": {
-        "message": "為硬體加速最佳化編碼" 
+        "message": "為硬體加速最佳化編碼"
     },
     "orange": {
-        "message": "橙色" 
+        "message": "橙色"
     },
     "os": {
-        "message": "作業系統" 
+        "message": "作業系統"
     },
     "other": {
-        "message": "其他" 
+        "message": "其他"
     },
     "outline": {
-        "message": "外框" 
+        "message": "外框"
     },
     "overlay": {
-        "message": "疊加層" 
+        "message": "疊加層"
     },
     "passwordOptions": {
-        "message": "密碼選項" 
+        "message": "密碼選項"
     },
     "pauseWhileIAmTypingOnYouTube": {
-        "message": "在 YouTube 上打字時暫停" 
+        "message": "在 YouTube 上打字時暫停"
     },
     "pauseWhileIUnplugTheCharger": {
-        "message": "拔下充電器時暫停" 
+        "message": "拔下充電器時暫停"
     },
     "permissions": {
-        "message": "權限" 
+        "message": "權限"
     },
     "pictureInPicture": {
-        "message": "子母畫面" 
+        "message": "子母畫面"
     },
     "pink": {
-        "message": "粉紅色" 
+        "message": "粉紅色"
     },
     "PipRequiresUserInteraction": {
-        "message": "子母畫面需要使用者近期與來源頁面進行互動。這是 Chrome 子母畫面 API 的限制，我們無法規避。為了達到最佳效果，請關閉自動播放功能並手動控制播放，或在切換分頁前點擊頁面任意位置。" 
+        "message": "子母畫面需要使用者近期與來源頁面進行互動。這是 Chrome 子母畫面 API 的限制，我們無法規避。為了達到最佳效果，請關閉自動播放功能並手動控制播放，或在切換分頁前點擊頁面任意位置。"
     },
     "plain": {
-        "message": "簡約" 
+        "message": "簡約"
     },
     "platform": {
-        "message": "平台" 
+        "message": "平台"
     },
     "playAllButton": {
-        "message": "「全部播放」按鈕" 
+        "message": "「全部播放」按鈕"
     },
     "playbackSpeed": {
-        "message": "播放速度" 
+        "message": "播放速度"
     },
     "playbackSpeedButton": {
-        "message": "播放速度按鈕" 
+        "message": "播放速度按鈕"
     },
     "playbackSpeedHotkey": {
-        "message": "播放速度快速鍵" 
+        "message": "播放速度快速鍵"
     },
     "player": {
-        "message": "播放器" 
+        "message": "播放器"
     },
     "player_auto_cinema_mode": {
-        "message": "自動劇院模式" 
+        "message": "自動劇院模式"
     },
     "player_auto_hide_cinema_mode_when_paused": {
-        "message": "暫停時自動隱藏劇院模式" 
+        "message": "暫停時自動隱藏劇院模式"
     },
     "player_cinema_mode_button": {
-        "message": "劇院模式 (ImprovedTube)" 
+        "message": "劇院模式 (ImprovedTube)"
     },
     "player_dont_speed_education": {
-        "message": "不要加速「不常見」類別：教育" 
+        "message": "不要加速「不常見」類別：教育"
     },
     "player_fit_to_win_button": {
-        "message": "播放器適合視窗按鈕" 
+        "message": "播放器適合視窗按鈕"
     },
     "player_rewind_and_forward_buttons": {
-        "message": "播放器快轉倒轉按鈕" 
+        "message": "播放器快轉倒轉按鈕"
     },
     "player_rotate_button": {
-        "message": "播放器旋轉影片按鈕" 
+        "message": "播放器旋轉影片按鈕"
     },
     "playerAutoPipOutside": {
-        "message": "僅在來源分頁外自動進入子母畫面" 
+        "message": "僅在來源分頁外自動進入子母畫面"
     },
     "playerColor": {
-        "message": "影片進度列顏色" 
+        "message": "影片進度列顏色"
     },
     "playerIncreaseDecreaseSpeedButtons": {
-        "message": "播放器加減速按鈕" 
+        "message": "播放器加減速按鈕"
     },
     "playerPlaybackSpeedStep": {
-        "message": "播放速度級距" 
+        "message": "播放速度級距"
     },
     "playerSize": {
-        "message": "播放器大小" 
+        "message": "播放器大小"
     },
     "playlist": {
-        "message": "播放清單" 
+        "message": "播放清單"
     },
     "playlists": {
-        "message": "播放清單" 
+        "message": "播放清單"
     },
     "playPause": {
-        "message": "播放/暫停" 
+        "message": "播放/暫停"
     },
     "popupAd": {
-        "message": "彈出式廣告：隱藏" 
+        "message": "彈出式廣告：隱藏"
     },
     "popupPlayer": {
-        "message": "彈出式播放器" 
+        "message": "彈出式播放器"
     },
     "popupWindowButtons": {
-        "message": "新增彈出式播放器按鈕" 
+        "message": "新增彈出式播放器按鈕"
     },
     "position": {
-        "message": "位置" 
+        "message": "位置"
     },
     "pressAnyKeyOrScroll": {
-        "message": "按任意鍵或捲動滑鼠" 
+        "message": "按任意鍵或捲動滑鼠"
     },
     "pressAnyKeyOrUseMouseWheel": {
-        "message": "按任意鍵或使用滑鼠滾輪" 
+        "message": "按任意鍵或使用滑鼠滾輪"
     },
     "preventShortVideoAutoloop": {
-        "message": "避免短影片自動循環播放" 
+        "message": "避免短影片自動循環播放"
     },
     "previousVideo": {
-        "message": "上一部影片" 
+        "message": "上一部影片"
     },
     "primaryColor": {
-        "message": "主要顏色" 
+        "message": "主要顏色"
     },
     "pullSyncSettings": {
-        "message": "擷取" 
+        "message": "擷取"
     },
     "purchase": {
-        "message": "購買" 
+        "message": "購買"
     },
     "purple": {
-        "message": "紫色" 
+        "message": "紫色"
     },
     "pushSyncSettings": {
-        "message": "推送" 
+        "message": "推送"
     },
     "quality": {
-        "message": "畫質" 
+        "message": "畫質"
     },
     "qualityWhenRunningOnBattery": {
-        "message": "畫質「使用電池供電時」" 
+        "message": "畫質「使用電池供電時」"
     },
     "qualityWithoutFocus": {
-        "message": "畫質「未聚焦時」" 
+        "message": "畫質「未聚焦時」"
     },
     "quickDeleteShortcut": {
-        "message": "快速刪除快速鍵" 
+        "message": "快速刪除快速鍵"
     },
     "raised": {
-        "message": "浮凸" 
+        "message": "浮凸"
     },
     "rateMe": {
-        "message": "為我評分" 
+        "message": "為我評分"
     },
     "rateUs": {
-        "message": "為我們評分" 
+        "message": "為我們評分"
     },
     "red": {
-        "message": "紅色" 
+        "message": "紅色"
     },
     "redDislikeButton": {
-        "message": "「不喜歡」按鈕使用紅色" 
+        "message": "「不喜歡」按鈕使用紅色"
     },
     "refreshCategories": {
-        "message": "重新整理類別" 
+        "message": "重新整理類別"
     },
     "relatedVideos": {
-        "message": "相關影片" 
+        "message": "相關影片"
     },
     "relative": {
-        "message": "相對時間 (如「5 分鐘前」)" 
+        "message": "相對時間 (如「5 分鐘前」)"
     },
     "remote": {
-        "message": "在電視上播放" 
+        "message": "在電視上播放"
     },
     "Remove": {
-        "message": "移除" 
+        "message": "移除"
     },
     "removeBlackBars": {
-        "message": "全螢幕模式移除黑邊" 
+        "message": "全螢幕模式移除黑邊"
     },
     "removeContextButtons": {
-        "message": "移除 Shorts 中的選單按鈕" 
+        "message": "移除 Shorts 中的選單按鈕"
     },
     "removeIcons": {
-        "message": "移除圖示" 
+        "message": "移除圖示"
     },
     "removeMemberOnly": {
-        "message": "移除會員專屬影片" 
+        "message": "移除會員專屬影片"
     },
     "removeName": {
-        "message": "移除名稱" 
+        "message": "移除名稱"
     },
     "removeNames": {
-        "message": "移除名稱" 
+        "message": "移除名稱"
     },
     "removePlaylistParam": {
-        "message": "在新分頁中開啟影片時不進入播放清單" 
+        "message": "在新分頁中開啟影片時不進入播放清單"
     },
     "removeRelatedSearchResults": {
-        "message": "移除相關搜尋結果" 
+        "message": "移除相關搜尋結果"
     },
     "removeShortsReelSearchResults": {
-        "message": "移除搜尋結果中的 Shorts" 
+        "message": "移除搜尋結果中的 Shorts"
     },
     "RemoveSubtitlesForLyrics": {
-        "message": "移除歌詞字幕" 
+        "message": "移除歌詞字幕"
     },
     "repeat": {
-        "message": "重複播放" 
+        "message": "重複播放"
     },
     "report": {
-        "message": "檢舉" 
+        "message": "檢舉"
     },
     "requirePassword": {
-        "message": "需要密碼才能變更 ImprovedTube 設定" 
+        "message": "需要密碼才能變更 ImprovedTube 設定"
     },
     "reset": {
-        "message": "重設" 
+        "message": "重設"
     },
     "resetAllSettings": {
-        "message": "重設所有設定" 
+        "message": "重設所有設定"
     },
     "resetAllShortcuts": {
-        "message": "重設所有快速鍵" 
+        "message": "重設所有快速鍵"
     },
     "reverse": {
-        "message": "反向" 
+        "message": "反向"
     },
     "revertTheaterModeButtonSizes": {
-        "message": "還原劇院模式按鈕大小" 
+        "message": "還原劇院模式按鈕大小"
     },
     "rotate": {
-        "message": "旋轉影片" 
+        "message": "旋轉影片"
     },
     "save": {
-        "message": "儲存" 
+        "message": "儲存"
     },
     "saveAs": {
-        "message": "另存新檔" 
+        "message": "另存新檔"
     },
     "schedule": {
-        "message": "排程" 
+        "message": "排程"
     },
     "screen": {
-        "message": "螢幕" 
+        "message": "螢幕"
     },
     "screenshot": {
-        "message": "🖼️截圖" 
+        "message": "🖼️截圖"
     },
     "scrollBar": {
-        "message": "捲軸" 
+        "message": "捲軸"
     },
     "sd": {
-        "message": "標準畫質 (SD)" 
+        "message": "標準畫質 (SD)"
     },
     "search": {
-        "message": "搜尋" 
+        "message": "搜尋"
     },
     "searchBarOnly": {
-        "message": "僅搜尋列" 
+        "message": "僅搜尋列"
     },
     "secondaryColor": {
-        "message": "次要顏色" 
+        "message": "次要顏色"
     },
     "seekBackward10Seconds": {
-        "message": "倒轉 10 秒" 
+        "message": "倒轉 10 秒"
     },
     "seekForward10Seconds": {
-        "message": "快轉 10 秒" 
+        "message": "快轉 10 秒"
     },
     "seekNextChapter": {
-        "message": "下一章節" 
+        "message": "下一章節"
     },
     "seekPreviousChapter": {
-        "message": "上一章節" 
+        "message": "上一章節"
     },
     "settings": {
-        "message": "ImprovedTube 設定" 
+        "message": "ImprovedTube 設定"
     },
     "settingsSuccessfullyImported": {
-        "message": "設定匯入成功" 
+        "message": "設定匯入成功"
     },
     "share": {
-        "message": "分享" 
+        "message": "分享"
     },
     "shortcut_chapters": {
-        "message": "章節「側邊欄」開關" 
+        "message": "章節「側邊欄」開關"
     },
     "shortcut_screenshot": {
-        "message": "截圖" 
+        "message": "截圖"
     },
     "shortcut_transcript": {
-        "message": "轉錄稿「側邊欄」開關" 
+        "message": "轉錄稿「側邊欄」開關"
     },
     "shortcuts": {
-        "message": "快速鍵" 
+        "message": "快速鍵"
     },
     "ShortsForceTheStandardPlayer": {
-        "message": "Shorts：強制使用標準播放器" 
+        "message": "Shorts：強制使用標準播放器"
     },
     "showCardsOnMouseHover": {
-        "message": "滑鼠懸停時顯示資訊卡" 
+        "message": "滑鼠懸停時顯示資訊卡"
     },
     "showChannelVideosCount": {
-        "message": "顯示頻道影片總數" 
+        "message": "顯示頻道影片總數"
     },
     "showExactDate": {
-        "message": "顯示精確日期" 
+        "message": "顯示精確日期"
     },
     "showLastWatchedOverlay": {
-        "message": "在縮圖上顯示「最近觀看」疊加層" 
+        "message": "在縮圖上顯示「最近觀看」疊加層"
     },
     "showLess": {
-        "message": "顯示較少" 
+        "message": "顯示較少"
     },
     "showMore": {
-        "message": "顯示更多" 
+        "message": "顯示更多"
     },
     "showRemainingDuration": {
-        "message": "顯示影片剩餘時間" 
+        "message": "顯示影片剩餘時間"
     },
     "showVersion": {
-        "message": "顯示版本號碼" 
+        "message": "顯示版本號碼"
     },
     "shuffle": {
-        "message": "隨機播放" 
+        "message": "隨機播放"
     },
     "sidebar": {
-        "message": "側邊欄" 
+        "message": "側邊欄"
     },
     "Sidebar_simple_alternative": {
-        "message": "側邊欄「簡易變體」" 
+        "message": "側邊欄「簡易變體」"
     },
     "softwareInformation": {
-        "message": "軟體資訊" 
+        "message": "軟體資訊"
     },
     "spacebar": {
-        "message": "空白鍵" 
+        "message": "空白鍵"
     },
     "squaredUserImages": {
-        "message": "方形使用者圖示" 
+        "message": "方形使用者圖示"
     },
     "static": {
-        "message": "靜態" 
+        "message": "靜態"
     },
     "statsForNerds": {
-        "message": "詳細統計資料" 
+        "message": "詳細統計資料"
     },
     "step": {
-        "message": "級距" 
+        "message": "級距"
     },
     "stickyNavigation": {
-        "message": "固定導覽列" 
+        "message": "固定導覽列"
     },
     "stop": {
-        "message": "停止" 
+        "message": "停止"
     },
     "style": {
-        "message": "樣式" 
+        "message": "樣式"
     },
     "styles": {
-        "message": "樣式" 
+        "message": "樣式"
     },
     "subscribe": {
-        "message": "訂閱" 
+        "message": "訂閱"
     },
     "subscriptions": {
-        "message": "訂閱內容" 
+        "message": "訂閱內容"
     },
     "Subtitle_Capture_including_the_current_words": {
-        "message": "字幕「包含目前文字」" 
+        "message": "字幕「包含目前文字」"
     },
     "subtitleLine": {
-        "message": "隱藏字幕紅線" 
+        "message": "隱藏字幕紅線"
     },
     "subtitles": {
-        "message": "字幕" 
+        "message": "字幕"
     },
     "sunset": {
-        "message": "日落" 
+        "message": "日落"
     },
     "sunsetToSunrise": {
-        "message": "從日落到日出" 
+        "message": "從日落到日出"
     },
     "systemPeferenceDark": {
-        "message": "系統偏好：深色" 
+        "message": "系統偏好：深色"
     },
     "systemPeferenceLight": {
-        "message": "系統偏好：淺色" 
+        "message": "系統偏好：淺色"
     },
     "teal": {
-        "message": "藍綠色" 
+        "message": "藍綠色"
     },
     "textColor": {
-        "message": "文字顏色" 
+        "message": "文字顏色"
     },
     "thanks": {
-        "message": "超級感謝" 
+        "message": "超級感謝"
     },
     "themes": {
-        "message": "主題" 
+        "message": "主題"
     },
     "thisWillRemoveAllCookies": {
-        "message": "這將移除所有的 Cookie" 
+        "message": "這將移除所有的 Cookie"
     },
     "thisWillRemoveAllWatchedVideos": {
-        "message": "這將移除所有已觀看的影片" 
+        "message": "這將移除所有已觀看的影片"
     },
     "thisWillRemoveAllYouTubeCookies": {
-        "message": "這將移除所有 YouTube 的 Cookie" 
+        "message": "這將移除所有 YouTube 的 Cookie"
     },
     "thisWillResetAllSettings": {
-        "message": "這將重設所有設定" 
+        "message": "這將重設所有設定"
     },
     "thisWillResetAllShortcuts": {
-        "message": "這將重設所有快速鍵" 
+        "message": "這將重設所有快速鍵"
     },
     "thumbnails": {
-        "message": "縮圖" 
+        "message": "縮圖"
     },
     "thumbnailSize": {
-        "message": "縮圖大小" 
+        "message": "縮圖大小"
     },
     "thumbnailsQuality": {
-        "message": "縮圖畫質" 
+        "message": "縮圖畫質"
     },
     "timeFrom": {
-        "message": "開始時間" 
+        "message": "開始時間"
     },
     "timeTo": {
-        "message": "結束時間" 
+        "message": "結束時間"
     },
     "To_the_side_No_page_margin": {
-        "message": "至側邊「無頁面邊界」" 
+        "message": "至側邊「無頁面邊界」"
     },
     "todayAt": {
-        "message": "今天" 
+        "message": "今天"
     },
     "toggleAutoplay": {
-        "message": "切換自動播放" 
+        "message": "切換自動播放"
     },
     "toggleCards": {
-        "message": "切換資訊卡" 
+        "message": "切換資訊卡"
     },
     "toggleControls": {
-        "message": "切換控制項" 
+        "message": "切換控制項"
     },
     "topChat": {
-        "message": "熱門聊天" 
+        "message": "熱門聊天"
     },
     "topLeft": {
-        "message": "左上" 
+        "message": "左上"
     },
     "topRight": {
-        "message": "右上" 
+        "message": "右上"
     },
     "trackWatchedVideos": {
-        "message": "追蹤已觀看的影片" 
+        "message": "追蹤已觀看的影片"
     },
     "trailerAutoplay": {
-        "message": "自動播放預告片" 
+        "message": "自動播放預告片"
     },
     "Transcript": {
-        "message": "轉錄稿" 
+        "message": "轉錄稿"
     },
     "translations": {
-        "message": "翻譯" 
+        "message": "翻譯"
     },
     "transparentBackground": {
-        "message": "透明背景" 
+        "message": "透明背景"
     },
     "transparentBackgroundAlternative": {
-        "message": "透明背景變體" 
+        "message": "透明背景變體"
     },
     "transparentColor": {
-        "message": "透明" 
+        "message": "透明"
     },
     "trending": {
-        "message": "發燒影片" 
+        "message": "發燒影片"
     },
     "tryToReloadThePage": {
-        "message": "請嘗試重新載入頁面" 
-    },
-    "turnOff": {
-        "message": "關閉" 
-    },
-    "turnOn": {
-        "message": "開啟" 
+        "message": "請嘗試重新載入頁面"
     },
     "type": {
-        "message": "類型" 
+        "message": "類型"
     },
     "undoTheNewSidebar": {
-        "message": "還原側邊欄更新" 
+        "message": "還原側邊欄更新"
     },
     "upNextAutoplay": {
-        "message": "自動播放下一部影片" 
+        "message": "自動播放下一部影片"
     },
     "use24HourFormat": {
-        "message": "使用24小時格式" 
+        "message": "使用24小時格式"
     },
     "version": {
-        "message": "版本號碼" 
+        "message": "版本號碼"
     },
     "video": {
-        "message": "影片" 
+        "message": "影片"
     },
     "videoDescriptionWillBeExpandedToGetNameOfCategory": {
-        "message": "展開影片說明以取得類別名稱" 
+        "message": "展開影片說明以取得類別名稱"
     },
     "videoFormats": {
-        "message": "影片格式" 
+        "message": "影片格式"
     },
     "videos": {
-        "message": "影片" 
+        "message": "影片"
     },
     "viewMode": {
-        "message": "檢視模式" 
+        "message": "檢視模式"
     },
     "volume": {
-        "message": "音量" 
+        "message": "音量"
     },
     "watchedVideos": {
-        "message": "已觀看的影片" 
+        "message": "已觀看的影片"
     },
     "watchLater": {
-        "message": "稍後觀看" 
+        "message": "稍後觀看"
     },
     "watchTime": {
-        "message": "觀看時間" 
+        "message": "觀看時間"
     },
     "whenBatteryIslowDecreaseQuality": {
-        "message": "電池電量低時，降低畫質" 
+        "message": "電池電量低時，降低畫質"
     },
     "whenPaused": {
-        "message": "暫停時" 
+        "message": "暫停時"
     },
     "whenTabIsChanged": {
-        "message": "切換分頁時" 
+        "message": "切換分頁時"
     },
     "white": {
-        "message": "白色" 
+        "message": "白色"
     },
     "windowColor": {
-        "message": "視窗顏色" 
+        "message": "視窗顏色"
     },
     "windowOpacity": {
-        "message": "視窗不透明度" 
+        "message": "視窗不透明度"
     },
     "with_scrollbars": {
-        "message": "包含卷軸" 
+        "message": "包含卷軸"
     },
     "withoutVideos": {
-        "message": "「空白」，不包含影片預覽" 
+        "message": "「空白」，不包含影片預覽"
     },
     "yellow": {
-        "message": "黃色" 
+        "message": "黃色"
     },
     "Youtube_Search": {
-        "message": "YouTube 搜尋" 
+        "message": "YouTube 搜尋"
     },
     "youTubeButtons": {
-        "message": "YouTube 按鈕" 
+        "message": "YouTube 按鈕"
     },
     "youtubeHeaderLeft": {
-        "message": "YouTube 頁首左側" 
+        "message": "YouTube 頁首左側"
     },
     "youtubeHeaderRight": {
-        "message": "YouTube 頁首右側" 
+        "message": "YouTube 頁首右側"
     },
     "youtubeHomePage": {
-        "message": "預設的 YouTube 首頁" 
+        "message": "預設的 YouTube 首頁"
     },
     "youtubeLanguage": {
-        "message": "YouTube 語言" 
+        "message": "YouTube 語言"
     },
     "youtubeLimitsVideoQualityTo1080pForH264Codec": {
-        "message": "使用 H.264 編碼時，YouTube 會將影片畫質限制為 1080P" 
+        "message": "使用 H.264 編碼時，YouTube 會將影片畫質限制為 1080P"
     },
     "youtubesDark": {
-        "message": "YouTube 深色主題" 
+        "message": "YouTube 深色主題"
     },
     "youtubesLight": {
-        "message": "YouTube 淺色主題" 
+        "message": "YouTube 淺色主題"
     }
 }


### PR DESCRIPTION
## Summary

This PR performs maintenance and cleanup across localization files in `_locales/`:
- Removes obsolete keys from non-English locales that are no longer defined in the reference `en` locale (`_locales/en/messages.json`).
- Removes a duplicated key definition in `ja/messages.json`.
- Trims trailing whitespace in `en/messages.json` and `zh_TW/messages.json`.

No functional logic or extension runtime behavior is changed.

---

## Changes Overview

- **Obsolete keys removed**:
  - `_locales/el/messages.json`: Removed 11 obsolete keys (`Download`, `Focus`, `Titles`, `comment`, `community`, `hide_Labels`, `maxWidthWithinThePage`, `player_auplayer_SDR`, `player_autoplay_disable`, `remove`, `shorts`).
  - `_locales/pt_PT/messages.json`: Removed 2 obsolete keys (`Cores`, `removeHomePageShorts`).
  - `_locales/zh/messages.json`: Removed 1 obsolete key (`Buttons`).
  - `_locales/zh_CN/messages.json`: Removed 4 obsolete keys (`hideAiSummaries`, `hideYouTubeLogo`, `turnOff`, `turnOn`).
  - `_locales/zh_TW/messages.json`: Removed 4 obsolete keys (`hideAiSummaries`, `hideYouTubeLogo`, `turnOff`, `turnOn`).
- **Duplicate key removed**:
  - `_locales/ja/messages.json`: Removed duplicate `displayDayOfTheWeak` entry at line 1616 (already defined at line 491).
- **Trailing whitespace removed**:
  - `_locales/en/messages.json`: Removed trailing whitespace at line 713.
  - `_locales/zh_TW/messages.json`: Removed trailing whitespace across lines.

---

## Testing & Quality Assurance

- [x] **JSON Validation**: Verified syntax and validity of all modified `messages.json` files.
- [x] **Unit Tests**: Ran `npm test` (`npx jest`) — all test suites passed.
- [x] **Linting**: Verified with `npm run lint` — 0 errors/warnings.