### PR TITLE
manifest: remove MV2 background.scripts from Chromium MV3 manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,8 +17,7 @@
     }
   },
   "background": {
-    "service_worker": "background.js",
-    "scripts": ["background.js"]
+    "service_worker": "background.js"
   },
   "action": {
     "default_popup": "menu/index.html",


### PR DESCRIPTION
## Summary

Clean up the Chromium Manifest V3 background declaration by removing the MV2-only `background.scripts` entry while keeping `background.service_worker`.

## Confirmed upstream issue

In the current upstream manifest, `manifest_version` is 3 while `background` contains both:

- `service_worker: "background.js"`
- `scripts: ["background.js"]`

This predates the accessibility work and is present in upstream itself.

## Build-system context

The Firefox build already performs the browser-specific transformation in the other direction: it removes `service_worker` and ensures `scripts` is present.

The Chromium path does not remove the MV2-style `scripts` entry, so it survives into the Chromium package.

## Change

- remove `background.scripts` from the root Chromium/MV3 manifest
- keep `background.service_worker: "background.js"` unchanged
- leave Firefox build behavior unchanged; it still adds `scripts` after removing `service_worker`

## Scope and risk

No accessibility, localization or feature changes. The expected final states are:

- Chromium MV3: `service_worker` present, `scripts` absent
- Firefox package: `scripts` present, `service_worker` absent