### PR TITLE
i18n: replace hard-coded menu labels with locale keys

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1757,5 +1757,83 @@
   },
   "autoVideoRecovery": {
   "message": "Auto video recovery"
+  },
+  "hideWatchLaterVideos": {
+    "message": "Hide Watch Later Videos"
+  },
+  "maxWidthWithinPage": {
+    "message": "Max. width within the page"
+  },
+  "smartSpeedSelectYouTubeCategory": {
+    "message": "1. Select YouTube Category"
+  },
+  "smartSpeedSelectCategory": {
+    "message": "Select Category..."
+  },
+  "categoryEntertainment": {
+    "message": "Entertainment"
+  },
+  "categoryMusic": {
+    "message": "Music"
+  },
+  "categoryGaming": {
+    "message": "Gaming"
+  },
+  "categoryPeopleBlogs": {
+    "message": "People & Blogs"
+  },
+  "categoryComedy": {
+    "message": "Comedy"
+  },
+  "categoryHowtoStyle": {
+    "message": "Howto & Style"
+  },
+  "categoryFilmAnimation": {
+    "message": "Film & Animation"
+  },
+  "categoryEducation": {
+    "message": "Education"
+  },
+  "categoryScienceTechnology": {
+    "message": "Science & Technology"
+  },
+  "categorySports": {
+    "message": "Sports"
+  },
+  "categoryNewsPolitics": {
+    "message": "News & Politics"
+  },
+  "categoryAutosVehicles": {
+    "message": "Autos & Vehicles"
+  },
+  "categoryTravelEvents": {
+    "message": "Travel & Events"
+  },
+  "categoryPetsAnimals": {
+    "message": "Pets & Animals"
+  },
+  "categoryNonprofitsActivism": {
+    "message": "Nonprofits & Activism"
+  },
+  "smartSpeedAddSelectedCategory": {
+    "message": "➕ Add Selected Category"
+  },
+  "smartSpeedEnterAddChannelName": {
+    "message": "➕ Enter & Add Channel Name"
+  },
+  "smartSpeedChannelPrompt": {
+    "message": "Enter Channel Handle (e.g., @MrBeast) or Name:"
+  },
+  "smartSpeedWhitelistDisable": {
+    "message": "Whitelist (Disable Speedup)"
+  },
+  "smartSpeedMaxProfileSpeed": {
+    "message": "Max Speed"
+  },
+  "smartSpeedMinProfileSpeed": {
+    "message": "Min Speed"
+  },
+  "smartSpeedDeleteProfile": {
+    "message": "🗑️ Delete Profile"
   }
 }

--- a/menu/skeleton-parts/appearance.js
+++ b/menu/skeleton-parts/appearance.js
@@ -153,7 +153,7 @@ extension.skeleton.main.layers.section.appearance.on.click.player = {
 						text: "fullWindow",
 						value: "full_window"
 					}, {
-						text: "Max. width within the page",
+						text: "maxWidthWithinPage",
 						value: "max_width"
 					}, {
 						text: "fitToWindow",

--- a/menu/skeleton-parts/general.js
+++ b/menu/skeleton-parts/general.js
@@ -472,7 +472,7 @@ extension.skeleton.main.layers.section.general = {
 				},
 				hide_watch_later: {
 					component: 'switch',
-					text: 'Hide Watch Later Videos'
+					text: 'hideWatchLaterVideos'
 				},
 				delete_watched_videos: {
 					component: 'button',

--- a/menu/skeleton-parts/player.js
+++ b/menu/skeleton-parts/player.js
@@ -376,24 +376,24 @@ extension.skeleton.main.layers.section.player.on.click = {
 
 													add_category_dropdown: {
 														component: 'select',
-														text: '1. Select YouTube Category',
+														text: 'smartSpeedSelectYouTubeCategory',
 														options: [
-															{value: 'none', text: 'Select Category...'},
-															{value: 'Entertainment', text: 'Entertainment'},
-															{value: 'Music', text: 'Music'},
-															{value: 'Gaming', text: 'Gaming'},
-															{value: 'People & Blogs', text: 'People & Blogs'},
-															{value: 'Comedy', text: 'Comedy'},
-															{value: 'Howto & Style', text: 'Howto & Style'},
-															{value: 'Film & Animation', text: 'Film & Animation'},
-															{value: 'Education', text: 'Education'},
-															{value: 'Science & Technology', text: 'Science & Technology'},
-															{value: 'Sports', text: 'Sports'},
-															{value: 'News & Politics', text: 'News & Politics'},
-															{value: 'Autos & Vehicles', text: 'Autos & Vehicles'},
-															{value: 'Travel & Events', text: 'Travel & Events'},
-															{value: 'Pets & Animals', text: 'Pets & Animals'},
-															{value: 'Nonprofits & Activism', text: 'Nonprofits & Activism'}
+															{value: 'none', text: 'smartSpeedSelectCategory'},
+															{value: 'Entertainment', text: 'categoryEntertainment'},
+															{value: 'Music', text: 'categoryMusic'},
+															{value: 'Gaming', text: 'categoryGaming'},
+															{value: 'People & Blogs', text: 'categoryPeopleBlogs'},
+															{value: 'Comedy', text: 'categoryComedy'},
+															{value: 'Howto & Style', text: 'categoryHowtoStyle'},
+															{value: 'Film & Animation', text: 'categoryFilmAnimation'},
+															{value: 'Education', text: 'categoryEducation'},
+															{value: 'Science & Technology', text: 'categoryScienceTechnology'},
+															{value: 'Sports', text: 'categorySports'},
+															{value: 'News & Politics', text: 'categoryNewsPolitics'},
+															{value: 'Autos & Vehicles', text: 'categoryAutosVehicles'},
+															{value: 'Travel & Events', text: 'categoryTravelEvents'},
+															{value: 'Pets & Animals', text: 'categoryPetsAnimals'},
+															{value: 'Nonprofits & Activism', text: 'categoryNonprofitsActivism'}
 														],
 														on: {
 															change: function() { tempCategory = this.value; }
@@ -401,7 +401,7 @@ extension.skeleton.main.layers.section.player.on.click = {
 													},
 													add_category_btn: {
 														component: 'button',
-														text: '➕ Add Selected Category',
+														text: 'smartSpeedAddSelectedCategory',
 														on: {
 															click: function() {
 																if (tempCategory !== 'none') {
@@ -419,10 +419,10 @@ extension.skeleton.main.layers.section.player.on.click = {
 
 													add_channel_btn: {
 														component: 'button',
-														text: '➕ Enter & Add Channel Name',
+														text: 'smartSpeedEnterAddChannelName',
 														on: {
 															click: function() {
-																let name = prompt("Enter Channel Handle (e.g., @MrBeast) or Name:");
+																let name = prompt(satus.locale.get('smartSpeedChannelPrompt'));
 																if (name) {
 																	let freshState = Object.assign({}, satus.storage.get('smart_speed_profiles') || {});
 																	let newObj = {};
@@ -443,10 +443,10 @@ extension.skeleton.main.layers.section.player.on.click = {
 													skeleton['rule_' + safeKey + '_' + ts] = {
 														component: 'section',
 														variant: 'card',
-														title: key,
+														title: ({'Entertainment':'categoryEntertainment', 'Music':'categoryMusic', 'Gaming':'categoryGaming', 'People & Blogs':'categoryPeopleBlogs', 'Comedy':'categoryComedy', 'Howto & Style':'categoryHowtoStyle', 'Film & Animation':'categoryFilmAnimation', 'Education':'categoryEducation', 'Science & Technology':'categoryScienceTechnology', 'Sports':'categorySports', 'News & Politics':'categoryNewsPolitics', 'Autos & Vehicles':'categoryAutosVehicles', 'Travel & Events':'categoryTravelEvents', 'Pets & Animals':'categoryPetsAnimals', 'Nonprofits & Activism':'categoryNonprofitsActivism'}[key] || key),
 														whitelist_toggle: {
 															component: 'switch',
-															text: 'Whitelist (Disable Speedup)',
+															text: 'smartSpeedWhitelistDisable',
 															value: profiles[key].whitelist || false,
 															on: {
 																change: function() {
@@ -457,7 +457,7 @@ extension.skeleton.main.layers.section.player.on.click = {
 															}
 														},
 														max_slider: {
-															component: 'slider', text: 'Max Speed', value: profiles[key].max, min: 1.0, max: 4.0, step: 0.1,
+															component: 'slider', text: 'smartSpeedMaxProfileSpeed', value: profiles[key].max, min: 1.0, max: 4.0, step: 0.1,
 															on: {
 																change: function() {
 																	let freshState = Object.assign({}, satus.storage.get('smart_speed_profiles'));
@@ -467,7 +467,7 @@ extension.skeleton.main.layers.section.player.on.click = {
 															}
 														},
 														min_slider: {
-															component: 'slider', text: 'Min Speed', value: profiles[key].min, min: 0.5, max: 2.0, step: 0.1,
+															component: 'slider', text: 'smartSpeedMinProfileSpeed', value: profiles[key].min, min: 0.5, max: 2.0, step: 0.1,
 															on: {
 																change: function() {
 																	let freshState = Object.assign({}, satus.storage.get('smart_speed_profiles'));
@@ -477,7 +477,7 @@ extension.skeleton.main.layers.section.player.on.click = {
 															}
 														},
 														sens_slider: {
-															component: 'slider', text: 'Sensitivity', value: profiles[key].sens || 0.5, min: 0.01, max: 1.0, step: 0.01,
+															component: 'slider', text: 'smartSpeedSensitivity', value: profiles[key].sens || 0.5, min: 0.01, max: 1.0, step: 0.01,
 															on: {
 																change: function() {
 																	let freshState = Object.assign({}, satus.storage.get('smart_speed_profiles'));
@@ -487,7 +487,7 @@ extension.skeleton.main.layers.section.player.on.click = {
 															}
 														},
 														delete_btn: {
-															component: 'button', text: '🗑️ Delete Profile',
+															component: 'button', text: 'smartSpeedDeleteProfile',
 															on: {
 																click: function() {
 																	let freshState = Object.assign({}, satus.storage.get('smart_speed_profiles'));

--- a/menu/skeleton-parts/settings.js
+++ b/menu/skeleton-parts/settings.js
@@ -331,7 +331,7 @@ extension.skeleton.header.sectionEnd.menu.on.click.settings.on.click.secondSecti
 					text: 'youtubeLanguage',
 					storage: 'youtube_language',
 					options: function () {
-						return [{value: 'disabled', text: "Disabled"}].concat(extension.skeleton.header.sectionEnd.menu.on.click.settings.on.click.secondSection.language.on.click.section.languages);
+						return [{value: 'disabled', text: "disabled"}].concat(extension.skeleton.header.sectionEnd.menu.on.click.settings.on.click.secondSection.language.on.click.section.languages);
 					},
 					on: {
 						change: function (event) {


### PR DESCRIPTION
## Summary

Move visible English strings that currently bypass ImprovedTube's locale system into locale keys.

This is intentionally separate from any Spanish translation update: the architecture change benefits every locale.

## What changes

- `Hide Watch Later Videos` -> `hideWatchLaterVideos`
- `Max. width within the page` -> `maxWidthWithinPage`
- literal `Disabled` -> existing `disabled` locale key
- externalize Smart Speed category labels, known YouTube category names, add-category/channel actions, channel prompt, whitelist label, max/min speed, sensitivity and delete-profile text

Known category profile **values** remain canonical upstream strings. Only their displayed titles are localized. Arbitrary user/channel profile names are left unchanged.

## Why

Locale completeness checks cannot translate text that is hard-coded directly in JavaScript. Runtime testing exposed this first through `Hide Watch Later Videos`, then the audit found the additional strings included here.

## Scope

No Spanish wording is proposed in this PR; that is a separate follow-up so localization architecture and translation review can be accepted independently.