### PR TITLE
Fix settings restore persistence race

### DIFF
--- a/menu/functions.js
+++ b/menu/functions.js
@@ -129,6 +129,22 @@ extension.exportSettings = function () {
 # IMPORT SETTINGS
 --------------------------------------------------------------*/
 
+// Keep the import UI open until one batch write makes the in-memory and persisted settings agree.
+extension.applyImportedSettings = function (data, callback) {
+	chrome.storage.local.set(data, function () {
+		if (chrome.runtime.lastError) {
+			if (callback) callback(chrome.runtime.lastError);
+
+			return;
+		}
+
+		Object.assign(satus.storage.data, data);
+		satus.events.trigger('storage-import');
+
+		if (callback) callback();
+	});
+};
+
 extension.importSettings = function () {
 	if (location.href.indexOf('action=import-settings') !== -1) {
 		satus.render({
@@ -159,19 +175,19 @@ extension.importSettings = function () {
 
 								file_reader.onload = function () {
 									var data = JSON.parse(this.result);
-									for (var key in data) {
-										satus.storage.set(key, data[key]);
-									}
 
-									setTimeout(function () {
+									extension.applyImportedSettings(data, function (error) {
+										if (error) {
+											console.error(error);
+
+											return;
+										}
+
 										chrome.runtime.sendMessage({
 											action: 'import-settings'
 										});
-
-										setTimeout(function () {
-											close();
-										}, 128);
-									}, 256);
+										close();
+									});
 								};
 
 								file_reader.readAsText(this.files[0]);
@@ -246,13 +262,21 @@ extension.pullSettings = function () {
 				text: 'ok',
 				on: {
 					click: function () {
+						var modal_provider = this.modalProvider;
+
 						chrome.storage.sync.get('settings', function (r) {
 							var data = JSON.parse(r['settings']);
-							for (var key in data) {
-								satus.storage.set(key, data[key]);
-							}
+
+							extension.applyImportedSettings(data, function (error) {
+								if (error) {
+									console.error(error);
+
+									return;
+								}
+
+								modal_provider.close();
+							});
 						});
-						this.modalProvider.close();
 					}
 				}
 			}

--- a/menu/functions.js
+++ b/menu/functions.js
@@ -133,11 +133,13 @@ extension.exportSettings = function () {
 extension.applyImportedSettings = function (data, callback) {
 	chrome.storage.local.set(data, function () {
 		if (chrome.runtime.lastError) {
+			satus.events.trigger('storage-import-error', chrome.runtime.lastError);
 			if (callback) callback(chrome.runtime.lastError);
 
 			return;
 		}
 
+		// Populate the cache before notifying subscribers.
 		Object.assign(satus.storage.data, data);
 		satus.events.trigger('storage-import');
 
@@ -262,6 +264,7 @@ extension.pullSettings = function () {
 				text: 'ok',
 				on: {
 					click: function () {
+						// Capture the click handler's receiver before entering the async callback.
 						var modal_provider = this.modalProvider;
 
 						chrome.storage.sync.get('settings', function (r) {

--- a/tests/unit/settings-import.test.js
+++ b/tests/unit/settings-import.test.js
@@ -1,0 +1,116 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('Settings import persistence', () => {
+	let context;
+	let importedFile;
+	let input;
+	let modal;
+	let storageCallback;
+
+	beforeEach(() => {
+		jest.useFakeTimers();
+		importedFile = JSON.stringify({theme: 'dark', player_volume: 80});
+		input = {
+			files: [{}],
+			addEventListener: jest.fn((event, listener) => {
+				if (event === 'change') input.changeListener = listener;
+			}),
+			click: jest.fn()
+		};
+
+		context = {
+			Blob,
+			URL,
+			console,
+			close: jest.fn(),
+			location: {href: 'moz-extension://test/menu/index.html?action=import-settings'},
+			document: {createElement: jest.fn(() => input)},
+			FileReader: class {
+				readAsText() {
+					this.result = importedFile;
+					this.onload();
+				}
+			},
+			setTimeout,
+			clearTimeout,
+			extension: {skeleton: {rendered: {}}},
+			satus: {
+				events: {trigger: jest.fn()},
+				storage: {
+					data: {},
+					set(key, value) {
+						this.data[key] = value;
+						context.chrome.storage.local.set({[key]: value}, () => {});
+					}
+				},
+				render: jest.fn((skeleton) => {
+					modal = skeleton;
+				})
+			},
+			chrome: {
+				runtime: {sendMessage: jest.fn()},
+				storage: {
+					local: {
+						set: jest.fn((settings, callback) => {
+							storageCallback = callback;
+						})
+					},
+					sync: {
+						get: jest.fn((key, callback) => {
+							callback({settings: importedFile});
+						})
+					}
+				}
+			}
+		};
+		vm.runInNewContext(
+			fs.readFileSync(path.join(__dirname, '../../menu/functions.js'), 'utf8'),
+			context
+		);
+	});
+
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	test('waits for the imported settings to persist before notifying and closing', () => {
+		context.extension.importSettings();
+		modal.buttons.ok.on.click();
+		input.changeListener.call(input);
+
+		expect(context.chrome.storage.local.set).toHaveBeenCalledTimes(1);
+		expect(context.chrome.storage.local.set.mock.calls[0][0]).toEqual({
+			theme: 'dark',
+			player_volume: 80
+		});
+		jest.runAllTimers();
+		expect(context.chrome.runtime.sendMessage).not.toHaveBeenCalled();
+		expect(context.close).not.toHaveBeenCalled();
+		expect(context.satus.storage.data).toEqual({});
+
+		storageCallback();
+
+		expect(context.satus.storage.data).toEqual({theme: 'dark', player_volume: 80});
+		expect(context.chrome.runtime.sendMessage).toHaveBeenCalledWith({
+			action: 'import-settings'
+		});
+		expect(context.close).toHaveBeenCalledTimes(1);
+	});
+
+	test('keeps browser-account restore open until the local write completes', () => {
+		const modalProvider = {close: jest.fn()};
+
+		context.extension.pullSettings();
+		modal.buttons.ok.on.click.call({modalProvider});
+
+		expect(modalProvider.close).not.toHaveBeenCalled();
+		expect(context.satus.storage.data).toEqual({});
+
+		storageCallback();
+
+		expect(context.satus.storage.data).toEqual({theme: 'dark', player_volume: 80});
+		expect(modalProvider.close).toHaveBeenCalledTimes(1);
+	});
+});

--- a/tests/unit/settings-import.test.js
+++ b/tests/unit/settings-import.test.js
@@ -97,6 +97,8 @@ describe('Settings import persistence', () => {
 			action: 'import-settings'
 		});
 		expect(context.close).toHaveBeenCalledTimes(1);
+		expect(context.chrome.runtime.sendMessage.mock.invocationCallOrder[0])
+			.toBeLessThan(context.close.mock.invocationCallOrder[0]);
 	});
 
 	test('keeps browser-account restore open until the local write completes', () => {
@@ -113,4 +115,30 @@ describe('Settings import persistence', () => {
 		expect(context.satus.storage.data).toEqual({theme: 'dark', player_volume: 80});
 		expect(modalProvider.close).toHaveBeenCalledTimes(1);
 	});
+    test('returns storage errors without updating the cache or closing', () => {
+        const failure = {message: 'storage unavailable'};
+        context.chrome.runtime.lastError = failure;
+        const callback = jest.fn();
+        context.extension.applyImportedSettings({theme: 'dark'}, callback);
+        storageCallback();
+        expect(callback).toHaveBeenCalledWith(failure);
+        expect(context.satus.storage.data).toEqual({});
+        expect(context.satus.events.trigger).toHaveBeenCalledWith('storage-import-error', failure);
+        expect(context.satus.events.trigger).not.toHaveBeenCalledWith('storage-import');
+        expect(context.close).not.toHaveBeenCalled();
+    });
+
+    test('keeps file import open when persistence fails', () => {
+        const log = jest.spyOn(console, 'error').mockImplementation(() => {});
+        try {
+            context.extension.importSettings();
+            modal.buttons.ok.on.click();
+            input.changeListener.call(input);
+            context.chrome.runtime.lastError = {message: 'storage unavailable'};
+            storageCallback();
+            expect(context.close).not.toHaveBeenCalled();
+            expect(context.chrome.runtime.sendMessage).not.toHaveBeenCalled();
+        } finally { log.mockRestore(); }
+    });
+
 });


### PR DESCRIPTION
Fixes #4314.

Settings restore previously started one asynchronous write per key, then notified and closed the import page after fixed delays. On slower Firefox storage, the menu's in-memory state could show the imported features even though persistence had not finished.

This routes file and browser-account restores through one batch write. The in-memory cache, notification, and window/modal close now occur only after `chrome.storage.local.set` completes; storage errors leave the importer open.

Validation:
- reproduced the premature notification/close with a delayed storage callback before the fix
- `npm test -- --runInBand` (115 passed)
- `npm run lint`
