### PR TITLE
feat(themes): add a "None" theme that leaves YouTube's styling alone

### DIFF
--- a/js&css/extension/www.youtube.com/styles.css
+++ b/js&css/extension/www.youtube.com/styles.css
@@ -733,20 +733,20 @@ html[it-theme=plain] #cinematics {
 }
 
 /* Background-color update */
-html[it-theme]:not([it-theme=default]) ytd-app,
-html[it-theme]:not([it-theme=default]) ytd-browse-view,
-html[it-theme]:not([it-theme=default]) ytd-watch-flexy,
-html[it-theme]:not([it-theme=default]) #page,
-html[it-theme]:not([it-theme=default]) #content { background-color: var(--yt-spec-base-background) !important; };
+html[it-theme]:not([it-theme=default]):not([it-theme=none]) ytd-app,
+html[it-theme]:not([it-theme=default]):not([it-theme=none]) ytd-browse-view,
+html[it-theme]:not([it-theme=default]):not([it-theme=none]) ytd-watch-flexy,
+html[it-theme]:not([it-theme=default]):not([it-theme=none]) #page,
+html[it-theme]:not([it-theme=default]):not([it-theme=none]) #content { background-color: var(--yt-spec-base-background) !important; };
 
 /*video detail text color. Fix. Themes didnt apply video description text color*/
-html[it-theme]:not([it-theme=default]):not([it-theme=dark]) .yt-core-attributed-string--link-inherit-color {color: var(--yt-spec-text-primary) !important}
-html[it-theme]:not([it-theme=default]):not([it-theme=dark]) .yt-core-attributed-string__link--call-to-action-color {color: var(--yt-spec-call-to-action)}
+html[it-theme]:not([it-theme=default]):not([it-theme=none]):not([it-theme=dark]) .yt-core-attributed-string--link-inherit-color {color: var(--yt-spec-text-primary) !important}
+html[it-theme]:not([it-theme=default]):not([it-theme=none]):not([it-theme=dark]) .yt-core-attributed-string__link--call-to-action-color {color: var(--yt-spec-call-to-action)}
 /*The next two lines below can be removed if exact theming consistency isn't the goal and we just want to keep it simple.*/
-html[it-theme]:not([it-theme=default]):not([it-theme=dark]) a.yt-simple-endpoint.yt-formatted-string {color: var(--yt-spec-call-to-action) !important}
+html[it-theme]:not([it-theme=default]):not([it-theme=none]):not([it-theme=dark]) a.yt-simple-endpoint.yt-formatted-string {color: var(--yt-spec-call-to-action) !important}
 /* Actually this above line is wrong. Default behavior is to have #tags near the views and upload date have two different colors depending if the video detail is expanded or not, but I don't know how to replicate that.*/
-html[it-theme]:not([it-theme=default]):not([it-theme=dark]) yt-formatted-string[has-link-only_]:not([force-default-style]) a.yt-simple-endpoint.yt-formatted-string {color: var(--yt-spec-text-primary) !important}
-html[it-theme]:not([it-theme=default]):not([it-theme=dark]) .yt-core-attributed-string--highlight-text-decorator .yt-core-attributed-string__link--display-type {color: var(--yt-spec-text-primary)}
+html[it-theme]:not([it-theme=default]):not([it-theme=none]):not([it-theme=dark]) yt-formatted-string[has-link-only_]:not([force-default-style]) a.yt-simple-endpoint.yt-formatted-string {color: var(--yt-spec-text-primary) !important}
+html[it-theme]:not([it-theme=default]):not([it-theme=none]):not([it-theme=dark]) .yt-core-attributed-string--highlight-text-decorator .yt-core-attributed-string__link--display-type {color: var(--yt-spec-text-primary)}
 
 /*BLACK*/
 html[it-theme=black] [dark],

--- a/js&css/web-accessible/www.youtube.com/themes.js
+++ b/js&css/web-accessible/www.youtube.com/themes.js
@@ -125,6 +125,9 @@ ImprovedTube.setTheme = function () {
 			this.elements.my_colors?.remove();
 			break
 
+		// 'none' leaves YouTube's own light/dark mode alone (no `dark` attribute,
+		// no PREF f6 cookie) so user styles such as Stylus are not fought.
+		case 'none':
 		case 'default':
 			document.getElementById('cinematics')?.removeAttribute('style');
 			this.elements.my_colors?.remove();

--- a/menu/skeleton-parts/themes.js
+++ b/menu/skeleton-parts/themes.js
@@ -75,6 +75,19 @@ extension.skeleton.main.layers.section.themes.on.click.section = {
 			}
 		}
 	},
+	// Leaves YouTube's own styling alone, for people who theme it with
+	// Stylus or similar and don't want the extension to fight them.
+	none: {
+		component: 'label',
+		variant: 'none-theme',
+		text: 'none',
+		tags: 'off,disable,stylus,userstyle,userstyles',
+		radio: {
+			component: 'radio',
+			group: 'theme',
+			value: 'none'
+		}
+	},
 	custom: {
 		component: 'label',
 		variant: 'custom-theme',

--- a/menu/styles/themes.css
+++ b/menu/styles/themes.css
@@ -224,6 +224,13 @@
 	height: 48px !important;
 }
 
+.satus-label--none-theme {
+	height: 48px !important;
+	background: transparent;
+	outline: 1px dashed currentColor;
+	outline-offset: -1px;
+}
+
 .satus-label--dark-theme {
 	position: relative;
     height: 48px !important; margin-top: -5px !important;

--- a/tests/unit/theme-none.test.js
+++ b/tests/unit/theme-none.test.js
@@ -1,0 +1,89 @@
+const fs = require('fs');
+const path = require('path');
+
+/* A "none" theme that leaves YouTube's own styling alone, so user styles
+ * (Stylus and similar) are not fought (#4329). */
+
+describe('"none" theme option in the menu', () => {
+	beforeAll(() => {
+		global.extension = {skeleton: {main: {layers: {section: {}}}}};
+		global.satus = {storage: {get: jest.fn()}};
+		jest.isolateModules(() => {
+			require('../../menu/skeleton-parts/themes.js');
+		});
+	});
+
+	test('is offered as a theme radio with the value "none"', () => {
+		const option = extension.skeleton.main.layers.section.themes.on.click.section.none;
+
+		// reuses the existing "none" string, already translated in most locales
+		expect(option.text).toBe('none');
+		expect(option.radio.group).toBe('theme');
+		expect(option.radio.value).toBe('none');
+	});
+});
+
+describe('setTheme with the "none" theme', () => {
+	let html, masthead, cinematics;
+
+	beforeEach(() => {
+		html = {setAttribute: jest.fn(), removeAttribute: jest.fn()};
+		masthead = {setAttribute: jest.fn(), removeAttribute: jest.fn()};
+		cinematics = {removeAttribute: jest.fn(), style: {setProperty: jest.fn()}};
+
+		global.document = {
+			documentElement: html,
+			querySelector: jest.fn(() => masthead),
+			getElementById: jest.fn(() => cinematics)
+		};
+		global.ImprovedTube = {
+			storage: {theme: 'none'},
+			elements: {my_colors: {remove: jest.fn()}},
+			messages: {send: jest.fn()},
+			setPrefCookieValueByName: jest.fn()
+		};
+		jest.isolateModules(() => {
+			require('../../js&css/web-accessible/www.youtube.com/themes.js');
+		});
+	});
+
+	test("leaves YouTube's own light/dark mode untouched", () => {
+		ImprovedTube.setTheme();
+
+		// neither the `dark` attribute nor YouTube's PREF f6 dark-mode cookie is touched
+		expect(html.setAttribute).not.toHaveBeenCalled();
+		expect(html.removeAttribute).not.toHaveBeenCalled();
+		expect(masthead.setAttribute).not.toHaveBeenCalled();
+		expect(masthead.removeAttribute).not.toHaveBeenCalled();
+		expect(ImprovedTube.setPrefCookieValueByName).not.toHaveBeenCalled();
+		expect(ImprovedTube.messages.send).not.toHaveBeenCalled();
+	});
+
+	test('drops the custom palette and restores the default cinematics glow', () => {
+		const palette = ImprovedTube.elements.my_colors;
+
+		ImprovedTube.setTheme();
+
+		expect(palette.remove).toHaveBeenCalled();
+		expect(cinematics.removeAttribute).toHaveBeenCalledWith('style');
+		expect(cinematics.style.setProperty).not.toHaveBeenCalled();
+	});
+});
+
+describe('theme stylesheet with the "none" theme', () => {
+	const css = fs.readFileSync(
+		path.join(__dirname, '../../js&css/extension/www.youtube.com/styles.css'),
+		'utf8'
+	);
+
+	test('no rule meant for "any theme but default" also matches "none"', () => {
+		// `html[it-theme]` matches every stored theme, "none" included, so each of
+		// these rules has to exclude "none" explicitly or it restyles the page anyway.
+		const selectors = css.match(/html\[it-theme\]:not\(\[it-theme=default\]\)[^,{]*/g) || [];
+
+		expect(selectors.length).toBeGreaterThan(0);
+		for (const selector of selectors) {
+			expect(selector).toContain(':not([it-theme=none])');
+		}
+	});
+});


### PR DESCRIPTION
Closes #4329.

Adds a **None** theme that leaves YouTube's own styling alone, for people who theme it with Stylus or similar.

## Why the extension fights user styles today

Picking "YouTube's Light" does not actually mean "don't restyle".

- The radio stores `light`, and every setting is mirrored to an `it-*` attribute on `<html>`, so the page gets `it-theme="light"`.
- The rules in `styles.css` are written as `html[it-theme]:not([it-theme=default])`, so they match `light` and force the page background (`ytd-app`, `#page`, `#content`, …) and the link colours with `!important`.
- `setTheme('light')` also clears YouTube's `PREF f6` dark-mode cookie and removes the `dark` attribute.

So there was no setting under which the extension stays out of theming, and that is what the report runs into.

## Changes

- **Menu:** a "None" radio after YouTube's Dark, with search tags (`off`, `disable`, `stylus`, `userstyle`). It reuses the existing `none` string, which is already translated in 43 of 65 locales, so no new strings were needed.
- **`setTheme`:** `'none'` shares the `'default'` branch. It drops the custom palette and restores the cinematics glow. It never touches the `dark` attribute, the masthead or the `PREF` cookie.
- **`styles.css`:** the ten "any theme but default" selectors now also exclude `none`. Without that, `it-theme="none"` would still match them and restyle the page.
- **Menu swatch:** `.satus-label--none-theme` gets the same row height as the other themes and a dashed outline instead of a colour.

The dark/light switch in the header already handles this. It treats `none` as a light theme and restores it when you toggle back. The load-time heuristic that stores `dark` only fires when no theme is stored at all, so it leaves `none` alone.

## Deliberately left alone

The light-mode tonal-button rule (`html:not([dark]):not([it-theme=black])…`, around `styles.css:2166`) still applies with `none`. It compensates for an unconditional rule just above it, which makes those buttons translucent white. Excluding `none` there would leave them nearly invisible in light mode.

More generally, the extension's feature styles that are not tied to a theme still apply. This option switches off the theme layer, not every stylesheet the extension ships.

## Tests

New `tests/unit/theme-none.test.js`, following the style of the existing `themes-menu` and `theme-cookie` tests:

- the menu offers a `none` radio in the `theme` group;
- `setTheme` with `none` leaves the `dark` attribute, the masthead, the `PREF` cookie and storage untouched;
- it still drops the custom palette and restores cinematics;
- a guard over `styles.css`: every `html[it-theme]:not([it-theme=default])` selector must also exclude `none`, so a rule added later cannot quietly restyle the page again. I checked that the guard fails when one exclusion is removed; the failure names the offending selector.

`npx jest`: 117 passed (113 before, plus these 4).

## Not verified

I did not load the unpacked extension in a browser. The behaviour is covered by the unit tests above, but a quick manual check with Stylus active would be worth doing before merge.

## Unrelated, for what it's worth

The CI step `npx eslint --config=tests/eslint_rules.config.mjs` currently fails before linting anything. ESLint 8 reads the flat `.mjs` config as a legacy config and throws a `YAMLException`, and `continue-on-error` hides it. Running it with `ESLINT_USE_FLAT_CONFIG=true` works. With that flag, this change adds no new findings.
