### PR TITLE
a11y: label injected controls and preserve native focus

### DIFF
--- a/js&css/extension/init.js
+++ b/js&css/extension/init.js
@@ -89,6 +89,7 @@ const pageWorldFiles = [
 	'/js&css/web-accessible/www.youtube.com/last-watched-overlay.js', // Neue Zeile hinzufügen
 	'/js&css/web-accessible/www.youtube.com/return-youtube-dislike.js',
 	'/js&css/web-accessible/www.youtube.com/return-youtube-dislike.css',
+	'/js&css/web-accessible/accessibility.js',
 	'/js&css/web-accessible/init.js'
 ];
 

--- a/js&css/web-accessible/accessibility.js
+++ b/js&css/web-accessible/accessibility.js
@@ -1,0 +1,124 @@
+/* Accessibility repair for ImprovedTube controls injected into YouTube. */
+(function (root, factory) {
+	'use strict';
+	const api = factory(root);
+	if (typeof module !== 'undefined' && module.exports) module.exports = api;
+	if (root) root.ImprovedTubePageAccessibility = api;
+	if (root && root.document && typeof module === 'undefined') api.install();
+})(typeof globalThis !== 'undefined' ? globalThis : this, function (root) {
+	'use strict';
+
+	const classNames = {
+		'it-add-to-blocklist': 'Add or remove video from blocklist',
+		'it-add-channel-to-blocklist': 'Add or remove channel from blocklist',
+		'it-playlist-copy-video-id': 'Copy video ID',
+		'it-popup-window': 'Open video in popup window',
+		'it-scroll-to-top': 'Scroll to top'
+	};
+
+	function textName (element) {
+		if (!element) return '';
+		const aria = element.getAttribute && element.getAttribute('aria-label');
+		if (aria && aria.trim()) return aria.trim();
+		const text = typeof element.textContent === 'string' ? element.textContent.trim() : '';
+		if (text) return text;
+		const title = element.getAttribute && element.getAttribute('title');
+		if (title && title.trim()) return title.trim();
+		if (element.dataset) {
+			if (element.dataset.tooltip && element.dataset.tooltip.trim()) return element.dataset.tooltip.trim();
+			if (element.dataset.title && element.dataset.title.trim()) return element.dataset.title.trim();
+		}
+		if (element.classList) {
+			for (const [className, label] of Object.entries(classNames)) if (element.classList.contains(className)) return label;
+		}
+		return '';
+	}
+
+	function decorateSvg (element) {
+		if (!element || typeof element.querySelector !== 'function') return;
+		const svg = element.querySelector('svg');
+		if (svg) {
+			svg.setAttribute('aria-hidden', 'true');
+			svg.setAttribute('focusable', 'false');
+		}
+	}
+
+	function enhanceControl (element) {
+		if (!element) return element;
+		const name = textName(element);
+		if (name && element.setAttribute) element.setAttribute('aria-label', name);
+		decorateSvg(element);
+		return element;
+	}
+
+	function ensureStatusRegion () {
+		if (!root.document) return null;
+		let status = root.document.getElementById('it-a11y-status');
+		if (!status) {
+			status = root.document.createElement('div');
+			status.id = 'it-a11y-status';
+			status.setAttribute('role', 'status');
+			status.setAttribute('aria-live', 'polite');
+			status.setAttribute('aria-atomic', 'true');
+			status.style.cssText = 'position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0';
+			(root.document.body || root.document.documentElement).appendChild(status);
+		}
+		return status;
+	}
+
+	function announceIfFeedback (element) {
+		if (!element || !element.dataset) return;
+		const value = element.dataset.tooltip || element.dataset.title || '';
+		if (!/copied|error|failed|saved|done|complete/i.test(value)) return;
+		const status = ensureStatusRegion();
+		if (status) status.textContent = value;
+	}
+
+	function enhanceFrame (frame) {
+		if (!frame || !frame.setAttribute) return;
+		if (!frame.getAttribute('title')) frame.setAttribute('title', 'ImprovedTube settings');
+	}
+
+	function enhanceRoot (container) {
+		if (!container || typeof container.querySelectorAll !== 'function') return;
+		const selector = 'button[class*="it-"],a[class*="it-"],button[id^="it-"],a[id^="it-"],.it-player-button,.it-button';
+		if (container.matches && container.matches(selector)) enhanceControl(container);
+		for (const element of container.querySelectorAll(selector)) enhanceControl(element);
+		if (container.matches && container.matches('iframe.it-button__iframe')) enhanceFrame(container);
+		for (const frame of container.querySelectorAll('iframe.it-button__iframe')) enhanceFrame(frame);
+	}
+
+	function pageStyleText () {
+		return 'button[class*="it-"]:focus-visible,a[class*="it-"]:focus-visible,button[id^="it-"]:focus-visible,a[id^="it-"]:focus-visible,.it-player-button:focus-visible,.it-button:focus-visible{outline:2px solid Highlight!important;outline-offset:2px!important}';
+	}
+
+	function installFocusStyle () {
+		if (!root.document || root.document.getElementById('it-page-a11y-style')) return;
+		const style = root.document.createElement('style');
+		style.id = 'it-page-a11y-style';
+		style.textContent = pageStyleText();
+		(root.document.head || root.document.documentElement).appendChild(style);
+	}
+
+	function install () {
+		if (!root.document || root.__itA11yPageInstalled) return;
+		root.__itA11yPageInstalled = true;
+		installFocusStyle();
+		ensureStatusRegion();
+		enhanceRoot(root.document);
+		if (typeof MutationObserver !== 'undefined') {
+			const observer = new MutationObserver(function (mutations) {
+				for (const mutation of mutations) {
+					if (mutation.type === 'attributes') {
+						enhanceControl(mutation.target);
+						announceIfFeedback(mutation.target);
+					}
+					for (const node of mutation.addedNodes || []) if (node && node.nodeType === 1) enhanceRoot(node);
+				}
+			});
+			observer.observe(root.document.documentElement, {subtree: true, childList: true, attributes: true, attributeFilter: ['data-title', 'data-tooltip', 'title']});
+		}
+	}
+
+	return {textName, decorateSvg, enhanceControl, enhanceFrame, enhanceRoot, ensureStatusRegion, announceIfFeedback, pageStyleText, install};
+});

--- a/js&css/web-accessible/www.youtube.com/appearance.js
+++ b/js&css/web-accessible/www.youtube.com/appearance.js
@@ -475,11 +475,11 @@ ImprovedTube.transcript = function (el) { if (ImprovedTube.storage.transcript ==
 	if (available) {
 		if (!ImprovedTube.originalFocus) {ImprovedTube.originalFocus = HTMLElement.prototype.focus;}  // Backing up default method. Youtube doesn't use alternatives Element.prototype.scrollIntoView  window.scrollTo  window.scrollBy)
 		ImprovedTube.forbidFocus =  function (ms) {
-			HTMLElement.prototype.focus = function() {console.log("Preventing YouTube's scripted scrolling for a moment."); }
+			// Accessibility: native HTMLElement.prototype.focus remains unchanged.
 			if(document.hidden) ms = 3*ms;
 			setTimeout(function() { HTMLElement.prototype.focus = ImprovedTube.originalFocus; }, ms); 	// Restoring JS's "focus()"
 		}
-		ImprovedTube.forbidFocus(2100);
+		// Accessibility: preserve native HTMLElement.focus(); do not globally suppress focus.
 		const descriptionTranscript = el.querySelector('ytd-video-description-transcript-section-renderer button[aria-label]');
 		descriptionTranscript ? descriptionTranscript.click() : el.querySelector('[target-id*=transcript]')?.removeAttribute('visibility');
 		if ( yt.config_.EXPERIMENT_FLAGS.kevlar_watch_grid === true ) { available.setAttribute('z-index', '98765') }
@@ -493,11 +493,11 @@ ImprovedTube.chapters = function (el) { if (ImprovedTube.storage.chapters === tr
 	if (available) {
 		if (!ImprovedTube.originalFocus) { ImprovedTube.originalFocus = HTMLElement.prototype.focus;}  // Backing up default method. Youtube doesn't use alternatives Element.prototype.scrollIntoView  window.scrollTo  window.scrollBy)
 		ImprovedTube.forbidFocus =  function (ms) {
-			HTMLElement.prototype.focus = function() {console.log("Preventing YouTube's scripted scrolling for a moment."); }
+			// Accessibility: native HTMLElement.prototype.focus remains unchanged.
 			if(document.hidden) ms = 3*ms;
 			setTimeout(function() { HTMLElement.prototype.focus = ImprovedTube.originalFocus; }, ms); 	// Restoring JS's "focus()"
 		}
-		ImprovedTube.forbidFocus(2100);
+		// Accessibility: preserve native HTMLElement.focus(); do not globally suppress focus.
 		const modernChapters = el.querySelector('[modern-chapters] #navigation-button button[aria-label]');
 		modernChapters ? modernChapters.click() : el.querySelector('[target-id*=chapters]')?.removeAttribute('visibility');
 		if ( yt.config_.EXPERIMENT_FLAGS.kevlar_watch_grid === true ) { available.setAttribute('z-index', '98765') }
@@ -698,12 +698,12 @@ ImprovedTube.expandDescription = function (el) {
 	if (this.storage.description === "expanded") {
 		if (!ImprovedTube.originalFocus) { ImprovedTube.originalFocus = HTMLElement.prototype.focus;}  // Backing up default method. Youtube doesn't use alternatives Element.prototype.scrollIntoView  window.scrollTo  window.scrollBy)
 		ImprovedTube.forbidFocus =  function (ms) {
-			HTMLElement.prototype.focus = function() {console.log("Preventing YouTube's scripted scrolling for a moment."); }
+			// Accessibility: native HTMLElement.prototype.focus remains unchanged.
 			if(document.hidden) ms = 3*ms;
 			setTimeout(function() { HTMLElement.prototype.focus = ImprovedTube.originalFocus; }, ms); 	// Restoring JS's "focus()"
 		}
 		if (el) {
-			ImprovedTube.forbidFocus(2100); // setTimeout(function () {ImprovedTube.elements.player.focus();}, 2500);
+			// Accessibility: preserve native HTMLElement.focus(); do not globally suppress focus. // setTimeout(function () {ImprovedTube.elements.player.focus();}, 2500);
 			el.click();
 		}
 		else { // wait for the description

--- a/js&css/web-accessible/www.youtube.com/shortcuts.js
+++ b/js&css/web-accessible/www.youtube.com/shortcuts.js
@@ -461,7 +461,7 @@ ImprovedTube.shortcutResetPlaybackSpeed = function () {
 ImprovedTube.shortcutGoToSearchBox = function () {
 	document.querySelector('input[name="search_query"]')?.click();
 	document.querySelector('input#search')?.click();
-	if (ImprovedTube.originalFocus) { HTMLElement.prototype.focus = originalFocus }
+	// Accessibility: native HTMLElement.prototype.focus is intentionally untouched.
 	document.querySelector('input[name="search_query"]')?.focus();
 	document.querySelector('input#search')?.focus();
 };

--- a/manifest.json
+++ b/manifest.json
@@ -80,6 +80,7 @@
         "js&css/web-accessible/www.youtube.com/last-watched-overlay.js",
         "js&css/web-accessible/www.youtube.com/return-youtube-dislike.js",
         "js&css/web-accessible/www.youtube.com/return-youtube-dislike.css",
+        "js&css/web-accessible/accessibility.js",
         "js&css/web-accessible/init.js",
         "menu/icons/48.png"
       ],

--- a/menu/accessibility.js
+++ b/menu/accessibility.js
@@ -1,0 +1,265 @@
+/* ImprovedTube accessibility compatibility layer.
+ * Additive: preserves existing Satus behavior and visual layout.
+ */
+(function (root, factory) {
+	'use strict';
+	const api = factory(root);
+	if (typeof module !== 'undefined' && module.exports) module.exports = api;
+	if (root) root.ImprovedTubeMenuAccessibility = api;
+	if (root && root.document && typeof module === 'undefined') api.install();
+})(typeof globalThis !== 'undefined' ? globalThis : this, function (root) {
+	'use strict';
+
+	let idCounter = 0;
+
+	function safeLocale (key, fallback, localizer) {
+		if (!key) return fallback || '';
+		try {
+			if (localizer) {
+				const translated = localizer(key);
+				if (translated && translated !== key) return String(translated);
+				if (translated && !fallback) return String(translated);
+			}
+			if (typeof satus !== 'undefined' && satus.locale && typeof satus.locale.get === 'function') {
+				const translated = satus.locale.get(key);
+				if (translated && translated !== key) return String(translated);
+				if (translated && !fallback) return String(translated);
+			}
+		} catch (_) {}
+		return fallback || String(key);
+	}
+
+	function skeletonName (element, localizer) {
+		const skeleton = element && element.skeleton;
+		if (skeleton) {
+			for (const candidate of [skeleton.text, skeleton.label && skeleton.label.text, skeleton.title]) {
+				if (typeof candidate === 'string' && candidate.trim()) {
+					return safeLocale(candidate, candidate, localizer).trim();
+				}
+			}
+		}
+		const text = element && typeof element.textContent === 'string' ? element.textContent.trim() : '';
+		return text;
+	}
+
+	function accessibleName (element, includeText) {
+		if (!element) return '';
+		const aria = element.getAttribute && element.getAttribute('aria-label');
+		if (aria && aria.trim()) return aria.trim();
+		const labelled = element.getAttribute && element.getAttribute('aria-labelledby');
+		if (labelled && labelled.trim()) return labelled.trim();
+		const title = element.getAttribute && element.getAttribute('title');
+		if (title && title.trim()) return title.trim();
+		if (includeText !== false) {
+			const text = typeof element.textContent === 'string' ? element.textContent.trim() : '';
+			if (text) return text;
+		}
+		return '';
+	}
+
+	function setLabel (element, label, includeText) {
+		if (!element || !label || accessibleName(element, includeText)) return;
+		if (element.setAttribute) element.setAttribute('aria-label', label);
+	}
+
+	function addKeyboardClick (element) {
+		if (!element || element.__itA11yKeyboard) return;
+		element.__itA11yKeyboard = true;
+		element.addEventListener('keydown', function (event) {
+			if (event.key === ' ' || event.key === 'Enter') {
+				event.preventDefault();
+				if (typeof this.click === 'function') this.click();
+			}
+		});
+	}
+
+	function enhanceSwitch (element, localizer) {
+		if (!element) return element;
+		element.setAttribute('role', 'switch');
+		if (!element.hasAttribute('tabindex')) element.setAttribute('tabindex', '0');
+		element.setAttribute('aria-checked', element.dataset && String(element.dataset.value) === 'true' ? 'true' : 'false');
+		setLabel(element, skeletonName(element, localizer));
+		addKeyboardClick(element);
+		return element;
+	}
+
+	function controlName (wrapper, localizer) {
+		let name = skeletonName(wrapper, localizer);
+		if (name) return name;
+
+		const skeleton = wrapper && wrapper.skeleton;
+		const parentSkeleton = skeleton && skeleton.parentSkeleton;
+		if (parentSkeleton) {
+			for (const candidate of [parentSkeleton.text, parentSkeleton.label && parentSkeleton.label.text, parentSkeleton.title]) {
+				if (typeof candidate === 'string' && candidate.trim()) return safeLocale(candidate, candidate, localizer).trim();
+			}
+		}
+
+		const parent = wrapper && (wrapper.parentElement || wrapper.parentNode);
+		if (parent && parent !== wrapper) name = skeletonName(parent, localizer);
+		return name || '';
+	}
+
+	function enhanceNativeControl (wrapper, selector, localizer) {
+		if (!wrapper || typeof wrapper.querySelector !== 'function') return null;
+		const control = wrapper.querySelector(selector);
+		if (!control) return null;
+		setLabel(control, controlName(wrapper, localizer), false);
+		return control;
+	}
+
+	function enhanceCustomButton (element, localizer) {
+		if (!element) return element;
+		element.setAttribute('role', 'button');
+		if (!element.hasAttribute('tabindex')) element.setAttribute('tabindex', '0');
+		setLabel(element, skeletonName(element, localizer));
+		addKeyboardClick(element);
+		return element;
+	}
+
+	function knownIconName (button) {
+		try {
+			if (typeof extension !== 'undefined' && extension.skeleton) {
+				const h = extension.skeleton.header;
+				if (h && h.sectionStart && h.sectionStart.back && h.sectionStart.back.rendered === button) return safeLocale('back', 'Back');
+				if (h && h.sectionEnd) {
+					if (h.sectionEnd.darkLightSwitch && h.sectionEnd.darkLightSwitch.rendered === button) return safeLocale('theme', 'Theme');
+					if (h.sectionEnd.search && h.sectionEnd.search.rendered === button) return safeLocale('search', 'Search');
+					if (h.sectionEnd.menu && h.sectionEnd.menu.rendered === button) return safeLocale('menu', 'Menu');
+					if (h.sectionEnd.search && h.sectionEnd.search.on && h.sectionEnd.search.on.click && h.sectionEnd.search.on.click.close && h.sectionEnd.search.on.click.close.rendered === button) return safeLocale('close', 'Close');
+				}
+			}
+		} catch (_) {}
+		return '';
+	}
+
+	function enhanceButton (button) {
+		if (!button) return;
+		const name = skeletonName(button) || knownIconName(button);
+		setLabel(button, name);
+		const svg = typeof button.querySelector === 'function' ? button.querySelector('svg') : null;
+		if (svg) {
+			svg.setAttribute('aria-hidden', 'true');
+			svg.setAttribute('focusable', 'false');
+		}
+	}
+
+	function visuallyHiddenStyle () {
+		if (!root.document || root.document.getElementById('it-a11y-style')) return;
+		const style = root.document.createElement('style');
+		style.id = 'it-a11y-style';
+		style.textContent = [
+			'.it-a11y-heading,.it-a11y-status{position:absolute!important;width:1px!important;height:1px!important;padding:0!important;margin:-1px!important;overflow:hidden!important;clip:rect(0,0,0,0)!important;white-space:nowrap!important;border:0!important}',
+			'.satus-button:focus-visible,.satus-switch:focus-visible,.satus-shortcut:focus-visible,.satus-color-picker:focus-visible,.satus-select select:focus-visible,.satus-checkbox input:focus-visible,.satus-slider input:focus-visible{outline:2px solid Highlight!important;outline-offset:2px!important}'
+		].join('\n');
+		(root.document.head || root.document.documentElement).appendChild(style);
+	}
+
+	function ensureId (element, prefix) {
+		if (element.id) return element.id;
+		idCounter += 1;
+		element.id = `${prefix || 'it-a11y'}-${idCounter}`;
+		return element.id;
+	}
+
+	function enhanceSection (section) {
+		if (!section || !section.dataset || !section.dataset.title || section.__itA11yHeading) return;
+		if (!root.document || typeof root.document.createElement !== 'function') return;
+		section.__itA11yHeading = true;
+		const heading = root.document.createElement('h2');
+		heading.className = 'it-a11y-heading';
+		heading.textContent = section.dataset.title;
+		heading.setAttribute('tabindex', '-1');
+		ensureId(heading, 'it-a11y-heading');
+		if (typeof section.insertBefore === 'function') section.insertBefore(heading, section.firstChild || null);
+		else if (typeof section.appendChild === 'function') section.appendChild(heading);
+		section.setAttribute('role', 'region');
+		section.setAttribute('aria-labelledby', heading.id);
+	}
+
+	function isInteractiveElement (element) {
+		if (!element || typeof element.focus !== 'function') return false;
+		const tagName = String(element.tagName || '').toLowerCase();
+		if (['button', 'input', 'select', 'textarea'].includes(tagName)) return true;
+		if (tagName === 'a' && element.getAttribute && element.getAttribute('href')) return true;
+		const role = element.getAttribute && element.getAttribute('role');
+		if (role === 'button' || role === 'switch' || role === 'checkbox' || role === 'radio' || role === 'combobox' || role === 'link') return true;
+		const tabindex = element.getAttribute && element.getAttribute('tabindex');
+		return tabindex !== null && tabindex !== undefined && Number(tabindex) >= 0;
+	}
+
+	function enhanceIframe (frame) {
+		if (!frame || frame.getAttribute('title')) return;
+		frame.setAttribute('title', safeLocale('improvedTube', 'ImprovedTube content'));
+	}
+
+	function enhanceRoot (container) {
+		if (!container || typeof container.querySelectorAll !== 'function') return;
+		const includeSelf = function (selector, callback) {
+			try { if (container.matches && container.matches(selector)) callback(container); } catch (_) {}
+			for (const element of container.querySelectorAll(selector)) callback(element);
+		};
+
+		includeSelf('.satus-switch', function (el) { enhanceSwitch(el); });
+		includeSelf('.satus-select', function (el) { enhanceNativeControl(el, 'select'); });
+		includeSelf('.satus-checkbox', function (el) { enhanceNativeControl(el, 'input[type="checkbox"]'); });
+		includeSelf('.satus-radio', function (el) { enhanceNativeControl(el, 'input[type="radio"]'); });
+		includeSelf('.satus-slider', function (el) { enhanceNativeControl(el, 'input[type="range"]'); });
+		includeSelf('.satus-text-field', function (el) { enhanceNativeControl(el, 'input,textarea'); });
+		includeSelf('.satus-time', function (el) { enhanceNativeControl(el, 'select'); });
+		includeSelf('.satus-shortcut,.satus-color-picker', function (el) { enhanceCustomButton(el); });
+		includeSelf('button.satus-button', enhanceButton);
+		includeSelf('.satus-section[data-title]', enhanceSection);
+		includeSelf('iframe', enhanceIframe);
+
+		const title = root.document && root.document.querySelector ? root.document.querySelector('.satus-span--title') : null;
+		if (title) {
+			title.setAttribute('role', 'heading');
+			title.setAttribute('aria-level', '1');
+		}
+	}
+
+	function install () {
+		if (!root.document || root.__itA11yMenuInstalled) return;
+		root.__itA11yMenuInstalled = true;
+		visuallyHiddenStyle();
+
+		const start = function () {
+			enhanceRoot(root.document);
+			if (typeof MutationObserver !== 'undefined') {
+				const observer = new MutationObserver(function (mutations) {
+					for (const mutation of mutations) {
+						if (mutation.type === 'attributes' && mutation.target && mutation.target.classList && mutation.target.classList.contains('satus-switch')) {
+							enhanceSwitch(mutation.target);
+						}
+							for (const node of mutation.addedNodes || []) {
+							if (node && node.nodeType === 1) {
+								enhanceRoot(node);
+							}
+						}
+					}
+				});
+				observer.observe(root.document.documentElement, {subtree: true, childList: true, attributes: true, attributeFilter: ['data-value', 'data-title']});
+			}
+
+		};
+
+		if (root.document.readyState === 'loading') root.document.addEventListener('DOMContentLoaded', start, {once: true});
+		else start();
+	}
+
+	return {
+		safeLocale,
+		skeletonName,
+		controlName,
+		accessibleName,
+		enhanceSwitch,
+		enhanceNativeControl,
+		enhanceCustomButton,
+		enhanceButton,
+		enhanceSection,
+		enhanceIframe,
+		enhanceRoot,
+		install
+	};
+});

--- a/menu/accessibility.js
+++ b/menu/accessibility.js
@@ -188,6 +188,126 @@
 		return tabindex !== null && tabindex !== undefined && Number(tabindex) >= 0;
 	}
 
+	function firstFocusable (container) {
+		if (!container || typeof container.querySelector !== 'function') return null;
+		return container.querySelector('button:not([disabled]),[role="button"][tabindex="0"],[role="switch"][tabindex="0"],select:not([disabled]),input:not([disabled]),textarea:not([disabled]),[tabindex="0"]');
+	}
+
+	function isLayerComponent (element) {
+		if (!element || !element.classList) return false;
+		const tagName = String(element.tagName || '').toLowerCase();
+		if (tagName === 'button' || tagName === 'input' || tagName === 'select' || tagName === 'textarea') return true;
+		if (element.classList.contains('satus-switch') ||
+			element.classList.contains('satus-select') ||
+			element.classList.contains('satus-checkbox') ||
+			element.classList.contains('satus-radio') ||
+			element.classList.contains('satus-slider') ||
+			element.classList.contains('satus-text-field') ||
+			element.classList.contains('satus-time') ||
+			element.classList.contains('satus-shortcut') ||
+			element.classList.contains('satus-color-picker')) return true;
+		return !!(element.classList.contains('satus-section') && element.dataset && element.dataset.title);
+	}
+
+	function componentLandingTarget (component) {
+		if (!component) return null;
+		if (component.classList && component.classList.contains('satus-section') && component.dataset && component.dataset.title) {
+			const heading = component.querySelector && component.querySelector('.it-a11y-heading');
+			return heading || component;
+		}
+
+		// For compound form components, focus the visible wrapper rather than the
+		// native input/select inside it. This positions a screen reader at the first
+		// logical item without forcing it straight into focus/forms mode.
+		if (component.classList && (
+			component.classList.contains('satus-select') ||
+			component.classList.contains('satus-checkbox') ||
+			component.classList.contains('satus-radio') ||
+			component.classList.contains('satus-slider') ||
+			component.classList.contains('satus-text-field') ||
+			component.classList.contains('satus-time')
+		)) {
+			if (!component.hasAttribute || !component.hasAttribute('tabindex')) component.setAttribute('tabindex', '-1');
+			return component;
+		}
+
+		return component;
+	}
+
+	function layerLandingTarget (layer) {
+		if (!layer) return null;
+		function walk (parent) {
+			const children = parent && parent.children ? Array.from(parent.children) : [];
+			for (const child of children) {
+				if (isLayerComponent(child)) return componentLandingTarget(child);
+				const nested = walk(child);
+				if (nested) return nested;
+			}
+			return null;
+		}
+		return walk(layer);
+	}
+
+	function modalName (modal) {
+		if (!modal || !modal.classList) return safeLocale('dialog', 'Dialog');
+		if (modal.classList.contains('search-results')) return safeLocale('search', 'Search results');
+		if (modal.classList.contains('satus-modal--vertical-menu')) return safeLocale('menu', 'Menu');
+		if (modal.classList.contains('satus-modal--shortcut')) return safeLocale('shortcut', 'Keyboard shortcut');
+		if (modal.classList.contains('satus-modal--color-picker')) return safeLocale('color', 'Color picker');
+		return safeLocale('dialog', 'Dialog');
+	}
+
+	function ensureModalCloseButton (modal, surface) {
+		if (!modal || !surface || !modal.classList || !modal.classList.contains('satus-modal--vertical-menu')) return null;
+		const children = surface.children ? Array.from(surface.children) : [];
+		for (const child of children) {
+			if (child.getAttribute && child.getAttribute('data-it-a11y-close') === 'true') return child;
+		}
+		if (!root.document || typeof root.document.createElement !== 'function') return null;
+		const button = root.document.createElement('button');
+		button.type = 'button';
+		button.className = 'satus-button it-a11y-modal-close';
+		button.setAttribute('data-it-a11y-close', 'true');
+		const label = safeLocale('close', 'Close');
+		button.textContent = label;
+		button.setAttribute('aria-label', label);
+		button.addEventListener('click', function (event) {
+			if (event && typeof event.preventDefault === 'function') event.preventDefault();
+			if (typeof modal.close === 'function') modal.close();
+		});
+		if (typeof surface.appendChild === 'function') surface.appendChild(button);
+		return button;
+	}
+
+	function enhanceModal (modal) {
+		if (!modal || modal.__itA11yModal) return;
+		modal.__itA11yModal = true;
+		const surface = typeof modal.querySelector === 'function' ? (modal.querySelector('.satus-modal__surface') || modal) : modal;
+		const isSearchResults = !!(modal.classList && modal.classList.contains('search-results'));
+
+		if (isSearchResults) {
+			// Search results are controlled by a search field outside this container.
+			// Treating them as aria-modal would incorrectly imply that focus is trapped here.
+			surface.setAttribute('role', 'region');
+			surface.removeAttribute('aria-modal');
+			setLabel(surface, modalName(modal), false);
+			return;
+		}
+
+		surface.setAttribute('role', 'dialog');
+		surface.setAttribute('aria-modal', 'true');
+		setLabel(surface, modalName(modal), false);
+		ensureModalCloseButton(modal, surface);
+		setTimeout(function () {
+			const target = firstFocusable(surface);
+			if (target && typeof target.focus === 'function') target.focus();
+		}, 0);
+		// Escape and post-close focus intentionally remain under the original
+		// ImprovedTube/Chrome popup behavior. Intercepting Escape here cannot
+		// prevent Chrome from dismissing the extension popup and may conflict
+		// with the browser's own focus restoration.
+	}
+
 	function enhanceIframe (frame) {
 		if (!frame || frame.getAttribute('title')) return;
 		frame.setAttribute('title', safeLocale('improvedTube', 'ImprovedTube content'));
@@ -210,6 +330,7 @@
 		includeSelf('.satus-shortcut,.satus-color-picker', function (el) { enhanceCustomButton(el); });
 		includeSelf('button.satus-button', enhanceButton);
 		includeSelf('.satus-section[data-title]', enhanceSection);
+		includeSelf('.satus-modal', enhanceModal);
 		includeSelf('iframe', enhanceIframe);
 
 		const title = root.document && root.document.querySelector ? root.document.querySelector('.satus-span--title') : null;
@@ -217,6 +338,18 @@
 			title.setAttribute('role', 'heading');
 			title.setAttribute('aria-level', '1');
 		}
+	}
+
+	function focusNewestLayer (layers) {
+		if (!layers || !root.document) return;
+		const all = layers.querySelectorAll ? layers.querySelectorAll('.satus-layers__layer') : [];
+		const layer = all && all.length ? all[all.length - 1] : null;
+		if (!layer) return;
+		setTimeout(function () {
+			if (!layer.isConnected) return;
+			const target = layerLandingTarget(layer) || firstFocusable(layer);
+			if (target && typeof target.focus === 'function') target.focus();
+		}, 0);
 	}
 
 	function install () {
@@ -235,6 +368,12 @@
 							for (const node of mutation.addedNodes || []) {
 							if (node && node.nodeType === 1) {
 								enhanceRoot(node);
+								if (node.matches?.('.satus-layers__layer')) {
+									setTimeout(function () {
+										const target = layerLandingTarget(node) || firstFocusable(node);
+										if (target && typeof target.focus === 'function') target.focus();
+									}, 0);
+								}
 							}
 						}
 					}
@@ -242,6 +381,13 @@
 				observer.observe(root.document.documentElement, {subtree: true, childList: true, attributes: true, attributeFilter: ['data-value', 'data-title']});
 			}
 
+			root.document.addEventListener('open', function (event) {
+				const layers = event.target && event.target.classList && event.target.classList.contains('satus-layers') ? event.target : event.target?.closest?.('.satus-layers');
+				if (layers) {
+					enhanceRoot(layers);
+					focusNewestLayer(layers);
+				}
+			}, true);
 		};
 
 		if (root.document.readyState === 'loading') root.document.addEventListener('DOMContentLoaded', start, {once: true});
@@ -258,6 +404,9 @@
 		enhanceCustomButton,
 		enhanceButton,
 		enhanceSection,
+		layerLandingTarget,
+		ensureModalCloseButton,
+		enhanceModal,
 		enhanceIframe,
 		enhanceRoot,
 		install

--- a/menu/index.html
+++ b/menu/index.html
@@ -1,4 +1,4 @@
-<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width">
+<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width">
 <title>ImprovedTube</title>
 <style> body { margin: 0; width: 320px; max-width: 320px; min-height: 522px !important; height: 584px; max-height: 584px; } </style>
 <script src="satus.js"></script>
@@ -20,6 +20,7 @@
 <script src="skeleton-parts/analyzer.js"></script>
 <script src="skeleton-parts/dark-light-switch.js"></script>
 <script src="skeleton-parts/refresh-categories.js"></script>
+<script src="accessibility.js"></script>
 <script defer src="index.js"></script>
 <link rel="stylesheet" href="satus.css">
 <link rel="stylesheet" href="styles/home.css">

--- a/menu/sidepanel.html
+++ b/menu/sidepanel.html
@@ -1,4 +1,4 @@
-<!doctype html><html><head><meta charset="utf-8"><meta name="viewport">
+<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport">
 <title>ImprovedTube</title><style> .satus-text-field--search { max-width:255px !important; margin-right: 36px !important; }
 body{background-color:#3d3d3d; width:327px;max-width:327px; margin: -1px;  height:99.9vh;max-height:99.9vh}
 </style>
@@ -21,6 +21,7 @@ body{background-color:#3d3d3d; width:327px;max-width:327px; margin: -1px;  heigh
 <script src="skeleton-parts/analyzer.js"></script>
 <script src="skeleton-parts/dark-light-switch.js"></script>
 <script src="skeleton-parts/refresh-categories.js"></script>
+<script src="accessibility.js"></script>
 <script defer src="index.js"></script>
 <link rel="stylesheet" href="satus.css">
 <link rel="stylesheet" href="styles/home.css">


### PR DESCRIPTION
## Stacked PR

**Depends on #4333** (and therefore #4332). This PR is a draft while the preceding accessibility layers are reviewed.

The new change to review here is commit `45e6b2fc5828c1807e1d1eaa1141872c54fe2149`.

## Problem

ImprovedTube injects icon-only/custom controls into YouTube that do not always expose stable accessible names. Separately, upstream code temporarily replaces `HTMLElement.prototype.focus`, which can interfere with keyboard and screen-reader focus at a global page level.

## What changes

### Page-world accessibility

- add `js&css/web-accessible/accessibility.js`
- derive stable names from ARIA/text/title/tooltip data and known ImprovedTube classes
- hide decorative SVGs
- add visible focus outlines to ImprovedTube controls
- title ImprovedTube settings iframes
- expose tooltip/title success/error feedback through a polite status region
- observe dynamically inserted/updated controls

### Wiring

- add the module to `manifest.json` web-accessible resources
- load it before page-world `init.js`

### Preserve native focus

- remove active `ImprovedTube.forbidFocus(2100)` usage
- neutralize the legacy global `HTMLElement.prototype.focus` replacement in `appearance.js`
- prevent `shortcuts.js` from assigning `HTMLElement.prototype.focus` as part of that workaround

The injected-control module is additive. The focus-safety part restores native browser focus semantics rather than introducing another focus model.